### PR TITLE
[Feat:] Time consensus implementation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Run benchmarks
       - name: Run cargo bench
-        run: cargo bench
+        run: cargo bench --features non_canonical
 
       # Save cache only if the previous steps succeeded and there was not an exact cache key match
       # This happens everytime we modify any `cargo.lock` or `cargo.toml`, or each two weeks (caching recent changes)

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -22,12 +22,12 @@ rustreexo = "0.4"
 sha2 = "^0.10.6"
 log = "0.4"
 kv = "0.24.0"
-bitcoin = { version = "0.32", features = [
-    "serde",
-], default-features = false }
+bitcoin = { version = "0.32", features = ["serde"], default-features = false }
 spin = "0.9.8"
 core2 = { version = "0.4.0", default-features = false }
-floresta-common = { path = "../floresta-common", default-features = false, features = ["std"] }
+floresta-common = { path = "../floresta-common", default-features = false, features = [
+    "std",
+] }
 bitcoinconsensus = { version = "0.106.0", optional = true, default-features = false }
 metrics = { path = "../../metrics", optional = true }
 
@@ -41,9 +41,14 @@ hex = "0.4.3"
 
 [features]
 default = []
+std = []
+# This disables floresta_chain dependency on canonical chains.
+# Better while pruned contexts like tests or benchmarks.
+non_canonical = []
 bitcoinconsensus = ["bitcoin/bitcoinconsensus", "dep:bitcoinconsensus"]
 metrics = ["dep:metrics"]
 
 [[bench]]
 name = "chain_state_bench"
+
 harness = false

--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -13,6 +13,7 @@ use criterion::criterion_main;
 use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::SamplingMode;
+use floresta_chain::pruned_utreexo::utxo_data::UtxoData;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::ChainState;
@@ -44,7 +45,7 @@ fn setup_test_chain<'a>(
 fn decode_block_and_inputs(
     block_file: File,
     stxos_file: File,
-) -> (Block, HashMap<OutPoint, TxOut>) {
+) -> (Block, HashMap<OutPoint, UtxoData>) {
     let block_bytes = zstd::decode_all(block_file).unwrap();
     let block: Block = deserialize(&block_bytes).unwrap();
 
@@ -58,7 +59,16 @@ fn decode_block_and_inputs(
         .iter()
         .skip(1) // Skip the coinbase transaction
         .flat_map(|tx| &tx.input)
-        .map(|txin| (txin.previous_output, stxos.remove(0)))
+        .map(|txin| {
+            (
+                txin.previous_output,
+                UtxoData {
+                    txout: stxos.remove(0),
+                    commited_height: 0,
+                    commited_time: 0,
+                },
+            )
+        })
         .collect();
 
     assert!(stxos.is_empty(), "Moved all stxos to the inputs map");

--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -10,7 +10,7 @@
 //! All data is stored in a `ChainStore` implementation, which is generic over the
 //! underlying database. See the ChainStore trait for more information. For a
 //! ready-to-use implementation, see the [KvChainStore] struct.
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 macro_rules! bhash {
     ($s:expr) => {{

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -39,6 +39,9 @@ pub struct TransactionError {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BlockValidationErrors {
+    BlockTooNew,
+    BlockTooOld,
+    InvalidBlockTimestamp,
     InvalidCoinbase(String),
     UtxoNotFound(OutPoint),
     ScriptValidationError(String),
@@ -57,6 +60,9 @@ pub enum BlockValidationErrors {
     BadBip34,
     InvalidProof,
     CoinbaseNotMatured,
+    BadRelativeBlockLock,
+    BadRelativeTimeLock,
+    BadAbsoluteLockTime,
 }
 
 // Helpful macro for generating a TransactionError
@@ -84,6 +90,27 @@ impl Display for TransactionError {
 impl Display for BlockValidationErrors {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            BlockValidationErrors::BlockTooNew => {
+                write!(f, "A block is too new for the MTP at its height")
+            }
+            BlockValidationErrors::BlockTooOld => {
+                write!(f, "A block is too old for the MTP at its height")
+            }
+            BlockValidationErrors::InvalidBlockTimestamp => {
+                write!(f, "A block contains a invalid timestamp")
+            }
+            BlockValidationErrors::BadAbsoluteLockTime => {
+                write!(f, "A transaction contains a invalid absolute lock time.",)
+            }
+            BlockValidationErrors::BadRelativeBlockLock => {
+                write!(f, "this transaction contains a Block Height locked Sequence that isnt satisfied. ",)
+            }
+            BlockValidationErrors::BadRelativeTimeLock => {
+                write!(
+                    f,
+                    "this transaction contains a Block Time locked Sequence that isnt satisfied. ",
+                )
+            }
             BlockValidationErrors::ScriptValidationError(e) => {
                 write!(f, "{}", e)
             }

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -25,14 +25,13 @@ use bitcoin::block::Header as BlockHeader;
 use bitcoin::hashes::sha256;
 use bitcoin::Block;
 use bitcoin::BlockHash;
-use bitcoin::OutPoint;
 use bitcoin::Transaction;
-use bitcoin::TxOut;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use rustreexo::accumulator::proof::Proof;
 use rustreexo::accumulator::stump::Stump;
 
 use self::partial_chain::PartialChainState;
+use self::utxo_data::UtxoMap;
 use crate::prelude::*;
 use crate::BestChain;
 use crate::BlockConsumer;
@@ -98,13 +97,22 @@ pub trait BlockchainInterface {
         &self,
         block: &Block,
         proof: Proof,
-        inputs: HashMap<OutPoint, TxOut>,
+        inputs: UtxoMap,
         del_hashes: Vec<sha256::Hash>,
         acc: Stump,
     ) -> Result<(), Self::Error>;
 
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error>;
     fn get_params(&self) -> bitcoin::params::Params;
+
+    /// Get the Median Time Past of the last 11 blocks from the given height
+    ///
+    /// Fails if all the 11 blocks are not present in the chain.
+    ///
+    /// feature = "non_canonical" make this allways return 0
+    /// due to its dependency on a canonical chain.
+    /// Which will disable some internal time relate checks.
+    fn get_mtp(&self, height: u32) -> Result<u32, Self::Error>;
 }
 /// [UpdatableChainstate] is a contract that a is expected from a chainstate
 /// implementation, that wishes to be updated. Using those methods, a backend like the p2p-node,
@@ -118,7 +126,7 @@ pub trait UpdatableChainstate {
         &self,
         block: &Block,
         proof: Proof,
-        inputs: HashMap<OutPoint, TxOut>,
+        inputs: UtxoMap,
         del_hashes: Vec<sha256::Hash>,
     ) -> Result<u32, BlockchainError>;
 
@@ -223,7 +231,7 @@ impl<T: UpdatableChainstate> UpdatableChainstate for Arc<T> {
         &self,
         block: &Block,
         proof: Proof,
-        inputs: HashMap<OutPoint, TxOut>,
+        inputs: UtxoMap,
         del_hashes: Vec<sha256::Hash>,
     ) -> Result<u32, BlockchainError> {
         T::connect_block(self, block, proof, inputs, del_hashes)
@@ -272,6 +280,10 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
 
     fn get_tx(&self, txid: &bitcoin::Txid) -> Result<Option<bitcoin::Transaction>, Self::Error> {
         T::get_tx(self, txid)
+    }
+
+    fn get_mtp(&self, height: u32) -> Result<u32, Self::Error> {
+        T::get_mtp(self, height)
     }
 
     fn get_params(&self) -> bitcoin::params::Params {
@@ -357,7 +369,7 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
         &self,
         block: &Block,
         proof: Proof,
-        inputs: HashMap<OutPoint, TxOut>,
+        inputs: UtxoMap,
         del_hashes: Vec<sha256::Hash>,
         acc: Stump,
     ) -> Result<(), Self::Error> {
@@ -367,4 +379,75 @@ impl<T: BlockchainInterface> BlockchainInterface for Arc<T> {
     fn get_fork_point(&self, block: BlockHash) -> Result<BlockHash, Self::Error> {
         T::get_fork_point(self, block)
     }
+}
+
+/// Module to delegate local-time context.
+///
+/// The consumer of `Floresta-chain` has the option to implement [`NodeTime`] if on a non-std environment.([`get_time()`] implementation that returns 0u32 will disable time checks.)
+///
+/// On std you can just use a instance [`StdNodeTime`] as input.
+pub mod nodetime {
+
+    /// Disable empty struct.
+    ///
+    /// Meant to be used in cases to disable time verifications
+    pub struct DisableTime;
+
+    /// One Hour in seconds constant.
+    pub const HOUR: u32 = 60 * 60;
+
+    /// Trait to return time-related context of the chain.
+    ///
+    /// [`get_time()`] should return a the latest [unix timestamp](https://en.wikipedia.org/wiki/Unix_time) when the consumer has time-notion.
+    ///
+    /// if the consumer does not have any time notion or MTP control, its safe to use `0u32` to disable any validations on time.
+    pub trait NodeTime {
+        /// Should return a unix timestamp or 0 to skip any time related validation.
+        fn get_time(&self) -> u32;
+    }
+
+    impl NodeTime for DisableTime {
+        fn get_time(&self) -> u32 {
+            // we simply return zero to disable time checks
+            0
+        }
+    }
+
+    #[cfg(feature = "std")]
+    /// A module to provide the standard implementation of [`NodeTime`] trait. It uses [`std::time::SystemTime`] to get the current time.
+    pub mod standard_node_time {
+        extern crate std;
+        use std::time;
+
+        /// A empty struct to implement [`NodeTime`] trait using [`std::time::SystemTime`]
+        pub struct StdNodeTime;
+        impl super::NodeTime for StdNodeTime {
+            fn get_time(&self) -> u32 {
+                time::SystemTime::now()
+                    .duration_since(time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as u32
+            }
+        }
+    }
+}
+
+///Module to hold methods and structs related to UTXO data.
+pub mod utxo_data {
+
+    use bitcoin::OutPoint;
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    /// A struct to hold unverified UTXOs and its metadata.
+    pub struct UtxoData {
+        /// The transaction output that created this UTXO.
+        pub txout: bitcoin::TxOut,
+        /// The lock value of the utxo.
+        pub commited_height: u32,
+        pub commited_time: u32,
+    }
+
+    pub(crate) type UtxoMap = HashMap<OutPoint, UtxoData>;
 }

--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -36,6 +36,7 @@ bip324 = { version = "0.7.0", features = [ "tokio" ] }
 
 [dev-dependencies]
 zstd = "0.13.3"
+floresta-chain = { path = "../floresta-chain", features = ["non_canonical"]}
 hex = "0.4.3"
 
 [features]

--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -385,7 +385,8 @@ where
     fn update_acc(&self, acc: Stump, block: UtreexoBlock, height: u32) -> Result<Stump, WireError> {
         let (proof, del_hashes, _) = floresta_chain::proof_util::process_proof(
             block.udata.as_ref().unwrap(),
-            &block.block.txdata,
+            &block.block,
+            height,
             &self.chain,
         )?;
 
@@ -524,14 +525,15 @@ where
             };
             break block;
         };
+        let fork_height = self.chain.get_block_height(&fork)?.unwrap_or(0);
 
         let (proof, del_hashes, inputs) = floresta_chain::proof_util::process_proof(
             block.udata.as_ref().unwrap(),
-            &block.block.txdata,
+            &block.block,
+            fork_height,
             &self.chain,
         )?;
 
-        let fork_height = self.chain.get_block_height(&fork)?.unwrap_or(0);
         let acc = self.find_accumulator_for_block(fork_height, fork).await?;
         let is_valid = self
             .chain

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -730,8 +730,12 @@ where
                 return Ok(());
             };
 
-            let (proof, del_hashes, inputs) =
-                floresta_chain::proof_util::process_proof(udata, &block.block.txdata, &self.chain)?;
+            let (proof, del_hashes, inputs) = floresta_chain::proof_util::process_proof(
+                udata,
+                &block.block,
+                validation_index + 1,
+                &self.chain,
+            )?;
 
             if let Err(e) =
                 self.chain
@@ -744,11 +748,17 @@ where
                     // to be invalidated.
                     match e {
                         BlockValidationErrors::InvalidCoinbase(_)
+                        | BlockValidationErrors::InvalidBlockTimestamp
                         | BlockValidationErrors::UtxoNotFound(_)
+                        | BlockValidationErrors::BadAbsoluteLockTime
+                        | BlockValidationErrors::BadRelativeBlockLock
+                        | BlockValidationErrors::BadRelativeTimeLock
                         | BlockValidationErrors::ScriptValidationError(_)
                         | BlockValidationErrors::InvalidOutput
                         | BlockValidationErrors::ScriptError
                         | BlockValidationErrors::BlockTooBig
+                        | BlockValidationErrors::BlockTooNew
+                        | BlockValidationErrors::BlockTooOld
                         | BlockValidationErrors::NotEnoughPow
                         | BlockValidationErrors::TooManyCoins
                         | BlockValidationErrors::BadMerkleRoot

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -216,8 +216,8 @@ where
 
         self.blocks.insert(block.block.block_hash(), (peer, block));
 
-        let next_block = self.chain.get_validation_index()? + 1;
-        let mut next_block = self.chain.get_block_hash(next_block)?;
+        let next_block_height = self.chain.get_validation_index()? + 1;
+        let mut next_block = self.chain.get_block_hash(next_block_height)?;
 
         while let Some((peer, block)) = self.blocks.remove(&next_block) {
             let start = Instant::now();
@@ -241,7 +241,8 @@ where
             debug!("processing block {}", block.block.block_hash(),);
             let (proof, del_hashes, inputs) = floresta_chain::proof_util::process_proof(
                 &block.udata.unwrap(),
-                &block.block.txdata,
+                &block.block,
+                next_block_height,
                 &self.chain,
             )?;
 
@@ -260,11 +261,17 @@ where
                     // to be invalidated.
                     match e {
                         BlockValidationErrors::InvalidCoinbase(_)
+                        | BlockValidationErrors::InvalidBlockTimestamp
                         | BlockValidationErrors::UtxoNotFound(_)
+                        | BlockValidationErrors::BadAbsoluteLockTime
+                        | BlockValidationErrors::BadRelativeBlockLock
+                        | BlockValidationErrors::BadRelativeTimeLock
                         | BlockValidationErrors::ScriptValidationError(_)
                         | BlockValidationErrors::InvalidOutput
                         | BlockValidationErrors::ScriptError
                         | BlockValidationErrors::BlockTooBig
+                        | BlockValidationErrors::BlockTooNew
+                        | BlockValidationErrors::BlockTooOld
                         | BlockValidationErrors::NotEnoughPow
                         | BlockValidationErrors::TooManyCoins
                         | BlockValidationErrors::BadMerkleRoot


### PR DESCRIPTION
Since #198 became abandoned and wasnt updated i decided to reimplement what was done from that PR.

This PR tries to add the validation for Time related data to floresta.
To implement this i ran trough some solutions and here they are:
- `locktime inside the transactions`: To validate them i need the `MTP` and the timestamp of the block **when the utxo was created.**
- `Block Timestamp`: To validate if a block is inserting the correct timestamp i need the `MTP` of the chain.

This changes implements a new struct and a trait on `mod` and a new function on `Consensus` .

- Trait NodeTime was made just to delegate real-time notion of time.
- Struct Utxo_Data for holding the utxo together with block-height and time data of the commitment of the utxo, when it was created.
- `validate_locktime` method inside `Consensus` to consume the other solutions (MTP, UTXO TIME-DATA) and to validate time itself.

The work from now on in this PR is:
- Include `validate_locktime` and populate support for it, changing some methods signature(including `validate_transactions`, `validate_block` and etc...).
- Implement a way of having MTP notion. Its a problematic because of how we organize our IBD and i dont have a good solution for it, besides including MTP validation only after the chain is validated(any thoughts on this ?).