### PR TITLE
Update getutxo

### DIFF
--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -66,6 +66,17 @@ fn do_request(cmd: &Cli, client: ReqwestClient) -> anyhow::Result<String> {
         Methods::GetPeerInfo => serde_json::to_string_pretty(&client.get_peer_info()?)?,
         Methods::Stop => serde_json::to_string_pretty(&client.stop()?)?,
         Methods::AddNode { node } => serde_json::to_string_pretty(&client.add_node(node)?)?,
+        Methods::FindTxOut {
+            txid,
+            vout,
+            script,
+            height_hint,
+        } => serde_json::to_string_pretty(&client.find_tx_out(
+            txid,
+            vout,
+            script,
+            height_hint.unwrap_or(0),
+        )?)?,
     })
 }
 
@@ -147,4 +158,11 @@ pub enum Methods {
     /// Usage: addnode <ip:[port]>
     #[command(name = "addnode")]
     AddNode { node: String },
+    #[command(name = "findtxout")]
+    FindTxOut {
+        txid: Txid,
+        vout: u32,
+        script: String,
+        height_hint: Option<u32>,
+    },
 }

--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -92,7 +92,7 @@ pub trait IteratableFilterStore:
     type I: Iterator<Item = (u32, bip158::BlockFilter)>;
     /// Fetches the first filter and sets our internal cursor to the first filter,
     /// succeeding calls to [next] will return the next filter until we reach the end
-    fn iter(&self) -> Result<Self::I, IteratableFilterStoreError>;
+    fn iter(&self, start_height: Option<usize>) -> Result<Self::I, IteratableFilterStoreError>;
     /// Writes a new filter to the store
     fn put_filter(
         &self,

--- a/crates/floresta-compact-filters/src/network_filters.rs
+++ b/crates/floresta-compact-filters/src/network_filters.rs
@@ -21,15 +21,12 @@ impl<Storage: IteratableFilterStore> NetworkFilters<Storage> {
     pub fn match_any(
         &self,
         query: Vec<&[u8]>,
-        end_height: u32,
+        start_height: Option<usize>,
         chain: impl BlockchainInterface,
     ) -> Result<Vec<BlockHash>, IteratableFilterStoreError> {
         let mut blocks = Vec::new();
         let iter = query.into_iter();
-        for (height, filter) in self.filters.iter()? {
-            if height >= end_height {
-                break;
-            }
+        for (height, filter) in self.filters.iter(start_height)? {
             let hash = chain.get_block_hash(height).unwrap();
             if filter.match_any(&hash, &mut iter.clone()).unwrap() {
                 blocks.push(hash);

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -574,14 +574,13 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
         addresses: Vec<ScriptBuf>,
     ) -> Result<(), super::error::Error> {
         // By default, we look from 1..tip
-        let height = cfilters.get_height().unwrap();
         let mut _addresses = addresses
             .iter()
             .map(|address| address.as_bytes())
             .collect::<Vec<_>>();
 
         // TODO (Davidson): Let users select what the starting and end height is
-        let blocks = cfilters.match_any(_addresses, height, self.chain.clone());
+        let blocks = cfilters.match_any(_addresses, Some(0), self.chain.clone());
         if blocks.is_err() {
             error!("error while rescanning with block filters: {:?}", blocks);
             self.addresses_to_scan.extend(addresses); // push them back to get a retry

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -567,6 +567,15 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         }
     }
 
+    pub fn get_utxo(&self, outpoint: &OutPoint) -> Option<TxOut> {
+        let inner = self.inner.read().expect("poisoned lock");
+        // a dirty way to check if the utxo is still unspent
+        let _ = inner.utxo_index.get(outpoint)?;
+        let tx = inner.get_transaction(&outpoint.txid)?;
+
+        Some(tx.tx.output[outpoint.vout as usize].clone())
+    }
+
     pub fn n_cached_addresses(&self) -> usize {
         let inner = self.inner.read().expect("poisoned lock");
         inner.address_map.len()

--- a/crates/floresta-wire/src/p2p_wire/seeds/mainnet_seeds.json
+++ b/crates/floresta-wire/src/p2p_wire/seeds/mainnet_seeds.json
@@ -31,5 +31,16 @@
         },
         "services": 50331657,
         "port": 8333
+    },
+    {
+        "address": {
+            "V4": "[2804:4308:8c:6700:ee8e:b5ff:fe78:cbcf]"
+        },
+        "last_connected": 1678986166,
+        "state": {
+            "Tried": 0
+        },
+        "services": 73,
+        "port": 8333
     }
 ]

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -99,6 +99,7 @@ pub struct BlockJson {
 #[derive(Debug)]
 pub enum Error {
     TxNotFound,
+    InvalidScript,
     InvalidDescriptor,
     BlockNotFound,
     Chain,
@@ -108,6 +109,7 @@ pub enum Error {
     NoBlockFilters,
     InvalidNetwork,
     InInitialBlockDownload,
+    Encode,
 }
 
 impl Display for Error {
@@ -123,6 +125,8 @@ impl Display for Error {
             Error::NoBlockFilters => "You don't have block filters enabled, please start florestad with --cfilters to run this RPC",
             Error::InvalidNetwork => "Invalid network",
             Error::InInitialBlockDownload => "Node is in initial block download, wait until it's finished",
+            Error::Encode => "Error encoding response",
+            Error::InvalidScript => "Invalid script",
         };
         write!(f, "{}", msg)
     }
@@ -141,6 +145,8 @@ impl From<Error> for i64 {
             Error::NoBlockFilters => 8,
             Error::InvalidNetwork => 9,
             Error::InInitialBlockDownload => 10,
+            Error::Encode => 11,
+            Error::InvalidScript => 12,
         }
     }
 }


### PR DESCRIPTION
Update the `gettxout` rpc to only return cached UTXOs, and create a `findtxout` to look for non-cached UTXOs using block filters. After calling this method, the address and UTXO will be cached, so any further call to `gettxout` or `findtxout` will return instantly.