### PR TITLE
Fix mismatch between `floresta-cli` command and `florestad` server

### DIFF
--- a/crates/floresta-cli/README.md
+++ b/crates/floresta-cli/README.md
@@ -12,7 +12,7 @@ Available commands:
  - [getblockhash](#getblockhash)
  - [gettxout](#gettxout)
  - [gettxproof](#gettxproof)
- - [getrawtransaction](#getrawtransaction)
+ - [gettransaction](#gettransaction)
  - [rescan](#rescan)
  - [sendrawtransaction](#sendrawtransaction)
  - [getblockheader](#getblockheader)
@@ -84,7 +84,7 @@ Returns a cached transaction output. The output itself doesn't have to be ours. 
 
 `spk`: The redeem script for this output
 
-## getrawtransaction
+## gettransaction
 
 Returns a transaction data, given its id. The transaction itself doesn't have to be ours. But it should be cached by our internal wallet or in the mempool.
 

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -46,7 +46,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::GetTxProof { txids, .. } => {
             serde_json::to_string_pretty(&client.get_tx_proof(txids)?)?
         }
-        Methods::GetRawTransaction { txid, .. } => {
+        Methods::GetTransaction { txid, .. } => {
             serde_json::to_string_pretty(&client.get_transaction(txid, Some(true))?)?
         }
         Methods::RescanBlockchain { start_height } => {
@@ -122,9 +122,9 @@ pub enum Methods {
         txids: Txid,
         blockhash: Option<BlockHash>,
     },
-    /// Returns the raw transaction, assuming it is cached by our watch only wallet
-    #[command(name = "getrawtransaction")]
-    GetRawTransaction { txid: Txid, verbose: Option<bool> },
+    /// Returns the transaction, assuming it is cached by our watch only wallet
+    #[command(name = "gettransaction")]
+    GetTransaction { txid: Txid, verbose: Option<bool> },
     /// Ask the node to rescan the blockchain for transactions
     #[command(name = "rescan")]
     RescanBlockchain { start_height: u32 },

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -205,7 +205,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
     fn get_transaction(&self, tx_id: Txid, verbosity: Option<bool>) -> Result<Value> {
         let verbosity = verbosity.unwrap_or(false);
         self.call(
-            "getrawtransaction",
+            "gettransaction",
             &[Value::String(tx_id.to_string()), Value::Bool(verbosity)],
         )
     }

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -86,7 +86,7 @@ pub struct RawTx {
     pub time: u32,
 }
 
-/// A transaction output returned by some RPCs like getrawtransaction and getblock
+/// A transaction output returned by some RPCs like gettransaction and getblock
 #[derive(Deserialize, Serialize)]
 pub struct TxOut {
     /// The amount in sats locked in this UTXO
@@ -119,7 +119,7 @@ pub struct ScriptPubKey {
     pub address: String,
 }
 
-/// A transaction input returned by some rpcs, like getrawtransaction and getblock
+/// A transaction input returned by some rpcs, like gettransaction and getblock
 #[derive(Deserialize, Serialize)]
 pub struct TxIn {
     /// The txid that created this UTXO
@@ -136,7 +136,7 @@ pub struct TxIn {
 }
 
 /// A representation for the transaction ScriptSig, returned by some rpcs
-/// like getrawtransaction and getblock
+/// like gettransaction and getblock
 #[derive(Deserialize, Serialize)]
 pub struct ScriptSigJson {
     /// A ASM representation for this scriptSig


### PR DESCRIPTION
This PR resolves an issue where `floresta-cli` was sending a `getrawtransaction` command while `florestad` expected a `gettransaction` command.  

The solution updates `floresta-cli` to use the `gettransaction` command, aligning it with the Bitcoin reference implementation as outlined in the [Bitcoin RPC documentation](https://developer.bitcoin.org/reference/rpc/gettransaction.html) for the `gettransaction` command:  
> Get detailed information about **in-wallet** transaction `<txid>`  

### **Changes made:**  
1. Updated the `Methods::GetRawTransaction` enum variant to `Methods::GetTransaction` in `main.rs`.
2. Renamed the corresponding command attribute from `getrawtransaction` to `gettransaction`.
3. Fixed the `FlorestaRPC` implementation to call the correct method (`gettransaction`) in `rpc.rs`.
4. Updated the `README.md` documentation to reflect the new command name.
5. Updated comments in `rpc_types.rs` and related files to ensure consistent terminology across the codebase.

### **Impact:**  
- Ensures consistency between `floresta-cli` and `florestad`.  
- Adopts Bitcoin's standard naming conventions, enhancing developer familiarity.  
- Improves documentation and clarity for future maintainers.  

### **Testing Plan:**  
#### Manual Testing:
1. Verified `gettransaction` calls work correctly using `floresta-cli`, returning expected results for valid transaction IDs.
2. Confirmed error handling for invalid or nonexistent transaction IDs.  

#### Automated Testing:
- Ran all existing tests to confirm no regressions.
- Verified that documentation and comments now align with the updated command name.  

### **Closes:**  
#301  