### PR TITLE
Improve CI caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker Publish
 
 on:
-    release:
-        types: [created]
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -10,19 +10,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
-            username: ${{ secrets.DOCKERHUB_USERNAME }}
-            password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
-              push: true
-              tags: dlsz/floresta:latest
+          push: true
+          tags: dlsz/floresta:latest

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,21 +1,26 @@
 # runs our functinal tests from tests/
 
 on:
-    push:
-      branches: [ "master" ]
-    pull_request:
-      branches: [ "master" ]
+  push:
+  pull_request:
+    branches: ["master"]
 
 jobs:
-    functional:
-        name: functional
-        runs-on: ubuntu-latest
+  functional:
+    name: Functional
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v3
-            - name: prepare environment
-              run: sudo apt-get install -y python3-pip && pip3 install -r tests/requirements.txt
-            - name: build
-              run: cargo build
-            - name: run functional tests
-              run: python tests/run_tests.py
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare environment
+        run: sudo apt-get install -y python3-pip && pip3 install -r tests/requirements.txt
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build Floresta
+        run: cargo build
+
+      - name: Run functional tests
+        run: python tests/run_tests.py

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,8 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,17 +13,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: install nightly rust
-      run: rustup install nightly; rustup +nightly component add rustfmt clippy
-      
-    # cargo fmt
-    - uses: actions/checkout@v3
-    - name: fmt
-      run: cargo +nightly fmt --all --check
+      - uses: actions/checkout@v4
 
-    # run cargo clippy
-    - name: Clippy
-      run: cargo +nightly clippy --all-targets
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo fmt
+        run: cargo fmt --all --check
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets
+        env:
+          PWD: ${{ github.workspace }} # without it ci can't see env!("PWD")
 
   cross-testing:
     strategy:
@@ -33,19 +38,33 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          toolchain: ${{ matrix.rust }}
+      - uses: actions/checkout@v4
 
-      - run: cargo build --verbose
-      - run: cargo test --verbose
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build Floresta
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+        env:
+          PWD: ${{ github.workspace }} # without it ci can't see env!("PWD")
 
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      
-      - name: build the docker image
-        run: docker build -t dlsz/floresta:latest .
+      - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ hashFiles('Dockerfile') }}
+
+      - name: Build Docker image
+        run: |
+          docker buildx build --cache-to=type=local,dest=/tmp/.buildx-cache --cache-from=type=local,src=/tmp/.buildx-cache -t dlsz/floresta:latest .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build Floresta
         run: cargo build --verbose


### PR DESCRIPTION
Closes #206 .

### Changelog:

- Updated all `actions/checkout` to use latest version (`v4`);
- Updated `docker/setup-buildx-action` from `v1` to `v3`;
- Updated `docker/login-action` from `v2` to `v3`;
- Updated `docker/build-push-action` from `v4` to `v6`;
- Use of caching with `actions/cache@v4` and `Swatinem/rust-cache@v2` to prevent excessive builds from docker and cargo;
- Replaced manual calls to rustup by the `dtolnay/rust-toolchain@nightly`;
- Removed redundant branches specification on the `on` configuration of actions.

### Expected behaviour:

After the builds are cached (i.e. from second run onwards), the CI time for the actions should drop around 50%.

Before:

<img width="1163" alt="image" src="https://github.com/user-attachments/assets/c5ccb3b6-7024-484d-b3fa-2206a9de9a86">

_Actions from the [vinteumorg/Floresta repo](https://github.com/vinteumorg/Floresta/actions)._

After:

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/d1e3ae48-5afc-4e0a-84ce-a4014c2cb1b7">

_Actions from the [Guilospanck/Floresta cloned repo](https://github.com/Guilospanck/Floresta/actions)._

### Observations

- Be aware that the first time it runs will be probably slower than what the CI has right now, as it will cache the information and that will take time. Subsequent runs will use the cached builds and therefore be much faster;

- The `PWD: ${{ github.workspace }}` is necessary to be passed as environment because the cached build somehow loses the working directory;

- The caches can then be found at the [/caches](https://github.com/vinteumorg/Floresta/actions/caches) page.