### PR TITLE
Wire: handle block filters out-of-order

### DIFF
--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -97,6 +97,7 @@ pub trait IteratableFilterStore:
     fn put_filter(
         &self,
         block_filter: bip158::BlockFilter,
+        height: u32,
     ) -> Result<(), IteratableFilterStoreError>;
     /// Persists the height of the last filter we have
     fn set_height(&self, height: u32) -> Result<(), IteratableFilterStoreError>;

--- a/crates/floresta-compact-filters/src/network_filters.rs
+++ b/crates/floresta-compact-filters/src/network_filters.rs
@@ -41,8 +41,9 @@ impl<Storage: IteratableFilterStore> NetworkFilters<Storage> {
     pub fn push_filter(
         &self,
         filter: crate::BlockFilter,
+        height: u32,
     ) -> Result<(), IteratableFilterStoreError> {
-        self.filters.put_filter(filter)
+        self.filters.put_filter(filter, height)
     }
 
     pub fn get_height(&self) -> Result<u32, IteratableFilterStoreError> {

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1,6 +1,7 @@
 //! Main file for this blockchain. A node is the central task that runs and handles important
 //! events, such as new blocks, peer connection/disconnection, new addresses, etc.
 //! A node should not care about peer-specific messages, peers'll handle things like pings.
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::IpAddr;
@@ -134,6 +135,7 @@ impl Default for RunningNode {
                 requests: Mutex::new(Vec::new()),
             }),
             last_invs: HashMap::default(),
+            inflight_filters: BTreeMap::new(),
         }
     }
 }


### PR DESCRIPTION
Right now, if we receive filters out of order, we'll consider that a misbehaving. But due to some weird connectivity or even how the remote node processes things, we may get those in a random order. This commit fixes that by holding the filters we've got in a BTree and only processing it after all the previous filters already got processed.