### PR TITLE
Fix compile errors for all feature combinations

### DIFF
--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4.3"
 
 [features]
 default = []
-bitcoinconsensus = ["dep:bitcoinconsensus"]
+bitcoinconsensus = ["bitcoin/bitcoinconsensus", "dep:bitcoinconsensus"]
 
 [[bench]]
 name = "chain_state_bench"

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -11,7 +11,6 @@ use core::cell::UnsafeCell;
 #[cfg(feature = "bitcoinconsensus")]
 use core::ffi::c_uint;
 
-#[cfg(feature = "bitcoinconsensus")]
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::consensus::deserialize_partial;

--- a/crates/floresta-cli/Cargo.toml
+++ b/crates/floresta-cli/Cargo.toml
@@ -20,11 +20,11 @@ bitcoin = { version = "0.32", features = ["serde", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
-jsonrpc = { version = "0.18.0", optional=true, features = ["minreq_http"] }
+jsonrpc = { version = "0.18.0", optional = true, features = ["minreq_http"] }
 
 [features]
 default = ["with-jsonrpc"]
-with-jsonrpc = ["jsonrpc"]
+with-jsonrpc = ["dep:jsonrpc"]
 
 [dev-dependencies]
 rand = "0.8.5"
@@ -34,3 +34,8 @@ rcgen = "0.13"
 [lib]
 name = "floresta_cli"
 path = "src/lib.rs"
+
+[[bin]]
+name = "floresta_cli"
+path = "src/main.rs"
+required-features = ["with-jsonrpc"]

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -278,6 +278,7 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+#[cfg(feature = "with-jsonrpc")]
 impl From<jsonrpc::Error> for Error {
     fn from(value: jsonrpc::Error) -> Self {
         Error::JsonRpc(value)
@@ -287,6 +288,7 @@ impl From<jsonrpc::Error> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            #[cfg(feature = "with-jsonrpc")]
             Error::JsonRpc(e) => write!(f, "JsonRpc returned an error {e}"),
             Error::Api(e) => write!(f, "general jsonrpc error: {e}"),
             Error::Serde(e) => write!(f, "error while deserializing the response: {e}"),

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -16,15 +16,15 @@ bitcoin = { version = "0.32", default-features = false, features = ["serde"] }
 spin = "0.9.8"
 
 # No-std specific dependencies
-hashbrown = { version = "0.14.0", optional = true }
-core2 = { version = "0.4.0", default-features = false, optional = true }
+hashbrown = { version = "0.14.0" }
+core2 = { version = "0.4.0", default-features = false }
 
 # Optional as descriptors feature
 miniscript = { version = "12", default-features = false, optional = true }
 
 [features]
-default = ["std", "descriptors"]
+default = ["std", "descriptors-std"]
 std = ["bitcoin/std", "sha2/std"]
-no-std = ["hashbrown", "core2"]
-descriptors = ["miniscript/std"]
+# Both features can be set at the same time, but for `no_std` only the latter should be used
+descriptors-std = ["miniscript/std"]
 descriptors-no-std = ["miniscript/no-std"]

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -1,23 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 #![no_std]
-// Ensure that both `std` and `no-std` are not enabled simultaneously
-#[cfg(all(feature = "std", feature = "no-std"))]
-compile_error!("Features `std` and `no-std` cannot be enabled simultaneously.");
-
-// Ensure that one of `std` or `no-std` is enabled
-#[cfg(not(any(feature = "std", feature = "no-std")))]
-compile_error!("One of the `std` or `no-std` features must be enabled.");
-
-#[cfg(all(feature = "no-std", feature = "descriptors"))]
-compile_error!("For `no-std` enable the `descriptors-no-std` feature instead of `descriptors`.");
 
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::ScriptBuf;
-#[cfg(any(feature = "descriptors", feature = "descriptors-no-std"))]
+#[cfg(any(feature = "descriptors-std", feature = "descriptors-no-std"))]
 use miniscript::Descriptor;
-#[cfg(any(feature = "descriptors", feature = "descriptors-no-std"))]
+#[cfg(any(feature = "descriptors-std", feature = "descriptors-no-std"))]
 use miniscript::DescriptorPublicKey;
 use sha2::Digest;
 pub mod spsc;
@@ -46,7 +36,7 @@ pub mod service_flags {
     pub const UTREEXO_FILTER: u64 = 1 << 25;
 }
 
-#[cfg(any(feature = "descriptors", feature = "descriptors-no-std"))]
+#[cfg(any(feature = "descriptors-std", feature = "descriptors-no-std"))]
 pub fn parse_descriptors(
     descriptors: &[String],
 ) -> Result<Vec<Descriptor<DescriptorPublicKey>>, miniscript::Error> {
@@ -64,7 +54,7 @@ pub fn parse_descriptors(
     Ok(descriptors)
 }
 
-#[cfg(feature = "no-std")]
+#[cfg(not(feature = "std"))]
 pub mod prelude {
     extern crate alloc;
     pub use alloc::borrow::ToOwned;

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -17,14 +17,14 @@ bitcoin = { version = "0.32", features = ["serde"] }
 kv = "0.24.0"
 log = "0.4"
 thiserror = "1.0"
-floresta-common = { path = "../floresta-common" }
+floresta-common = { path = "../floresta-common", default-features = false, features = ["descriptors-no-std"] }
 floresta-chain = { path = "../floresta-chain" }
 
 [dev-dependencies]
 rand = "0.8.5"
 
 [features]
-default = []
+default = ["std"]
 memory-database = []
-no-std = []
-std = ["serde/std"]
+# The default features in common are `std` and `descriptors-std` (which is a superset of `descriptors-no-std`)
+std = ["floresta-common/default", "serde/std"]

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -26,9 +26,7 @@ categories = ["cryptography::cryptocurrencies"]
 floresta-common = { path = "../floresta-common", version = "0.2.0" }
 floresta-chain = { path = "../floresta-chain", version = "0.2.0" }
 floresta-wire = { path = "../floresta-wire", version = "0.2.0" }
-floresta-watch-only = { path = "../floresta-watch-only", features = [
-    "memory-database",
-], optional = true, version = "0.2.0" }
+floresta-watch-only = { path = "../floresta-watch-only", optional = true, version = "0.2.0" }
 floresta-electrum = { path = "../floresta-electrum", optional = true, version = "0.2.0" }
 
 [dev-dependencies]
@@ -52,9 +50,10 @@ futures = "0.3.30"
 [features]
 default = ["bitcoinconsensus", "electrum-server", "watch-only-wallet"]
 bitcoinconsensus = ["floresta-chain/bitcoinconsensus"]
-memory-database = ["floresta-watch-only/memory-database"]
-electrum-server = ["floresta-electrum"]
-watch-only-wallet = ["floresta-watch-only"]
+electrum-server = ["dep:floresta-electrum"]
+watch-only-wallet = ["dep:floresta-watch-only"]
+# Works only if `watch-only-wallet` is set
+memory-database = ["floresta-watch-only?/memory-database"]
 
 [lib]
 crate-type = ["cdylib", "rlib", "staticlib"]

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -27,7 +27,7 @@ floresta-common = { path = "../crates/floresta-common" }
 floresta-electrum = { path = "../crates/floresta-electrum" }
 floresta-watch-only = { path = "../crates/floresta-watch-only" }
 floresta-wire = { path = "../crates/floresta-wire" }
-floresta-compact-filters = { path = "../crates/floresta-compact-filters", optional=true }
+floresta-compact-filters = { path = "../crates/floresta-compact-filters", optional = true }
 
 anyhow = "1.0.40"
 jsonrpc-http-server = { version = "18.0.0", optional = true }
@@ -53,16 +53,17 @@ path = "src/main.rs"
 pretty_assertions = "1"
 
 [features]
-compact-filters = ["floresta-compact-filters"]
-zmq-server = ["zmq"]
+compact-filters = ["dep:floresta-compact-filters"]
+zmq-server = ["dep:zmq"]
 experimental-p2p = []
 json-rpc = [
-    "jsonrpc-http-server",
-    "jsonrpc-derive",
-    "jsonrpc-core",
-    "jsonrpc-core-client",
+    "dep:jsonrpc-http-server",
+    "dep:jsonrpc-derive",
+    "dep:jsonrpc-core",
+    "dep:jsonrpc-core-client",
+    "compact-filters"
 ]
-default = ["experimental-p2p", "json-rpc", "compact-filters"]
+default = ["experimental-p2p", "json-rpc"]
 
 [build-dependencies]
 toml = "0.5.10"

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -22,7 +22,9 @@ use floresta_chain::AssumeValidArg;
 use floresta_chain::BlockchainError;
 use floresta_chain::ChainState;
 use floresta_chain::KvChainStore;
+#[cfg(feature = "compact-filters")]
 use floresta_compact_filters::flat_filters_store::FlatFiltersStore;
+#[cfg(feature = "compact-filters")]
 use floresta_compact_filters::network_filters::NetworkFilters;
 use floresta_electrum::electrum_protocol::client_accept_loop;
 use floresta_electrum::electrum_protocol::ElectrumServer;

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -50,6 +50,9 @@ fn main() {
         log_to_file: params.log_to_file,
         assume_valid: params.assume_valid,
         log_to_stdout: true,
+        #[cfg(feature = "zmq-server")]
+        zmq_address: params.zmq_address,
+        #[cfg(feature = "json-rpc")]
         json_rpc_address: params.rpc_address,
         electrum_address: params.electrum_address,
         ssl_electrum_address: params.ssl_electrum_address,

--- a/florestad/src/zmq.rs
+++ b/florestad/src/zmq.rs
@@ -4,14 +4,14 @@ use bitcoin::consensus::serialize;
 ///
 /// # Examples
 /// Creating a server
-/// ```
+/// ```ignore
 /// use florestad::zmq::ZMQServer;
 /// let _ = ZMQServer::new("tcp://127.0.0.1:5150");
 /// ```
 ///
 /// Listening for new blocks
 ///
-/// ```!
+/// ```ignore
 /// use zmq::{Context, Socket};
 /// let ctx =  Context::new();
 /// // The oposite of PUSH is PULL


### PR DESCRIPTION
*Floresta-chain*
- The `bitcoin/bitcoinconsensus` feature was still needed for the `verify_with_flags` method on `Transaction`
- `BlockHeader` is used without the feature

*Floresta-cli*
- Made `jsonrpc` not optional, as it is needed for the main function to actually run a client
- Changed the way we get the florestad path

*Floresta-common*
- Remove `no-std` feature to avoid the mutually exclusive features, as advised in https://doc.rust-lang.org/cargo/reference/features.html#mutually-exclusive-features. If `std` feature is not set, we are in `no_std`

*Floresta-watch-only*
- Update the common dependency accordingly

*Florestad*
- Make `json-rpc` feature use `compact-filters` as the Rpc trait methods require compact filters
- Missing conditional compilation

### Rust script to check all feature combinations

Since we don't have yet a CI check to know whether all feature combinations compile (and compiled tests are successful), here's a helpful Rust script. It requires `itertools` as dependency.

<details>
<summary>Rust script</summary>

```rust
use itertools::Itertools;
use std::process::{Command, Stdio};

const BASE_DIR: &str = "/your/path/to/Floresta";

fn main() {
    // Define crates and features in a list format
    let crates = vec![
        ("floresta-chain", vec!["bitcoinconsensus"]),
        ("floresta-cli", vec![]), // No features
        (
            "floresta-common",
            vec!["std", "descriptors-std", "descriptors-no-std"],
        ),
        ("floresta-compact-filters", vec![]), // No features
        ("floresta-electrum", vec![]),        // No features
        ("floresta-watch-only", vec!["memory-database", "std"]),
        ("floresta-wire", vec!["pruned_utreexo_chainstate"]),
        (
            "floresta",
            vec![
                "bitcoinconsensus",
                "memory-database",
                "electrum-server",
                "watch-only-wallet",
            ],
        ),
        (
            "florestad",
            vec![
                "compact-filters",
                "zmq-server",
                "experimental-p2p",
                "json-rpc",
            ],
        ),
    ];

    for (crate_name, features) in crates {
        // Determine the path to the crate's Cargo.toml
        let path = get_path(crate_name);

        println!("\nRunning tests for {crate_name} with {MAGENTA}default{RESET} features...\n");
        if crate_name == "floresta-cli" {
            build_florestad();
        }
        test_default(&path, crate_name);

        if features.is_empty() {
            // If there are no features we have already checked all the possibilities
            continue;
        }

        println!("\nRunning tests for {crate_name} with {MAGENTA}no{RESET} features...\n");
        test_no_features(&path, crate_name);

        // Loop through each feature combination to test it
        let len = features.len();
        let combinations = (1..=len).flat_map(|n| features.iter().cloned().combinations(n));

        for comb in combinations {
            let feature_list = comb.iter().join(", ");
            println!(
                "\nRunning tests for {crate_name} with features: {MAGENTA}{feature_list}{RESET}\n"
            );
            test_features(&path, crate_name, &feature_list);
        }
    }
}

fn test_features(path: &str, crate_name: &str, features: &str) {
    let status = Command::new("cargo")
        .args(&[
            "test",
            "--manifest-path",
            &format!("{}/Cargo.toml", path),
            "--no-default-features",
            "--features",
            features,
        ])
        .env("RUSTFLAGS", "-Awarnings") // Suppress warnings but keep errors
        .stdout(Stdio::null())
        .status()
        .expect("Failed to execute 'cargo test' with features");

    if !status.success() {
        panic!(
            "\n{}Tests failed for {} with features {}{}",
            RED, crate_name, features, RESET
        );
    } else {
        println!("OK");
    }
}

fn test_no_features(path: &str, crate_name: &str) {
    let status = Command::new("cargo")
        .args(&[
            "test",
            "--manifest-path",
            &format!("{}/Cargo.toml", path),
            "--no-default-features",
        ])
        .env("RUSTFLAGS", "-Awarnings") // Suppress warnings but keep errors
        .stdout(Stdio::null())
        .status()
        .expect("Failed to execute 'cargo test'");

    if !status.success() {
        panic!(
            "\n{}Tests failed for {} with no features{}",
            RED, crate_name, RESET
        );
    } else {
        println!("OK");
    }
}

fn test_default(path: &str, crate_name: &str) {
    let status = Command::new("cargo")
        .args(&["test", "--manifest-path", &format!("{}/Cargo.toml", path)])
        .env("RUSTFLAGS", "-Awarnings") // Suppress warnings but keep errors
        .stdout(Stdio::null())
        .status()
        .expect("Failed to execute 'cargo test'");

    if !status.success() {
        panic!(
            "\n{}Tests failed for {} with default features{}",
            RED, crate_name, RESET
        );
    } else {
        println!("OK");
    }
}

fn build_florestad() {
    let status = Command::new("cargo")
        .args(&[
            "build",
            "--manifest-path",
            &format!("{}/florestad/Cargo.toml", BASE_DIR),
        ])
        .env("RUSTFLAGS", "-Awarnings") // Suppress warnings but keep errors
        .stdout(Stdio::null())
        .status()
        .expect("Failed to execute 'cargo test'");
    assert!(status.success(), "Couldn't compile florestad");
}

fn get_path(crate_name: &str) -> String {
    if crate_name == "florestad" {
        format!("{}/{}", BASE_DIR, crate_name) // 'florestad' is in the root of base_dir
    } else {
        format!("{}/crates/{}", BASE_DIR, crate_name) // Other crates are under 'crates/' in base_dir
    }
}

const RESET: &str = "\x1b[0m";
const MAGENTA: &str = "\x1b[1;35m";
const RED: &str = "\x1b[91m";

```