### PR TITLE
Feat: refactor nix files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ a security vulnerability, please email `Davidson Souza at me AT dlsouza DOT lol`
 
 ## Building
 
-### (Prerequisites) 
+### (Prerequisites)
 ```bash
 sudo apt update
 sudo apt install gcc build-essential pkg-config libssl-dev
@@ -71,37 +71,31 @@ If you're using Nix, you can add Florestad to your system with its overlay.
 
 ```nix
 {
-  #Here you declare the import for your flake
-  inputs.florestad = {
+  #Here you declare the floresta set for your flake
+  inputs.floresta-node = {
     url = "github:vinteumorg/Floresta";
     inputs = {
       nixpkgs.follows = "nixpkgs";
       flake-parts.follows = "flake-parts";
     };
   };
-
-  outputs = inputs @ { self, ... }:
+  #Pass floresta-node as a input to "output".
+  outputs = { self, floresta-node }:
   {
     imports = [
       {
-        nixpkgs.overlays = [
-          # Here you use the floresta overlay with your others
-          inputs.florestad.overlays.default
+        overlays = [
+            # Here you use the floresta overlay with your others
+            floresta-node.overlay.default
         ];
       }
     ];
   };
 ```
-then Florestad will be available just like any other package with
+then `florestad` and `floresta-cli` will be available just like any other package with
 
 ```nix
-pkgs.florestad
-```
-
-
-But if you just want to test it or quickly run a instance you can do 
-```bash
-$ nix run github:vinteumorg/Floresta
+pkgs.floresta-node
 ```
 
 ### Running
@@ -159,7 +153,7 @@ floresta-cli help <command>
 
 #### Wallet
 
-Floresta comes with a watch-only wallet that you can use to track your transactions. You just need to provide the wallet 
+Floresta comes with a watch-only wallet that you can use to track your transactions. You just need to provide the wallet
 information, either as a configuration file or as a command line argument. See the [sample configuration file](config.toml.sample) for an example config. Floresta supports SLIP-132 extended public keys (xpubs) and output descriptors. You can add new wallets to follow at any time, just
 call the `rescan` rpc after adding the wallet.
 
@@ -169,7 +163,7 @@ You can add new descriptors to the wallet with the `importdescriptor` rpc.
 floresta-cli importdescriptor "wpkh(xpub6CFy3kRXorC3NMTt8qrsY9ucUfxVLXyFQ49JSLm3iEG5gfAmWewYFzjNYFgRiCjoB9WWEuJQiyYGCdZvUTwPEUPL9pPabT8bkbiD9Po47XG/<0;1>/*)"
 ```
 
-The rescan assumes that you have compact block filters for the blocks that you're scanning. You can either download all the filters 
+The rescan assumes that you have compact block filters for the blocks that you're scanning. You can either download all the filters
 (about 11GB on mainnet) or, if you know the block range that you're interested in, you can download only the filters for that range
 using the `--filters-start-height` option. Let's you know that none of your wallets are older than block 800,000. Just start the node with.
 
@@ -226,7 +220,7 @@ Here's some Guidelines:
 
 You can accomplish that using our flake.nix for development.
 
-### Using Nix
+### Developing on Floresta with Nix
 
 If you already have [Nix](https://nixos.org/) you just need to do:
 
@@ -236,13 +230,13 @@ $ nix develop
 
 and use our flake for development which include
 
-- nix(fmt) and rust(fmt) pre-commit.
-- Rust Msrv(1.74.0).
-- Clippy and some libs so rust can compile.
-- Typos for good spelling.
+- nix(fmt) and rust(fmt)  in pre-commit.
+- [pre-commit](https://pre-commit.com/).
+- [rustup](https://rustup.rs/).
+- Typos in pre-commit.
+- [Just, the command runner](https://just.systems/).
 
-If you do not have Nix
-[Check their guide](https://nixos.org/download/).
+If you do not have Nix you can [Check their guide](https://nixos.org/download/).
 
 ### License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/build.nix
+++ b/build.nix
@@ -1,15 +1,18 @@
-{ lib, rustPlatform, rust, buildInputs, nativeBuildInputs, ... }:
+{ lib, rustPlatform, florestaRust, buildInputs }:
 
 let
-  pname = "florestad";
-  version = "0.5.1";
+    # Pname defines the name of the package and will decide the output of this expression
+    pname = "floresta-node";
+    version = "0.6.0";
 
-  buildRustPackage = rustPlatform.buildRustPackage.override {
-    rustc = rust;
-    cargo = rust;
-  };
+    # This sets the rustc and cargo to the ones from the florestaRust.
+    #
+    # Defined in Flake.nix directly from the rust-toolchain.
+    buildRustPackage = rustPlatform.buildRustPackage.override {
+        rustc = florestaRust;
+        cargo = florestaRust;
+    };
 in
-
 buildRustPackage {
   inherit pname version;
 
@@ -24,17 +27,13 @@ buildRustPackage {
     };
   };
 
-  inherit buildInputs nativeBuildInputs;
-
-  # Override the Rust compiler used
-  rustc = "${rust}/bin/rustc";
-  cargo = "${rust}/bin/cargo";
+  inherit buildInputs;
 
   meta = with lib; {
-    description = "A full bitcoin node with Utreexo";
-    homepage = "https://github.com/Davidson-Souza/Floresta";
+    description = "A lightweight bitcoin full node";
+    homepage = "https://github.com/vinteumorg/Floresta";
     license = licenses.mit;
-    maintainers = [ maintainers.Davidson maintainers.afm maintainers.jaoleal ];
-    platforms = platforms.all;
+    maintainers = [ maintainers.Davidson maintainers.jaoleal ];
+    platforms = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
   };
 }


### PR DESCRIPTION
Fixes https://github.com/vinteumorg/Floresta/issues/253.

The problem with our nix was rust override.

After thinking a bit, its far from normal to a rust developer use more than a version of rust, so i delegated rust version control directly to rustup since it does the job better while doing development(nix-shell). just was added as a dev tool too

The build.nix had some overrides too, so i updated some meta-data and forced nix to pull rust version directly from rust-toolchain.toml. Now its easier to change dependencies.