### PR TITLE
feat: allow hostnames where we take addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -730,6 +730,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-lookup"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5766087c2235fec47fafa4cfecc81e494ee679d0fd4a59887ea0919bfb0e4fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "socket2 0.5.7",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,7 +915,7 @@ name = "floresta-wire"
 version = "0.2.0"
 dependencies = [
  "bitcoin 0.32.4",
- "dns-lookup",
+ "dns-lookup 1.0.8",
  "floresta-chain",
  "floresta-common",
  "floresta-compact-filters",
@@ -934,6 +946,7 @@ dependencies = [
  "ctrlc",
  "daemonize",
  "dirs",
+ "dns-lookup 2.0.4",
  "fern",
  "floresta-chain",
  "floresta-common",
@@ -1744,7 +1757,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.7",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2809,7 +2822,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2818,7 +2840,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2827,7 +2849,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2836,15 +2873,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2854,9 +2897,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2872,9 +2927,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2884,9 +2951,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1063,7 +1063,8 @@ mod test {
                 chain.clone(),
                 Arc::new(tokio::sync::RwLock::new(Mempool::new())),
                 None,
-            );
+            )
+            .unwrap();
 
         let node_interface = chain_provider.get_handle();
 

--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -1,3 +1,6 @@
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::{self};
 use std::io;
 
 use floresta_chain::BlockchainError;
@@ -36,6 +39,8 @@ pub enum WireError {
     CompactBlockFiltersError(IteratableFilterStoreError),
     #[error("Poisoned lock")]
     PoisonedLock,
+    #[error("We couldn't parse the provided address due to: {0}")]
+    InvalidAddress(AddrParseError),
 }
 
 impl_error_from!(WireError, PeerError, PeerError);
@@ -45,6 +50,7 @@ impl_error_from!(
     IteratableFilterStoreError,
     CompactBlockFiltersError
 );
+impl_error_from!(WireError, AddrParseError, InvalidAddress);
 
 impl From<tokio::sync::mpsc::error::SendError<NodeRequest>> for WireError {
     fn from(error: tokio::sync::mpsc::error::SendError<NodeRequest>) -> Self {
@@ -55,5 +61,26 @@ impl From<tokio::sync::mpsc::error::SendError<NodeRequest>> for WireError {
 impl From<io::Error> for WireError {
     fn from(err: io::Error) -> WireError {
         WireError::Io(err)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AddrParseError {
+    InvalidIpv6,
+    InvalidIpv4,
+    InvalidHostname,
+    InvalidPort,
+    Inconclusive,
+}
+
+impl Display for AddrParseError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            AddrParseError::InvalidIpv6 => write!(f, "Invalid ipv6"),
+            AddrParseError::InvalidIpv4 => write!(f, "Invalid ipv4"),
+            AddrParseError::InvalidHostname => write!(f, "Invalid hostname"),
+            AddrParseError::InvalidPort => write!(f, "Invalid port"),
+            AddrParseError::Inconclusive => write!(f, "Inconclusive"),
+        }
     }
 }

--- a/crates/floresta-wire/src/p2p_wire/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/mod.rs
@@ -6,8 +6,6 @@ use std::net::SocketAddr;
 use bitcoin::Network;
 use floresta_chain::AssumeUtreexoValue;
 
-use self::address_man::LocalAddress;
-
 #[derive(Debug, Clone)]
 /// Configuration for the Utreexo node.
 pub struct UtreexoNodeConfig {
@@ -30,7 +28,7 @@ pub struct UtreexoNodeConfig {
     ///
     /// If you want to connect to a specific peer, you can set this to a string with the
     /// format `ip:port`. For example, `localhost:8333`.
-    pub fixed_peer: Option<LocalAddress>,
+    pub fixed_peer: Option<String>,
     /// Maximum ban score. Defaults to 100.
     ///
     /// If a peer misbehaves, we increase its ban score. If the ban score reaches this value,

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -290,7 +290,9 @@ where
                 chain,
                 self.mempool.clone(),
                 None,
-            );
+            )
+            .expect("Failed to create backfill node"); // expect is fine here, because we already
+                                                       // validated this config before creating the RunningNode
 
             UtreexoNode::<SyncNode, PartialChainState>::run(
                 &mut backfill,

--- a/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
@@ -52,7 +52,8 @@ mod tests_utils {
             chain.clone(),
             mempool,
             None,
-        );
+        )
+        .unwrap();
 
         for (i, peer) in peers.into_iter().enumerate() {
             let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -62,7 +62,8 @@ async fn main() {
         chain.clone(),
         Arc::new(RwLock::new(Mempool::new())),
         None,
-    );
+    )
+    .unwrap();
     // A handle is a simple way to interact with the node. It implements a queue of requests
     // that will be processed by the node.
     let handle = p2p.get_handle();

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -37,6 +37,7 @@ jsonrpc-core-client = { version = "18.0.0", features = [
     "http",
 ], optional = true }
 zmq = { version = "0.10.0", optional = true }
+dns-lookup = "2.0.4"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }


### PR DESCRIPTION
Closes #284

Now you can pass a hostname (i.e.: localhost, node, vps) for addresses in configs like `rpc-address` and `electrum-address`. The format is <hostname>[:port].

One question is whether we should just pick the default one or to crash if we can't resolve the name. I'm leaning towards crashing, at least for the binding addresses.