### PR TITLE
chain/wire: remove the explicit rescan code

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -71,10 +71,6 @@ pub trait BlockchainInterface {
     fn get_block_locator_for_tip(&self, tip: BlockHash) -> Result<Vec<BlockHash>, BlockchainError>;
     /// Returns the last block we validated
     fn get_validation_index(&self) -> Result<u32, Self::Error>;
-    /// Triggers a rescan, downloading (but not validating) all blocks in [start_height:tip]
-    fn rescan(&self, start_height: u32) -> Result<(), Self::Error>;
-    /// Returns where we are in the rescan
-    fn get_rescan_index(&self) -> Option<u32>;
     /// Returns the height of a block, given it's hash
     fn get_block_height(&self, hash: &BlockHash) -> Result<Option<u32>, Self::Error>;
     fn update_acc(
@@ -134,8 +130,6 @@ pub trait UpdatableChainstate {
     /// Marks one block as being fully validated, this overrides a block that was explicitly
     /// marked as invalid.
     fn mark_block_as_valid(&self, block: BlockHash) -> Result<(), BlockchainError>;
-    /// Gives a requested block for rescan
-    fn process_rescan_block(&self, block: &Block) -> Result<(), BlockchainError>;
     /// Returns the root hashes of our utreexo forest
     fn get_root_hashes(&self) -> Vec<NodeHash>;
     /// Returns a partial chainstate from a range of blocks.
@@ -253,10 +247,6 @@ impl<T: UpdatableChainstate> UpdatableChainstate for Arc<T> {
         T::switch_chain(self, new_tip)
     }
 
-    fn process_rescan_block(&self, block: &Block) -> Result<(), BlockchainError> {
-        T::process_rescan_block(self, block)
-    }
-
     fn mark_block_as_valid(&self, block: BlockHash) -> Result<(), BlockchainError> {
         T::mark_block_as_valid(self, block)
     }
@@ -271,10 +261,6 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
 
     fn get_tx(&self, txid: &bitcoin::Txid) -> Result<Option<bitcoin::Transaction>, Self::Error> {
         T::get_tx(self, txid)
-    }
-
-    fn rescan(&self, start_height: u32) -> Result<(), Self::Error> {
-        T::rescan(self, start_height)
     }
 
     fn broadcast(&self, tx: &bitcoin::Transaction) -> Result<(), Self::Error> {
@@ -311,10 +297,6 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
 
     fn get_block_header(&self, hash: &BlockHash) -> Result<BlockHeader, Self::Error> {
         T::get_block_header(self, hash)
-    }
-
-    fn get_rescan_index(&self) -> Option<u32> {
-        T::get_rescan_index(self)
     }
 
     fn get_block_height(&self, hash: &BlockHash) -> Result<Option<u32>, Self::Error> {

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -360,10 +360,6 @@ impl UpdatableChainstate for PartialChainState {
         unimplemented!("we don't do transactions")
     }
 
-    fn process_rescan_block(&self, _block: &bitcoin::Block) -> Result<(), BlockchainError> {
-        unimplemented!("we don't do rescan")
-    }
-
     fn mark_chain_as_assumed(&self, _acc: Stump, _tip: BlockHash) -> Result<bool, BlockchainError> {
         unimplemented!("no need to mark as valid")
     }
@@ -466,10 +462,6 @@ impl BlockchainInterface for PartialChainState {
         unimplemented!("partialChainState::get_tx")
     }
 
-    fn rescan(&self, _start_height: u32) -> Result<(), Self::Error> {
-        unimplemented!("partialChainState::rescan")
-    }
-
     fn broadcast(&self, _tx: &bitcoin::Transaction) -> Result<(), Self::Error> {
         unimplemented!("partialChainState::broadcast")
     }
@@ -480,10 +472,6 @@ impl BlockchainInterface for PartialChainState {
 
     fn estimate_fee(&self, _target: usize) -> Result<f64, Self::Error> {
         unimplemented!("partialChainState::estimate_fee")
-    }
-
-    fn get_rescan_index(&self) -> Option<u32> {
-        unimplemented!("partialChainState::get_rescan_index")
     }
 
     fn get_block_height(&self, _hash: &bitcoin::BlockHash) -> Result<Option<u32>, Self::Error> {

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -557,16 +557,12 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
     ) -> Result<(), super::error::Error> {
         // If compact block filters are enabled, use them. Otherwise, fallback
         // to the "old-school" rescaning.
-        match &self.block_filters {
-            Some(cfilters) => {
-                self.rescan_with_block_filters(cfilters.clone(), addresses)
-                    .await
-            }
-            None => self
-                .chain
-                .rescan(1)
-                .map_err(|e| super::error::Error::Blockchain(Box::new(e))),
+        if let Some(cfilters) = &self.block_filters {
+            self.rescan_with_block_filters(cfilters.clone(), addresses)
+                .await?;
         }
+
+        Ok(())
     }
 
     /// If we have compact block filters enabled, this method will use them to

--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -34,6 +34,8 @@ pub enum WireError {
     PeerTimeout,
     #[error("Compact block filters error")]
     CompactBlockFiltersError(IteratableFilterStoreError),
+    #[error("Poisoned lock")]
+    PoisonedLock,
 }
 
 impl_error_from!(WireError, PeerError, PeerError);

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -90,13 +90,6 @@ pub struct Cli {
     /// The url of a proxy we should open p2p connections through (e.g. 127.0.0.1:9050)
     pub proxy: Option<String>,
 
-    #[arg(long, short, default_value = None, value_name = "HEIGHT")]
-    /// Instruct the node to rescan for our wallet on startup.
-    ///
-    /// This is useful if the node already did IBD, but you add a new descriptor with
-    /// balance, you'll need to rescan to find the old transactions.
-    pub rescan: Option<u32>,
-
     #[arg(long, value_name = "XPUB")]
     /// Add a xpub to our wallet
     ///

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -15,7 +15,6 @@ pub use bitcoin::Network;
 use fern::colors::Color;
 use fern::colors::ColoredLevelConfig;
 use fern::FormatCallback;
-use floresta_chain::pruned_utreexo::BlockchainInterface;
 pub use floresta_chain::AssumeUtreexoValue;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::BlockchainError;
@@ -88,11 +87,6 @@ pub struct Config {
     /// This should be a list of ouptut descriptors that we should add to our watch-only wallet.
     /// This works just like wallet_xpub, but with a descriptor.
     pub wallet_descriptor: Option<Vec<String>>,
-    /// Whether we should rescan for wallet transactions
-    ///
-    /// If your wallet is missing some transaction (e.g. you've just added a new address), you can
-    /// set this value to some height, and we'll rescan from this block to the tip.
-    pub rescan: Option<u32>,
     /// Where should we read from a config file
     ///
     /// This is a toml-encoded file with floresta's configs. For a sample of how this file looks
@@ -291,12 +285,6 @@ impl Florestad {
                 .as_ref()
                 .map(|value| value.parse().expect("invalid assumevalid")),
         ));
-
-        if let Some(height) = self.config.rescan {
-            blockchain_state
-                .rescan(height)
-                .expect("Fail while setting rescan");
-        }
 
         #[cfg(feature = "compact-filters")]
         let cfilters = if self.config.cfilters {

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -40,7 +40,6 @@ fn main() {
         data_dir: params.data_dir.clone(),
         cfilters: params.cfilters,
         proxy: params.proxy,
-        rescan: params.rescan,
         assume_utreexo: params.assume_utreexo,
         connect: params.connect,
         wallet_xpub: params.wallet_xpub,


### PR DESCRIPTION
Explicit rescan is when we download and scan all blocks in a given range. This is not only inefficient, but the current code is buggy and would need some improvements.

Since we now have support for block filters, there's no point in keeping this alive.