### PR TITLE
Add floresta-cli to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM debian:11.6-slim@sha256:171530d298096f0697da36b3324182e872db77c66452b85783ea893680cc1b62
 
 COPY --from=builder /opt/app/target/release/florestad /usr/local/bin/florestad
+COPY --from=builder /opt/app/target/release/floresta_cli /usr/local/bin/floresta-cli
 RUN chmod +x /usr/local/bin/florestad
 
 EXPOSE 50001


### PR DESCRIPTION
Allows easy usage like

```
$ docker run --detach --name floresta --volume floresta:/data floresta florestad --data-dir /data
fda244c1a43cad76f45b8615a0ff20628cebd36c4f927b2984b5f106887158df

$ docker exec floresta floresta-cli getblockchaininfo
{
  "best_block": "00000000000000000001c1f5a0f1864a6dc29d6fc1e7d0e66d5831aaee69e908",
  "height": 871039,
  "ibd": true,
  "validated": 855611,
  "latest_work": "439336363866695155673542",
  "latest_block_time": 1732023060,
  "leaf_count": 2588053492,
  "root_count": 16,
  "root_hashes": [
    "0abad777a20146eb4a48ee01d4152f5c36c9a7ffc400058723c03a9d3f664585",
    "0ebafacf7163e201d160ed952a9e4024ba2bdf768317d6e877609dc7d1d76e59",
    "32888e0c96b66e9ae575628c08991c362a0e4ae6a564308329977bc2c8c2e8e6",
    "ad38b638d39c3cc421361bc8392da7720f031cba3a0f35ed135245c03e11a247",
    "cffcc620aaa8b46b23924c16b51a53630d35b5c355943ce42aff586f43332df8",
    "a54e07fedf09245c10ebd702aab51398de5f931c7cddd9f93d55fff5f72f8ca0",
    "9155acb044dcc81ae71f594cab3f04818f5a64a4e5801fbf3cf34ec07e330af9",
    "06c2645bd1d0f60839e47a359f1bb624f2e5635cec998b2664aeef36ef3943e9",
    "ba89df87509db1457115e579d2bd45ac284ee9dd704e514e77579d2f8e209c56",
    "0971d033b1497d62b951356328509c05e3ef7c172088bc263145b99c81d49a09",
    "7e12d784ca1577eb43b977d2bcd7f4937c721f5a6c12947c20876aaf2d8c3ebe",
    "e1ca6e984044a503ff2f0de3bfacb8c8d406583e61ca73e15b14cae0b40c4e68",
    "b657e6bfe5b9413d07cd58f6bfbcb4a00d2f7e2c955ce8a24a5eb72aabdfcab2",
    "49893a5b518b5adfc1b07672c33eb5746a895f84c409f808f3c5ae7d42dcd547",
    "2405e8d0c05073996b510e009c81b808c139e55d5b95f7890817b94f8b8c53ee",
    "431ab140bd64e1890a0d756c1f77aa56f99ba1ad3130a017cb2537b583a84803"
  ],
  "chain": "bitcoin",
  "progress": 0.9822878,
  "difficulty": 102289407543323
}
```