### PR TITLE
Move assume-valid hashes to chainparams

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -488,7 +488,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             .update_block_index(0, genesis.block_hash())
             .expect("Error updating index");
 
-        let assume_valid = Self::get_assume_valid_value(network, assume_valid);
+        let assume_valid = ChainParams::get_assume_valid(network, assume_valid);
         ChainState {
             inner: RwLock::new(ChainStateInner {
                 chainstore,
@@ -509,33 +509,6 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
                 },
                 assume_valid,
             }),
-        }
-    }
-    fn get_assume_valid_value(network: Network, arg: AssumeValidArg) -> Option<BlockHash> {
-        fn get_hash(hash: &str) -> BlockHash {
-            BlockHash::from_str(hash).expect("hardcoded hash should not fail")
-        }
-        match arg {
-            AssumeValidArg::Disabled => None,
-            AssumeValidArg::UserInput(hash) => Some(hash),
-            AssumeValidArg::Hardcoded => match network {
-                Network::Bitcoin => {
-                    get_hash("00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9")
-                        .into()
-                }
-                Network::Testnet => {
-                    get_hash("000000000000001142ad197bff16a1393290fca09e4ca904dd89e7ae98a90fcd")
-                        .into()
-                }
-                Network::Signet => {
-                    get_hash("0000003ed17b9c93954daab00d73ccbd0092074c4ebfc751c7458d58b827dfea")
-                        .into()
-                }
-                Network::Regtest => {
-                    get_hash("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")
-                        .into()
-                }
-            },
         }
     }
     fn get_disk_block_header(&self, hash: &BlockHash) -> Result<DiskBlockHeader, BlockchainError> {
@@ -606,7 +579,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             consensus: Consensus {
                 parameters: network.into(),
             },
-            assume_valid: Self::get_assume_valid_value(network, assume_valid),
+            assume_valid: ChainParams::get_assume_valid(network, assume_valid),
         };
         info!(
             "Chainstate loaded at height: {}, checking if we have all blocks",

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -16,6 +16,7 @@ use bitcoin::Target;
 use rustreexo::accumulator::node_hash::NodeHash;
 
 use crate::prelude::*;
+use crate::AssumeValidArg;
 use crate::Network;
 #[derive(Clone, Debug)]
 pub struct ChainParams {
@@ -97,7 +98,7 @@ pub struct AssumeUtreexoValue {
 }
 
 impl ChainParams {
-    pub fn get_assumeutreexo_value(network: Network) -> AssumeUtreexoValue {
+    pub fn get_assume_utreexo(network: Network) -> AssumeUtreexoValue {
         match network {
             Network::Bitcoin => AssumeUtreexoValue {
                 block_hash: BlockHash::from_str(
@@ -149,9 +150,35 @@ impl ChainParams {
             },
         }
     }
-}
 
-impl ChainParams {
+    pub fn get_assume_valid(network: Network, arg: AssumeValidArg) -> Option<BlockHash> {
+        fn get_hash(hash: &str) -> BlockHash {
+            BlockHash::from_str(hash).expect("hardcoded hash should not fail")
+        }
+        match arg {
+            AssumeValidArg::Disabled => None,
+            AssumeValidArg::UserInput(hash) => Some(hash),
+            AssumeValidArg::Hardcoded => match network {
+                Network::Bitcoin => {
+                    get_hash("00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9")
+                        .into()
+                }
+                Network::Testnet => {
+                    get_hash("000000000000001142ad197bff16a1393290fca09e4ca904dd89e7ae98a90fcd")
+                        .into()
+                }
+                Network::Signet => {
+                    get_hash("0000003ed17b9c93954daab00d73ccbd0092074c4ebfc751c7458d58b827dfea")
+                        .into()
+                }
+                Network::Regtest => {
+                    get_hash("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")
+                        .into()
+                }
+            },
+        }
+    }
+
     fn max_target(net: Network) -> Target {
         match net {
             Network::Bitcoin => Target::MAX_ATTAINABLE_MAINNET,

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -15,6 +15,8 @@ pub use bitcoin::Network;
 use fern::colors::Color;
 use fern::colors::ColoredLevelConfig;
 use fern::FormatCallback;
+#[cfg(feature = "zmq-server")]
+use floresta_chain::pruned_utreexo::BlockchainInterface;
 pub use floresta_chain::AssumeUtreexoValue;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::BlockchainError;
@@ -330,7 +332,7 @@ impl Florestad {
 
         // If this network already allows pow fraud proofs, we should use it instead of assumeutreexo
         let assume_utreexo = match (pow_fraud_proofs, self.config.assume_utreexo) {
-            (false, true) => Some(floresta_chain::ChainParams::get_assumeutreexo_value(
+            (false, true) => Some(floresta_chain::ChainParams::get_assume_utreexo(
                 Self::get_net(&self.config.network).into(),
             )),
             _ => None,
@@ -665,17 +667,17 @@ impl Florestad {
         result
     }
 
-    fn create_tls_config(&self, data_dir: &String) -> io::Result<Arc<ServerConfig>> {
+    fn create_tls_config(&self, data_dir: &str) -> io::Result<Arc<ServerConfig>> {
         let cert_path = self
             .config
             .ssl_cert_path
             .clone()
-            .unwrap_or_else(|| (data_dir.clone() + "ssl/cert.pem"));
+            .unwrap_or_else(|| data_dir.to_owned() + "ssl/cert.pem");
         let key_path = self
             .config
             .ssl_cert_path
             .clone()
-            .unwrap_or_else(|| (data_dir.clone() + "ssl/key.pem"));
+            .unwrap_or_else(|| data_dir.to_owned() + "ssl/key.pem");
 
         let cert_file = File::open(cert_path)?;
         let key_file = File::open(key_path)?;


### PR DESCRIPTION
I think the natural location for them is in chainparams, alongside `assume-utreexo` hashes. Removed the `_value` suffix for both getters.

In florestad I brought into scope the trait needed for calling `subscribe` at line 380, and also changed a &String to &str.