### PR TITLE
minor improvement when printing height

### DIFF
--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -288,7 +288,7 @@ impl Florestad {
             let cfilters = Arc::new(NetworkFilters::new(filter_store));
             info!(
                 "loaded compact filters store at height: {:?}",
-                cfilters.get_height()
+                cfilters.get_height().unwrap()
             );
             Some(cfilters)
         } else {


### PR DESCRIPTION
Instead of:
```
loaded compact filters store at height: Ok(123)
```

print the value itself:
```
loaded compact filters store at height: 123
```