### PR TITLE
changed from `error` to `warn` message on logging the ssl cert load

### DIFF
--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -555,7 +555,7 @@ impl Florestad {
         Self::from_config(Config::default())
     }
 
-    /// Loads a config file from disk, returns default if some error happens
+    /// Loads a config file from disk, returns default if it cannot load it
     fn get_config_file(path: &str) -> ConfigFile {
         let data = ConfigFile::from_file(path);
 
@@ -564,12 +564,12 @@ impl Florestad {
         } else {
             match data.unwrap_err() {
                 crate::error::Error::TomlParsing(e) => {
-                    error!("Error while parsing config file, ignoring it");
+                    warn!("Could not parse config file, ignoring it");
                     debug!("{e}");
                     ConfigFile::default()
                 }
                 crate::error::Error::Io(e) => {
-                    error!("Error reading config file, ignoring it");
+                    warn!("Could not read config file, ignoring it");
                     debug!("{e}");
                     ConfigFile::default()
                 }

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -38,6 +38,7 @@ use futures::executor::block_on;
 use log::debug;
 use log::error;
 use log::info;
+use log::warn;
 use log::Record;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
@@ -426,7 +427,7 @@ impl Florestad {
             match self.create_tls_config(&data_dir) {
                 Ok(config) => Some(config),
                 Err(_) => {
-                    error!("Failed to load SSL certificates, ignoring SSL");
+                    warn!("Failed to load SSL certificates, ignoring SSL");
                     None
                 }
             }


### PR DESCRIPTION
On running the node, it displays an ERROR if the SSL certificates are not loaded correctly. Changed it to a WARN.