### PR TITLE
Only keep extra peers if they give us a new block

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -68,6 +68,7 @@ use super::peer::PeerMessages;
 use crate::address_man::AddressState;
 use crate::node::periodic_job;
 use crate::node::try_and_log;
+use crate::node::ConnectionKind;
 use crate::node::InflightRequests;
 use crate::node::NodeNotification;
 use crate::node::NodeRequest;
@@ -652,7 +653,7 @@ where
     }
 
     pub async fn run(&mut self, stop_signal: Arc<RwLock<bool>>) -> Result<(), WireError> {
-        self.create_connection(false).await;
+        self.create_connection(ConnectionKind::Regular).await;
 
         info!("Starting ibd, selecting the best chain");
 

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -22,6 +22,7 @@ use super::peer::PeerMessages;
 use crate::address_man::AddressState;
 use crate::node::periodic_job;
 use crate::node::try_and_log;
+use crate::node::ConnectionKind;
 use crate::node::InflightRequests;
 use crate::node::NodeNotification;
 use crate::node::NodeRequest;
@@ -100,7 +101,7 @@ where
                 > SyncNode::ASSUME_STALE
             {
                 self.1.last_block_requested = self.chain.get_validation_index().unwrap();
-                self.create_connection(false).await;
+                self.create_connection(ConnectionKind::Regular).await;
                 self.last_tip_update = Instant::now();
                 continue;
             }

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -27,6 +27,7 @@ use crate::node::LocalPeerView;
 use crate::node::NodeNotification;
 use crate::node::NodeRequest;
 use crate::node::PeerStatus;
+use crate::p2p_wire::node::ConnectionKind;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
 use crate::UtreexoNodeConfig;
@@ -83,7 +84,7 @@ impl TestPeer {
                 | ServiceFlags::WITNESS
                 | ServiceFlags::COMPACT_FILTERS
                 | ServiceFlags::from(1 << 25),
-            feeler: false,
+            kind: ConnectionKind::Regular,
         };
 
         self.node_tx
@@ -146,7 +147,7 @@ pub fn create_peer(
         state: PeerStatus::Ready,
         channel: sender,
         port: 8333,
-        feeler: false,
+        kind: ConnectionKind::Regular,
         banscore: 0,
         address_id: 0,
         _last_message: Instant::now(),


### PR DESCRIPTION
If some time has passed and we didn't see a tip update, we open a new extra connection. We do this to prevent the case where our subnet is somehow partitioned from the global network and we don't get new blocks. The problem with the current code is that it doesn't destroy another connection and always keep the new one. If let running for enough time, florestad will create too many connections and take a lot of CPU.

This commit fixes this by adding a new rule for extra peers; we only keep them if they have blocks we didn't have. If they don't have any unknown blocks, we disconnect. If they do, we disconnect one peer, based on how fast they announce a new block to us. Faster peers are preferable instead of slow ones.