### PR TITLE
ssl init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ dependencies = [
  "bitcoin 0.31.0",
  "clap",
  "rand 0.8.5",
+ "rcgen",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -704,7 +710,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "spin",
+ "spin 0.9.8",
  "tokio",
  "zstd 0.12.4",
 ]
@@ -730,7 +736,7 @@ dependencies = [
  "bitcoin 0.31.0",
  "miniscript 11.0.0",
  "sha2",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -761,12 +767,14 @@ dependencies = [
  "log",
  "miniscript 11.0.0",
  "rand 0.8.5",
+ "rustls 0.20.9",
  "rustreexo",
  "serde",
  "serde_json",
  "sha2",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "toml 0.5.11",
  "zstd 0.13.2",
 ]
@@ -840,11 +848,13 @@ dependencies = [
  "miniscript 11.0.0",
  "pretty_assertions",
  "rand 0.8.5",
+ "rustls 0.20.9",
  "rustreexo",
  "serde",
  "serde_json",
  "sha2",
  "tokio",
+ "tokio-rustls",
  "toml 0.5.11",
  "zmq",
 ]
@@ -1999,7 +2009,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2034,6 +2044,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "getrandom 0.2.14",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,12 +2102,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64 0.13.1",
+ "log",
+ "ring 0.16.20",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct 0.7.1",
+ "webpki 0.22.4",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2120,6 +2185,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "secp256k1"
@@ -2323,6 +2408,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -2499,6 +2590,17 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.1",
+ "tokio",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2693,6 +2795,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2963,26 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +563,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +782,7 @@ dependencies = [
  "log",
  "miniscript 11.0.0",
  "rand 0.8.5",
+ "rcgen",
  "rustls 0.20.9",
  "rustreexo",
  "serde",
@@ -1626,6 +1642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +1789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1827,12 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1928,6 +1966,19 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+dependencies = [
+ "pem",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -2134,6 +2185,12 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustreexo"
@@ -2536,6 +2593,25 @@ dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinyvec"
@@ -3190,6 +3266,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zerocopy"

--- a/crates/floresta-cli/Cargo.toml
+++ b/crates/floresta-cli/Cargo.toml
@@ -29,6 +29,7 @@ with-reqwest = ["reqwest"]
 [dev-dependencies]
 rand = "0.8.5"
 tempfile = "3.9.0"
+rcgen = "0.13"
 
 [lib]
 name = "floresta_cli"

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -81,7 +81,7 @@ mod tests {
             .args(["--data-dir", &dirname])
             .args(["--rpc-address", &format!("127.0.0.1:{}", port)])
             .args(["--electrum-address", &format!("127.0.0.1:{}", port + 1)])
-            .args(["--no-ssl"])
+            .args(["--ssl-electrum-address", &format!("127.0.0.1:{}", port + 2)])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -41,3 +41,4 @@ zstd = "0.13.1"
 
 [dev-dependencies]
 rand = "0.8.5"
+rcgen = "0.13"

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -24,6 +24,8 @@ floresta-wire = { path = "../floresta-wire" }
 rustreexo = "0.3.0"
 sha2 = "^0.10.6"
 tokio = { version = "1.0", features = ["full"] }
+tokio-rustls = "0.22"
+rustls = "0.20"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1068,6 +1068,7 @@ mod test {
 
     async fn start_electrum(port: u16) {
         let e_addr = format!("0.0.0.0:{}", port);
+        let ssl_e_addr = format!("0.0.0.0:{}", port + 1);
         let wallet = get_test_cache();
 
         // Create test_chain_state
@@ -1123,7 +1124,7 @@ mod test {
         // TLS Electrum accept loop
         if let Some(tls_acceptor) = tls_acceptor {
             let tls_listener: Arc<TcpListener> =
-                Arc::new(block_on(TcpListener::bind("0.0.0.0:50002")).unwrap());
+                Arc::new(block_on(TcpListener::bind(ssl_e_addr.clone())).unwrap());
             task::spawn(client_accept_loop(
                 tls_listener,
                 electrum_server.message_transmitter.clone(),

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1113,7 +1113,7 @@ mod test {
         let electrum_server: ElectrumServer<ChainState<KvChainStore>> =
             block_on(ElectrumServer::new(wallet, chain, None, node_interface)).unwrap();
 
-        let non_tls_listener = Arc::new(TcpListener::bind(e_addr.clone()).await.unwrap());
+        let non_tls_listener = Arc::new(block_on(TcpListener::bind(e_addr.clone())).unwrap());
         task::spawn(client_accept_loop(
             non_tls_listener,
             electrum_server.message_transmitter.clone(),
@@ -1122,7 +1122,8 @@ mod test {
 
         // TLS Electrum accept loop
         if let Some(tls_acceptor) = tls_acceptor {
-            let tls_listener = Arc::new(TcpListener::bind("0.0.0.0:50002").await.unwrap());
+            let tls_listener: Arc<TcpListener> =
+                Arc::new(block_on(TcpListener::bind("0.0.0.0:50002")).unwrap());
             task::spawn(client_accept_loop(
                 tls_listener,
                 electrum_server.message_transmitter.clone(),

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -8,6 +8,8 @@ rustreexo = "0.3.0"
 clap = { version = "4.0.29", features = ["derive"] }
 sha2 = "^0.10.6"
 tokio = { version = "1", features = ["full"] }
+tokio-rustls = "0.22"
+rustls = "0.20"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -170,6 +170,10 @@ pub struct Cli {
     /// Path to the SSL private key file
     pub ssl_key_path: Option<String>,
 
+    #[arg(long, default_value_t = false)]
+    /// Whether to disable SSL
+    pub no_ssl: bool,
+
     #[cfg(unix)]
     #[arg(long, default_value = "false")]
     /// Whether we should run as a daemon

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -162,6 +162,14 @@ pub struct Cli {
     /// height will be fully validated.
     pub assume_utreexo: bool,
 
+    #[arg(long, value_name = "PATH")]
+    /// Path to the SSL certificate file
+    pub ssl_cert_path: Option<String>,
+
+    #[arg(long, value_name = "PATH")]
+    /// Path to the SSL private key file
+    pub ssl_key_path: Option<String>,
+
     #[cfg(unix)]
     #[arg(long, default_value = "false")]
     /// Whether we should run as a daemon

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -146,8 +146,12 @@ pub struct Cli {
     pub rpc_address: Option<String>,
 
     #[arg(long, value_name = "address[:<port>]")]
-    /// The address where our electrum server should listen to tin the format <address>[:<port>]
+    /// The address where our electrum server should listen to in the format <address>[:<port>]
     pub electrum_address: Option<String>,
+
+    #[arg(long, value_name = "address[:<port>]")]
+    /// The address where our ssl electrum server should listen to in the format <address>[:<port>]
+    pub ssl_electrum_address: Option<String>,
 
     #[arg(long, value_name = "HEIGHT")]
     /// Download block filters starting at this height. Negative numbers are relative to the current tip.

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -41,7 +41,7 @@ use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tokio::task;
 use tokio_rustls::rustls::internal::pemfile::certs;
-use tokio_rustls::rustls::internal::pemfile::rsa_private_keys;
+use tokio_rustls::rustls::internal::pemfile::pkcs8_private_keys;
 use tokio_rustls::rustls::NoClientAuth;
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
@@ -442,7 +442,6 @@ impl Florestad {
         let tls_acceptor = tls_config.map(TlsAcceptor::from);
 
         let electrum_server = block_on(ElectrumServer::new(
-            electrum_address.clone(),
             wallet,
             blockchain_state,
             cfilters,
@@ -694,7 +693,7 @@ fn create_tls_config(cert_path: &str, key_path: &str) -> io::Result<Arc<ServerCo
     let cert_file = File::open(cert_path)?;
     let key_file = File::open(key_path)?;
     let cert_chain = certs(&mut BufReader::new(cert_file)).unwrap();
-    let mut keys = rsa_private_keys(&mut BufReader::new(key_file)).unwrap();
+    let mut keys = pkcs8_private_keys(&mut BufReader::new(key_file)).unwrap();
     let mut config = ServerConfig::new(Arc::new(NoClientAuth));
     config.set_single_cert(cert_chain, keys.remove(0)).unwrap();
     Ok(Arc::new(config))

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -137,6 +137,8 @@ pub struct Config {
     pub json_rpc_address: Option<String>,
     /// The address our electrum server should listen to
     pub electrum_address: Option<String>,
+    /// The address for ssl electrum server
+    pub ssl_electrum_address: Option<String>,
     /// Whether we should write logs to the stdio
     pub log_to_stdout: bool,
     //// Whether we should log to a fs file
@@ -422,7 +424,13 @@ impl Florestad {
             .electrum_address
             .clone()
             .unwrap_or("0.0.0.0:50001".into());
-        println!("{}", data_dir.clone());
+
+        let ssl_electrum_address = self
+            .config
+            .ssl_electrum_address
+            .clone()
+            .unwrap_or("0.0.0.0:50002".into());
+
         // Load TLS configuration if needed
         let tls_config = if !self.config.no_ssl {
             let cert_path = self
@@ -463,7 +471,8 @@ impl Florestad {
 
         // TLS Electrum accept loop
         if let Some(tls_acceptor) = tls_acceptor {
-            let tls_listener = Arc::new(block_on(TcpListener::bind("0.0.0.0:50002")).unwrap());
+            let tls_listener =
+                Arc::new(block_on(TcpListener::bind(ssl_electrum_address.clone())).unwrap());
             task::spawn(client_accept_loop(
                 tls_listener,
                 electrum_server.message_transmitter.clone(),

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
     let florestad = Florestad::from(config);
 
     _rt.block_on(async {
-        florestad.start().await;
+        florestad.start();
         let _stop_signal = stop_signal.clone();
         ctrlc::set_handler(move || {
             block_on(async {

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
         assumeutreexo_value: None,
         ssl_cert_path: params.ssl_cert_path,
         ssl_key_path: params.ssl_key_path,
+        no_ssl: params.no_ssl,
     };
 
     #[cfg(unix)]
@@ -81,7 +82,7 @@ fn main() {
     let florestad = Florestad::from(config);
 
     _rt.block_on(async {
-        florestad.start();
+        florestad.start().await;
         let _stop_signal = stop_signal.clone();
         ctrlc::set_handler(move || {
             block_on(async {

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -57,6 +57,8 @@ fn main() {
         filters_start_height: params.filters_start_height,
         user_agent: format!("/Floresta:{}/", env!("GIT_DESCRIBE")),
         assumeutreexo_value: None,
+        ssl_cert_path: params.ssl_cert_path,
+        ssl_key_path: params.ssl_key_path,
     };
 
     #[cfg(unix)]

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
         log_to_stdout: true,
         json_rpc_address: params.rpc_address,
         electrum_address: params.electrum_address,
+        ssl_electrum_address: params.ssl_electrum_address,
         wallet_descriptor: params.wallet_descriptor,
         filters_start_height: params.filters_start_height,
         user_agent: format!("/Floresta:{}/", env!("GIT_DESCRIBE")),

--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -20,7 +20,8 @@ class TestFramework:
             "florestad",
             "--",
             "--network",
-            net
+            net,
+            "--no-ssl"
         ])
         self.nodes.append(FlorestaRPC(node))
 


### PR DESCRIPTION
- Resolves #106 
- Adds SSL support in electrum server for remote connections.
- Runs both SSL and non-SSL server on different ports which can be specified.
- Introduces `no-ssl` tag to run without the SSL server.
- Reformats basic tests to test out SSL connection.