### PR TITLE
Add comments to explain RPC client code

### DIFF
--- a/crates/floresta-cli/src/jsonrpc_client.rs
+++ b/crates/floresta-cli/src/jsonrpc_client.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
+
 use serde::Deserialize;
+
 use crate::rpc::JsonRPCClient;
 
 // Define a Client struct that wraps a jsonrpc::Client

--- a/crates/floresta-cli/src/jsonrpc_client.rs
+++ b/crates/floresta-cli/src/jsonrpc_client.rs
@@ -1,12 +1,12 @@
 use std::fmt::Debug;
-
 use serde::Deserialize;
-
 use crate::rpc::JsonRPCClient;
 
+// Define a Client struct that wraps a jsonrpc::Client
 #[derive(Debug)]
 pub struct Client(jsonrpc::Client);
 
+// Configuration struct for JSON-RPC client
 pub struct JsonRPCConfig {
     pub url: String,
     pub user: Option<String>,
@@ -14,20 +14,22 @@ pub struct JsonRPCConfig {
 }
 
 impl Client {
+    // Constructor to create a new Client with a URL
     pub fn new(url: String) -> Self {
         let client =
             jsonrpc::Client::simple_http(&url, None, None).expect("Failed to create client");
         Self(client)
     }
 
+    // Constructor to create a new Client with a configuration
     pub fn new_with_config(config: JsonRPCConfig) -> Self {
         let client =
             jsonrpc::Client::simple_http(&config.url, config.user.clone(), config.pass.clone())
                 .expect("Failed to create client");
-
         Self(client)
     }
 
+    // Method to make an RPC call
     pub fn rpc_call<Response>(
         &self,
         method: &str,
@@ -36,17 +38,22 @@ impl Client {
     where
         Response: for<'a> serde::de::Deserialize<'a> + Debug,
     {
+        // Serialize parameters to raw JSON value
         let raw = serde_json::value::to_raw_value(params)?;
+        // Build the RPC request
         let req = self.0.build_request(method, Some(&*raw));
+        // Send the request and handle the response
         let resp = self
             .0
             .send_request(req)
             .map_err(crate::rpc_types::Error::from);
 
+        // Deserialize and return the result
         Ok(resp?.result()?)
     }
 }
 
+// Implement the JsonRPCClient trait for Client
 impl JsonRPCClient for Client {
     fn call<T: for<'a> serde::de::Deserialize<'a> + Debug>(
         &self,
@@ -57,6 +64,7 @@ impl JsonRPCClient for Client {
     }
 }
 
+// Struct to represent a JSON-RPC response
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcResponse<Res> {
     pub jsonrpc: String,

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
 
     // Create a new JSON-RPC client using the host from the CLI arguments
     let client = Client::new(get_host(&cli));
-    
+
     // Perform the requested RPC call and get the result
     let res = do_request(&cli, client)?;
 

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -9,22 +9,32 @@ use clap::Subcommand;
 use floresta_cli::jsonrpc_client::Client;
 use floresta_cli::rpc::FlorestaRPC;
 
+// Main function that runs the CLI application
 fn main() -> anyhow::Result<()> {
+    // Parse command line arguments into a Cli struct
     let cli = Cli::parse();
 
+    // Create a new JSON-RPC client using the host from the CLI arguments
     let client = Client::new(get_host(&cli));
+    
+    // Perform the requested RPC call and get the result
     let res = do_request(&cli, client)?;
 
+    // Print the result to the console
     println!("{}", res);
 
+    // Return Ok to indicate the program ran successfully
     anyhow::Ok(())
 }
 
+// Function to determine the RPC host based on CLI arguments and network type
 fn get_host(cmd: &Cli) -> String {
+    // If a specific RPC host is provided, use it
     if let Some(host) = cmd.rpc_host.clone() {
         return host;
     }
 
+    // Otherwise, use the default host based on the network type
     match cmd.network {
         Network::Bitcoin => "http://127.0.0.1:8332".into(),
         Network::Testnet => "http://127.0.0.1:18332".into(),
@@ -34,8 +44,10 @@ fn get_host(cmd: &Cli) -> String {
     }
 }
 
+// Function to perform the requested RPC call based on CLI arguments
 fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
     Ok(match cmd.methods.clone() {
+        // Handle each possible RPC method and serialize the result to a pretty JSON string
         Methods::GetBlockchainInfo => serde_json::to_string_pretty(&client.get_blockchain_info()?)?,
         Methods::GetBlockHash { height } => {
             serde_json::to_string_pretty(&client.get_block_hash(height)?)?


### PR DESCRIPTION
Added comments to the main function and helper functions to explain the purpose and functionality of each part of the RPC client code. Should help improve code readability and maintainability.