### PR TITLE
fix: specify version on just commands to avoid incorrect versions being used

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,19 +26,19 @@ clean:
 test name="":
     @just test-doc {{name}}
     @just test-unit {{name}}
-    @just test-int {{name}}
+    @just test-int
 
 # Execute doc tests
 test-doc name="":
-    cargo +nightly test {{name}} --doc
+    cargo  test {{name}} --doc
 
 # Execute unit tests
 test-unit name="":
     cargo test --lib {{name}} -- --nocapture
 
 # Execute integration tests
-test-int name="":
-    cargo test --test '*' {{name}} -- --nocapture
+test-int:
+    cargo test --workspace -- --nocapture
 
 # Generate documentation for all crates
 doc:


### PR DESCRIPTION
As shown by lucas here https://github.com/vinteumorg/Floresta/issues/295#issuecomment-2515337540 , #295 could be fixed aligning the versions of `cargo build` and the declared version in "rust-toolchain.toml". 

~~So i matched the version inside the justfile.~~

~~I know this changes looks strange inside the justfile and possibly will be another data to maintain if we update our MSRV.
But we need it, its the only way to certify such a external thing from our project.~~

Nope, not needed.

closes #295 
 