### PR TITLE
Fix electrum tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to use `libfloresta` to build your own Bitcoin application, you can 
   - [Running](#running)
     - [Assume Utreexo](#assume-utreexo)
     - [Compact Filters](#compact-filters)
-    - [Getting help](#getting-help)
+    - [Getting Help](#getting-help)
     - [Wallet](#wallet)
   - [Running the Tests](#running-the-tests)
     - [Requirements](#requirements)
@@ -30,7 +30,7 @@ If you want to use `libfloresta` to build your own Bitcoin application, you can 
   - [Using Nix](#developing-on-floresta-with-nix)
   - [License](#license)
   - [Acknowledgments](#acknowledgments)
-  - [Consensus implementation](#consensus-implementation)
+  - [Consensus Implementation](#consensus-implementation)
 
 ### Community
 


### PR DESCRIPTION
I noticed sometimes the `floresta-electrum` tests don't pass (e.g. like in my previous PR checks).

Since each test previously used a randomly chosen port within the range 18443 - 19442, along with `port + 1`, tests would occasionally fail with an "Address already in use" error due to port conflicts.

The port selection is now set to `0`, allowing the OS to automatically assign an available port. This change should eliminate this error.