### PR TITLE
No_std support for floresta-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,8 @@ name = "floresta-common"
 version = "0.2.0"
 dependencies = [
  "bitcoin 0.31.0",
+ "core2 0.4.0",
+ "hashbrown",
  "miniscript 11.0.0",
  "sha2",
  "spin 0.9.8",

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -30,7 +30,7 @@ spin = "0.9.8"
 core2 = { version = "0.4.0", default-features = false }
 hashbrown = { version = "0.14.0", optional = true }
 secp256k1 = { version = "*", features = ["alloc"], optional = true }
-floresta-common = { path = "../floresta-common", default-features = false }
+floresta-common = { path = "../floresta-common", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -10,11 +10,21 @@ readme = "README.md"
 
 
 [dependencies]
-sha2 = "^0.10.6"
-bitcoin = "0.31"
-miniscript = { version = "11", optional = true }
+# Common dependencies
+sha2 = { version = "0.10.6", default-features = false }
+bitcoin = { version = "0.31", default-features = false, features = ["serde"] }
 spin = "0.9.8"
 
+# No-std specific dependencies
+hashbrown = { version = "0.14.0", optional = true }
+core2 = { version = "0.4.0", default-features = false, optional = true }
+
+# Optional as descriptors feature
+miniscript = { version = "11", default-features = false, optional = true }
+
 [features]
-default = ["descriptors"]
-descriptors = ["miniscript"]
+default = ["std", "descriptors"]
+std = ["bitcoin/std", "sha2/std"]
+no-std = ["bitcoin/no-std", "hashbrown", "core2"]
+descriptors = ["miniscript/std"]
+descriptors-no-std = ["miniscript/no-std"]

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -1,12 +1,23 @@
 // SPDX-License-Identifier: MIT
 
 #![no_std]
+// Ensure that both `std` and `no-std` are not enabled simultaneously
+#[cfg(all(feature = "std", feature = "no-std"))]
+compile_error!("Features `std` and `no-std` cannot be enabled simultaneously.");
+
+// Ensure that one of `std` or `no-std` is enabled
+#[cfg(not(any(feature = "std", feature = "no-std")))]
+compile_error!("One of the `std` or `no-std` features must be enabled.");
+
+#[cfg(all(feature = "no-std", feature = "descriptors"))]
+compile_error!("For `no-std` enable the `descriptors-no-std` feature instead of `descriptors`.");
+
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::ScriptBuf;
-#[cfg(feature = "descriptors")]
+#[cfg(any(feature = "descriptors", feature = "descriptors-no-std"))]
 use miniscript::Descriptor;
-#[cfg(feature = "descriptors")]
+#[cfg(any(feature = "descriptors", feature = "descriptors-no-std"))]
 use miniscript::DescriptorPublicKey;
 use sha2::Digest;
 pub mod spsc;
@@ -35,7 +46,7 @@ pub mod service_flags {
     pub const UTREEXO_FILTER: u64 = 1 << 25;
 }
 
-#[cfg(feature = "descriptors")]
+#[cfg(any(feature = "descriptors", feature = "descriptors-no-std"))]
 pub fn parse_descriptors(
     descriptors: &[String],
 ) -> Result<Vec<Descriptor<DescriptorPublicKey>>, miniscript::Error> {
@@ -64,7 +75,6 @@ pub mod prelude {
     pub use alloc::vec::Vec;
     pub use core::cmp;
     pub use core::convert;
-    pub use core::core::str::FromStr;
     pub use core::fmt;
     pub use core::fmt::Display;
     pub use core::iter;
@@ -76,6 +86,7 @@ pub mod prelude {
     pub use core::result;
     pub use core::slice;
     pub use core::str;
+    pub use core::str::FromStr;
 
     pub use core2::error::Error;
     pub use core2::io::Error as ioError;
@@ -84,7 +95,7 @@ pub mod prelude {
     pub use hashbrown::HashMap;
     pub use hashbrown::HashSet;
 }
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 pub mod prelude {
     extern crate alloc;
     extern crate std;


### PR DESCRIPTION
I have tried to make `floresta-common` be able to compile without the standard library.

1. Added the missing `no-std` feature in `Cargo.toml`, together with a default `std` feature.
2. Added the missing `core2` and `hashbrown` dependencies (used in the `no-std` prelude).
3. `sha2`, `miniscript` and `bitcoin` default features disabled to avoid importing `std-lib`, although our new `std` feature enables it.
4. Also added a new `descriptors-no-std` feature to use them without the `std-lib`.

It should be able to compile without `std-lib` by running `cargo build --no-default-features --features no-std`, but we get an error with the current fork of the `bitcoin` crate. Concretely at `bitcoin/src/consensus/encode.rs`:
```rust
impl_vec!(UtreexoBlock);
impl_vec!(CompactLeafData);
```

`UtreexoBlock` and `CompactLeafData` are not found in the scope. The first one is because the import requires the `std-lib`, the second one perhaps because of the `impl_consensus_encoding!` macro used for `CompactLeafData`.

The rest of floresta crates use the `std` version of `floresta-common`, just as before, so this change shouldn't break current things.