### PR TITLE
Fix local seeds

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -709,6 +709,15 @@ mod test {
         let loc_adr_1 = LocalAddress::from(signet_address[random].address.clone());
         assert_eq!(loc_adr_1.address, signet_address[random].address);
     }
+
+    #[test]
+    fn test_fixed_peers() {
+        let _ = load_addresses_from_json("./src/p2p_wire/seeds/signet_seeds.json").unwrap();
+        let _ = load_addresses_from_json("./src/p2p_wire/seeds/mainnet_seeds.json").unwrap();
+        let _ = load_addresses_from_json("./src/p2p_wire/seeds/testnet_seeds.json").unwrap();
+        let _ = load_addresses_from_json("./src/p2p_wire/seeds/regtest_seeds.json").unwrap();
+    }
+
     #[test]
     fn test_address_man() {
         let mut address_man = AddressMan::default();

--- a/crates/floresta-wire/src/p2p_wire/seeds/mainnet_seeds.json
+++ b/crates/floresta-wire/src/p2p_wire/seeds/mainnet_seeds.json
@@ -31,16 +31,5 @@
         },
         "services": 50331657,
         "port": 8333
-    },
-    {
-        "address": {
-            "V4": "[2804:4308:8c:6700:ee8e:b5ff:fe78:cbcf]"
-        },
-        "last_connected": 1678986166,
-        "state": {
-            "Tried": 0
-        },
-        "services": 73,
-        "port": 8333
     }
 ]


### PR DESCRIPTION
Some early commit introduced a malformed mainnet seed, this will cause a fresh build of floresta to crash. This PR removes it, and creates a test that will catch the problem if it ever happens again.