### PR TITLE
Prepare for v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "floresta"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "floresta",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-chain"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "bitcoinconsensus 0.106.0+26.0",
@@ -811,7 +811,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustreexo",
- "secp256k1 0.30.0",
+ "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "sha2",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bitcoin 0.32.4",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "core2",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-compact-filters"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "floresta-chain",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-electrum"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "core2",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-watch-only"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "floresta-chain",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "floresta-wire"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.4",
  "dns-lookup 1.0.8",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "florestad"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bitcoin 0.32.4",
@@ -2172,17 +2172,6 @@ dependencies = [
  "bitcoin_hashes 0.14.0",
  "secp256k1-sys 0.10.1",
  "serde",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
-dependencies = [
- "bitcoin_hashes 0.14.0",
- "rand 0.8.5",
- "secp256k1-sys 0.10.1",
 ]
 
 [[package]]

--- a/build.nix
+++ b/build.nix
@@ -3,7 +3,7 @@
 let
     # Pname defines the name of the package and will decide the output of this expression
     pname = "floresta-node";
-    version = "0.6.0";
+    version = "0.7.0";
 
     # This sets the rustc and cargo to the ones from the florestaRust.
     #

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-chain"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]
 description = """

--- a/crates/floresta-cli/Cargo.toml
+++ b/crates/floresta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]
 license = "MIT"

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-common"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Common types and functions for Floresta"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]

--- a/crates/floresta-compact-filters/Cargo.toml
+++ b/crates/floresta-compact-filters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-compact-filters"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Davidson Sousa <davidson.lucas.souza@outlook.com>"]
 edition = "2018"
 homepage = "https://github.com/davidson-souza/floresta"

--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-electrum"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]
 description = """

--- a/crates/floresta-watch-only/Cargo.toml
+++ b/crates/floresta-watch-only/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-watch-only"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A simple, lightweight and Electrum-First, watch-only wallet"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta-wire"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]
 description = """

--- a/crates/floresta/Cargo.toml
+++ b/crates/floresta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floresta"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Davidson Souza <davidson.lucas.souza@outlook.com>"]
 edition = "2021"
 description = """
@@ -23,11 +23,11 @@ keywords = ["bitcoin", "utreexo", "node", "blockchain", "rust"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-floresta-common = { path = "../floresta-common", version = "0.2.0" }
-floresta-chain = { path = "../floresta-chain", version = "0.2.0" }
-floresta-wire = { path = "../floresta-wire", version = "0.2.0" }
-floresta-watch-only = { path = "../floresta-watch-only", optional = true, version = "0.2.0" }
-floresta-electrum = { path = "../floresta-electrum", optional = true, version = "0.2.0" }
+floresta-common = { path = "../floresta-common", version = "0.3.0" }
+floresta-chain = { path = "../floresta-chain", version = "0.3.0" }
+floresta-wire = { path = "../floresta-wire", version = "0.3.0" }
+floresta-watch-only = { path = "../floresta-watch-only", optional = true, version = "0.3.0" }
+floresta-electrum = { path = "../floresta-electrum", optional = true, version = "0.3.0" }
 
 [dev-dependencies]
 rustreexo = "0.3.0"
@@ -38,7 +38,7 @@ bitcoin = { version = "0.32", features = [
     "bitcoinconsensus",
 ], default-features=false }
 
-floresta = { version = "0.2.0", path = "../floresta", features = [
+floresta = { version = "0.3.0", path = "../floresta", features = [
     "bitcoinconsensus",
     "memory-database",
     "electrum-server",

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "florestad"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
As discussed in #287, this makes the release for v0.7.0. We now need to test the code in this version and make sure it works and is stable enough.