### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -450,7 +450,7 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         let inner = read_lock!(self);
         let mut ser_acc: Vec<u8> = Vec::new();
         inner.acc.leaves.consensus_encode(&mut ser_acc)?;
-        #[allow(clippy::significant_drop_in_scrutinee)]
+
         for root in inner.acc.roots.iter() {
             ser_acc
                 .write_all(&**root)
@@ -463,7 +463,6 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
             .expect("Chain store is not working");
         Ok(())
     }
-    #[allow(clippy::await_holding_lock)]
     fn notify(&self, block: &Block, height: u32) {
         let inner = self.inner.read();
         let subs = inner.subscribers.iter();

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -830,18 +830,18 @@ pub async fn client_accept_loop(
 /// 1. order confirmed transactions to the script hash by increasing height (and position in the block if there are more than one in a block)
 ///
 /// 2. form a string that is the concatenation of strings "tx_hash:height:" for each
-/// transaction in order, where:
+///    transaction in order, where:
 ///
 ///  tx_hash is the transaction hash in hexadecimal
 ///  height is the height of the block it is in.
 ///
 /// 3. Next, with mempool transactions in any order, append a similar string for those
-/// transactions, but where height is -1 if the transaction has at least one unconfirmed
-/// input, and 0 if all inputs are confirmed.
+///    transactions, but where height is -1 if the transaction has at least one unconfirmed
+///    input, and 0 if all inputs are confirmed.
 ///
 /// 4. The status of the script hash is the sha256() hash of the full string expressed
-/// as a hexadecimal string, or null if the string is empty because there are no
-/// transactions.
+///    as a hexadecimal string, or null if the string is empty because there are no
+///    transactions.
 fn get_status(transactions: Vec<CachedTransaction>) -> sha256::Hash {
     let mut status_preimage = String::new();
     for transaction in transactions {
@@ -1011,7 +1011,7 @@ mod test {
             )),
             Ok(Ok(n)) => {
                 let response: std::borrow::Cow<str> = String::from_utf8_lossy(&response[..n]);
-                let response: Value = serde_json::from_str(&response).unwrap();
+                let response: Value = serde_json::from_str(&response)?;
                 Ok(response)
             }
             Ok(Err(e)) => {
@@ -1136,30 +1136,29 @@ mod test {
     /// server.ping                             *
     /// server.version                          *
     fn generate_request(req_params: &mut Vec<Value>) -> Value {
-        let params: Vec<Value>;
         let binding = req_params.pop().unwrap();
         let method = binding.as_str().unwrap();
 
-        match method {
-            "server.banner" => params = vec![],
-            "blockchain.block.header" => params = vec![req_params.pop().unwrap()],
+        let params = match method {
+            "server.banner" => vec![],
+            "blockchain.block.header" => vec![req_params.pop().unwrap()],
             "blockchain.block.headers" => {
-                params = vec![req_params.pop().unwrap(), req_params.pop().unwrap()]
+                vec![req_params.pop().unwrap(), req_params.pop().unwrap()]
             }
-            "blockchain.estimatefee" => params = vec![],
-            "blockchain.relayfee" => params = vec![],
-            "blockchain.scripthash.subscribe" => params = vec![req_params.pop().unwrap()],
-            "blockchain.scripthash.unsubscribe" => params = vec![req_params.pop().unwrap()],
-            "blockchain.scripthash.get_mempool" => params = vec![],
-            "blockchain.scripthash.get_balance" => params = vec![req_params.pop().unwrap()],
-            "blockchain.scripthash.get_history" => params = vec![req_params.pop().unwrap()],
-            "blockchain.scripthash.listunspent" => params = vec![req_params.pop().unwrap()],
-            "blockchain.transaction.broadcast" => params = vec![req_params.pop().unwrap()],
-            "blockchain.transaction.get" => params = vec![req_params.pop().unwrap()],
-            "blockchain.transaction.get_merkle" => params = vec![req_params.pop().unwrap()],
+            "blockchain.estimatefee" => vec![],
+            "blockchain.relayfee" => vec![],
+            "blockchain.scripthash.subscribe" => vec![req_params.pop().unwrap()],
+            "blockchain.scripthash.unsubscribe" => vec![req_params.pop().unwrap()],
+            "blockchain.scripthash.get_mempool" => vec![],
+            "blockchain.scripthash.get_balance" => vec![req_params.pop().unwrap()],
+            "blockchain.scripthash.get_history" => vec![req_params.pop().unwrap()],
+            "blockchain.scripthash.listunspent" => vec![req_params.pop().unwrap()],
+            "blockchain.transaction.broadcast" => vec![req_params.pop().unwrap()],
+            "blockchain.transaction.get" => vec![req_params.pop().unwrap()],
+            "blockchain.transaction.get_merkle" => vec![req_params.pop().unwrap()],
 
-            _ => params = vec![],
-        }
+            _ => vec![],
+        };
 
         json!({
             "id": rand::random::<u32>(),

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -6,13 +6,14 @@ use serde::Serialize;
 pub mod electrum_protocol;
 pub mod error;
 pub mod request;
+
 #[derive(Debug, Deserialize, Serialize)]
-struct TransactionHistoryEntry {
+pub struct TransactionHistoryEntry {
     height: u32,
     tx_hash: String,
 }
 #[derive(Debug, Deserialize, Serialize)]
-struct MempoolTransaction {
+pub struct MempoolTransaction {
     height: u32,
     tx_hash: String,
     fee: u32,

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -732,6 +732,7 @@ impl<D: AddressCacheDatabase> AddressCache<D> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn cache_transaction(
         &self,
         transaction: &Transaction,

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -510,14 +510,12 @@ impl AddressMan {
                     self.good_addresses.push(idx);
                 }
 
-                self.addresses.get(&idx).cloned().map(|address| {
+                if let Some(address) = self.addresses.get(&idx).cloned() {
                     self.push_if_has_service(&address, service_flags::UTREEXO.into());
                     self.push_if_has_service(&address, ServiceFlags::from(1 << 25)); // UTREEXO_FILTER
                     self.push_if_has_service(&address, ServiceFlags::NONE); // this means any peer
                     self.push_if_has_service(&address, ServiceFlags::COMPACT_FILTERS);
-
-                    address
-                });
+                }
             }
             AddressState::NeverTried => {
                 self.good_addresses.retain(|&x| x != idx);

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -286,7 +286,7 @@ impl<T: AsyncWrite + Unpin> Peer<T> {
                         }
                     }
                 }
-            };
+            }
 
             if self.shutdown {
                 return Ok(());
@@ -597,6 +597,7 @@ impl<T: AsyncWrite + Unpin> Peer<T> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_peer(
         id: u32,
         mempool: Arc<RwLock<Mempool>>,

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -46,9 +46,9 @@ struct Block {
 
 #[derive(Debug)]
 pub struct TestPeer {
-    headers: Vec<Header>,
+    _headers: Vec<Header>,
     blocks: HashMap<BlockHash, UtreexoBlock>,
-    filters: HashMap<BlockHash, Vec<u8>>,
+    _filters: HashMap<BlockHash, Vec<u8>>,
     node_tx: UnboundedSender<NodeNotification>,
     node_rx: UnboundedReceiver<NodeRequest>,
     peer_id: u32,
@@ -64,9 +64,9 @@ impl TestPeer {
         peer_id: u32,
     ) -> Self {
         TestPeer {
-            headers,
+            _headers: headers,
             blocks,
-            filters,
+            _filters: filters,
             node_tx,
             node_rx,
             peer_id,


### PR DESCRIPTION
- Removed unneeded `#[allow(clippy::significant_drop_in_scrutinee)]` and `#[allow(clippy::await_holding_lock)]` in `chain_state.rs`
- Directly initialize `params` in `electrum_protocol.rs`
- Added `#[allow(clippy::too_many_arguments)]` for two functions
- A few more trivial changes

Mainly the remaining warnings are about feature flags to be implemented.