### PR TITLE
CI: Test all feature combinations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,16 +20,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-
       - name: Run cargo fmt
         run: cargo +nightly fmt --all --check
 
       - name: Run cargo clippy
         run: cargo +nightly clippy --all-targets
-        env:
-          PWD: ${{ github.workspace }} # without it ci can't see env!("PWD")
 
   cross-testing:
     strategy:
@@ -39,25 +34,56 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.74.1 # The version in our `rust-toolchain.toml`
+        with:
+          components: rustfmt, clippy
+      - uses: taiki-e/install-action@cargo-hack
 
-      - name: Cache Rust
-        uses: actions/cache@v4
+      # Bi-weekly numbers to refresh caches every two weeks, ensuring recent project changes are cached
+      - name: Set bi-weekly cache key
+        run: |
+          YEAR=$(date +%Y)
+          BIWEEK=$(( ($(date +%U) + 1) / 2 ))
+          echo "CACHE_VERSION=${YEAR}(${BIWEEK})" >> $GITHUB_ENV
+        shell: bash
+
+      # Restore cached dependencies and build artifacts
+      - name: Restore Rust cache
+        id: cache
+        uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            target/release/
+          # Cache key depends on the bi-week we are on (cache version)
+          key: ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-
+            ${{ runner.os }}-cargo-
 
-      - name: Build Floresta
-        run: cargo build --verbose
+      # Build only the binaries
+      - name: Build binaries
+        run: cargo build --release --bins --verbose
 
-      - name: Run tests
-        run: cargo test --verbose
-        env:
-          PWD: ${{ github.workspace }} # without it ci can't see env!("PWD")
+      # Run the feature testing script
+      - name: Run feature tests
+        run: ./contrib/test_features.sh --verbose
+        shell: bash   # Ensure the script runs using bash on all platforms
+
+      # Save cache only if the previous steps succeeded and there was not an exact cache key match
+      # This happens everytime we modify any `cargo.lock` or `cargo.toml`, or each two weeks (caching recent changes)
+      - name: Save Rust cache
+        if: success() && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/release/
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   build-docker:
     runs-on: ubuntu-latest

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -21,6 +21,7 @@ pub mod rpc_types;
 mod tests {
     use std::fs;
     use std::net::TcpListener;
+    use std::path::Path;
     use std::process::Child;
     use std::process::Command;
     use std::process::Stdio;
@@ -60,7 +61,15 @@ mod tests {
         // CARGO_MANIFEST_DIR is always floresta-cli's directory; PWD changes based on where the
         // command is executed.
         let root = format!("{}/../..", env!("CARGO_MANIFEST_DIR"));
-        let florestad_path = format!("{root}/target/debug/florestad");
+        let release_path = format!("{root}/target/release/florestad");
+        let debug_path = format!("{root}/target/debug/florestad");
+
+        let release_found = Path::new(&release_path).try_exists().unwrap();
+        // If release target not found, default to the debug path
+        let florestad_path = match release_found {
+            true => release_path,
+            false => debug_path,
+        };
 
         // makes a temporary directory
         let test_code = rand::random::<u64>();


### PR DESCRIPTION
Closes #241 

This PR builds on top of #276. This is a significant improvement for floresta as we will now check that no feature setup is broken and all tests pass across feature sets.

The `cargo` caches used for the `cross-testing` job are now smaller due to `release` builds (600MB macOS, 780MB Linux, 720MB Windows). While CI runtime has increased, it's still reasonable: 8–9 minutes for macOS and Linux, and 19 minutes for Windows (the slowest GitHub Actions runner).

The first CI run after merging into `master` will take longer due to cache rebuilding, but subsequent runs will align with the ~19 minutes.

#### Commit message

- Remove caching from the `lint` job as it is less critical for these quick checks (now takes ~1 min).
- Introduce `CACHE_VERSION` to the cache key, updated bi-weekly.
- Use only release artifacts (needed to not exceed the 10GB github actions limit, but also makes sense as we test the end user targets).