### PR TITLE
fuzz: add target for `LocalAddress` from string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +775,15 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "zstd 0.13.2",
+]
+
+[[package]]
+name = "floresta-fuzz"
+version = "0.0.0"
+dependencies = [
+ "bitcoin 0.31.0",
+ "floresta-wire",
+ "libfuzzer-sys",
 ]
 
 [[package]]
@@ -1449,6 +1464,17 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,19 @@
 resolver = "2"
 members = [
     "florestad",
+    "fuzz",
+    "crates/floresta",
+    "crates/floresta-chain",
+    "crates/floresta-cli",
+    "crates/floresta-common",
+    "crates/floresta-compact-filters",
+    "crates/floresta-electrum",
+    "crates/floresta-watch-only",
+    "crates/floresta-wire",
+]
+
+default-members = [ 
+    "florestad",
     "crates/floresta",
     "crates/floresta-chain",
     "crates/floresta-cli",

--- a/README.md
+++ b/README.md
@@ -13,20 +13,22 @@ If you want to use `libfloresta` to build your own Bitcoin application, you can 
 
 ### ToC
 
-- [Community](#community)
 - [Building](#building)
+  - [(Prerequisites)](#prerequisites)
   - [Building with nix](#building-with-nix)
-- [Running](#running)
-  - [Assume Utreexo](#assume-utreexo)
-  - [Compact Filters](#compact-filters)
-  - [Getting help](#getting-help)
-  - [Wallet](#wallet)
-- [Running the tests](#running-the-tests)
-- [Contributing](#contributing)
-- [Using Nix](#using-nix)
-- [License](#license)
-- [Acknowledgments](#acknowledgments)
-- [Consensus implementation](#consensus-implementation)
+  - [Running](#running)
+    - [Assume Utreexo](#assume-utreexo)
+    - [Compact Filters](#compact-filters)
+    - [Getting help](#getting-help)
+    - [Wallet](#wallet)
+  - [Running the tests](#running-the-tests)
+    - [Requirements](#requirements)
+  - [Fuzzing](#fuzzing)
+  - [Contributing](#contributing)
+  - [Using Nix](#using-nix)
+  - [License](#license)
+  - [Acknowledgments](#acknowledgments)
+  - [Consensus implementation](#consensus-implementation)
 
 ### Community
 
@@ -202,6 +204,15 @@ There's also a set of functional tests that you can run with
 pip3 install -r tests/requirements.txt
 python tests/run_tests.py
 ```
+
+### Fuzzing
+
+This project uses `cargo-fuzz` (libfuzzer) for fuzzing, you can run a fuzz target with:
+```bash
+cargo +nightly fuzz run local_address_str
+```
+
+You can replace `local_address_str` with the name of any other target you want to run.
 
 ### Contributing
 Contributions are welcome, feel free to open an issue or a pull request.

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "floresta-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+bitcoin = { version = "0.31", features = ["serde", "std"] }
+floresta-wire = { path = "../crates/floresta-wire" }
+
+[[bin]]
+name = "local_address_str"
+path = "fuzz_targets/local_address_str.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/local_address_str.rs
+++ b/fuzz/fuzz_targets/local_address_str.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use core::str;
+use std::str::FromStr;
+
+use floresta_wire::address_man::LocalAddress;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = match str::from_utf8(data) {
+        Ok(s) => LocalAddress::from_str(s),
+        Err(_) => return,
+    };
+});


### PR DESCRIPTION
This is a very simple fuzz target but might be the start of a journey :) 

Since there is no fuzzing in this project, I added `cargo-fuzz` into it.

To run:
```
cargo +nightly fuzz run local_address_str
```