### PR TITLE
reduce dependency on forked rust-bitcoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 [[package]]
 name = "bitcoin"
 version = "0.31.0"
-source = "git+https://github.com/Davidson-Souza/rust-bitcoin?rev=eb5d7a3896fff0ebf6394dabc882d46e439695be#eb5d7a3896fff0ebf6394dabc882d46e439695be"
+source = "git+https://github.com/Davidson-Souza/rust-bitcoin?rev=5a089f01131cfdf778769224ded792fd9194a334#5a089f01131cfdf778769224ded792fd9194a334"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin-internals",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ default-members = [
 
 # we use a fork of the bitcoin crate, which is not published on crates.io
 # because it doesn't have utreexo support (yet?)
-bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "eb5d7a3896fff0ebf6394dabc882d46e439695be" }
+bitcoin = { git = "https://github.com/Davidson-Souza/rust-bitcoin", rev = "5a089f01131cfdf778769224ded792fd9194a334" }

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -26,6 +26,15 @@ pub fn get_spk_hash(spk: &ScriptBuf) -> sha256::Hash {
     sha256::Hash::from_slice(hash.as_slice()).expect("Engines shouldn't be Err")
 }
 
+/// Non-standard service flags that aren't in rust-bitcoin yet
+pub mod service_flags {
+    /// This peer supports UTREEXO messages
+    pub const UTREEXO: u64 = 1 << 24;
+
+    /// This peer supports UTREEXO filter messages
+    pub const UTREEXO_FILTER: u64 = 1 << 25;
+}
+
 #[cfg(feature = "descriptors")]
 pub fn parse_descriptors(
     descriptors: &[String],
@@ -43,6 +52,7 @@ pub fn parse_descriptors(
         .collect::<Vec<_>>();
     Ok(descriptors)
 }
+
 #[cfg(feature = "no-std")]
 pub mod prelude {
     extern crate alloc;

--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -56,6 +56,7 @@ use bitcoin::BlockHash;
 use floresta_chain::pruned_utreexo::BlockchainInterface;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::UtreexoBlock;
+use floresta_common::service_flags;
 use log::info;
 use log::warn;
 use rustreexo::accumulator::node_hash::NodeHash;
@@ -118,7 +119,7 @@ impl NodeContext for ChainSelector {
     const TRY_NEW_CONNECTION: u64 = 10; // Try creating connections more aggressively
 
     fn get_required_services(&self) -> ServiceFlags {
-        ServiceFlags::NETWORK | ServiceFlags::UTREEXO | ServiceFlags::from(1 << 25)
+        ServiceFlags::NETWORK | service_flags::UTREEXO.into() | service_flags::UTREEXO_FILTER.into()
     }
 }
 
@@ -507,7 +508,7 @@ where
         let fork = self.chain.get_fork_point(other_tip)?;
         self.send_to_random_peer(
             NodeRequest::GetBlock((vec![fork], true)),
-            ServiceFlags::UTREEXO,
+            service_flags::UTREEXO.into(),
         )
         .await?;
 

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -19,6 +19,7 @@ use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::BlockValidationErrors;
 use floresta_chain::BlockchainError;
 use floresta_chain::UtreexoBlock;
+use floresta_common::service_flags;
 use floresta_compact_filters::BlockFilter;
 use log::debug;
 use log::error;
@@ -64,8 +65,8 @@ pub struct RunningNode {
 impl NodeContext for RunningNode {
     const REQUEST_TIMEOUT: u64 = 2 * 60;
     fn get_required_services(&self) -> ServiceFlags {
-        ServiceFlags::UTREEXO
-            | ServiceFlags::NETWORK
+        ServiceFlags::NETWORK
+            | service_flags::UTREEXO.into()
             | ServiceFlags::WITNESS
             | ServiceFlags::COMPACT_FILTERS
     }
@@ -215,7 +216,7 @@ where
                     let peer = self
                         .send_to_random_peer(
                             NodeRequest::GetBlock((vec![block], true)),
-                            ServiceFlags::UTREEXO,
+                            service_flags::UTREEXO.into(),
                         )
                         .await?;
                     self.inflight
@@ -838,8 +839,6 @@ where
                     Inventory::Error => {}
                     Inventory::Block(block)
                     | Inventory::WitnessBlock(block)
-                    | Inventory::UtreexoBlock(block)
-                    | Inventory::UtreexoWitnessBlock(block)
                     | Inventory::CompactBlock(block) => {
                         self.1
                             .user_requests

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -10,6 +10,7 @@ use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::BlockValidationErrors;
 use floresta_chain::BlockchainError;
 use floresta_chain::UtreexoBlock;
+use floresta_common::service_flags;
 use log::debug;
 use log::error;
 use log::info;
@@ -37,7 +38,7 @@ pub struct SyncNode {
 
 impl NodeContext for SyncNode {
     fn get_required_services(&self) -> bitcoin::p2p::ServiceFlags {
-        ServiceFlags::WITNESS | ServiceFlags::UTREEXO | ServiceFlags::NETWORK
+        ServiceFlags::WITNESS | service_flags::UTREEXO.into() | ServiceFlags::NETWORK
     }
 
     const MAX_OUTGOING_PEERS: usize = 5; // don't need many peers, half the default
@@ -163,7 +164,7 @@ where
                 let next_peer = self
                     .send_to_random_peer(
                         NodeRequest::GetBlock((vec![block.block.block_hash()], true)),
-                        ServiceFlags::UTREEXO,
+                        service_flags::UTREEXO.into(),
                     )
                     .await?;
                 self.inflight.insert(

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -13,6 +13,7 @@ use bitcoin::hex::FromHex;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
 use floresta_chain::UtreexoBlock;
+use floresta_common::service_flags;
 use hex;
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -79,8 +80,8 @@ impl TestPeer {
             blocks: rand::random::<u32>() % 23,
             id: self.peer_id,
             address_id: rand::random::<usize>(),
-            services: ServiceFlags::UTREEXO
-                | ServiceFlags::NETWORK
+            services: ServiceFlags::NETWORK
+                | service_flags::UTREEXO.into()
                 | ServiceFlags::WITNESS
                 | ServiceFlags::COMPACT_FILTERS
                 | ServiceFlags::from(1 << 25),
@@ -141,7 +142,7 @@ pub fn create_peer(
 
     LocalPeerView {
         address: "127.0.0.1".parse().unwrap(),
-        services: ServiceFlags::UTREEXO,
+        services: service_flags::UTREEXO.into(),
         user_agent: "/utreexo:0.1.0/".to_string(),
         height: 0,
         state: PeerStatus::Ready,


### PR DESCRIPTION
Up to now we used a fork of rust-bitcoin for utreexo stuff, but we moved many of them to floresta itself. This commit almost removes completely the usage of the modified code, making it almost possible to use the mainline rust-bitcoin