### PR TITLE
Add clean-data recipe, rename data/ dir to tmp-db/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 
 # Temporary files and generated data
 tmp/
+tmp-db/
 data/
 output.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Temporary files and generated data
 tmp/
+tmp-db/
 data/
 output.log
 

--- a/contrib/clean_data.sh
+++ b/contrib/clean_data.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Find all 'tmp-db' directories in subdirectories
+dirs=$(find . -type d -name 'tmp-db')
+
+# Display the directories that will be deleted
+echo "The following 'tmp-db' directories will be deleted:"
+echo "$dirs"
+
+# Prompt the user for confirmation
+read -r -p "Are you sure you want to delete './tmp' and all 'tmp-db' directories listed above? [y/N] " ans
+
+# Check the user's response
+if [[ "$ans" =~ ^[Yy]$ ]]; then
+    # User confirmed, proceed with deletion
+
+    # Delete 'tmp' in the current directory (if run via justfile this is the root)
+    rm -rf tmp
+
+    # Delete all 'tmp-db' directories found
+    find . -type d -name 'tmp-db' -exec rm -rf {} +
+
+    echo "Directories deleted."
+else
+    # User did not confirm, cancel the operation
+    echo "Deletion cancelled."
+fi

--- a/crates/floresta-chain/benches/chain_state_bench.rs
+++ b/crates/floresta-chain/benches/chain_state_bench.rs
@@ -37,7 +37,7 @@ fn setup_test_chain<'a>(
     assume_valid_arg: AssumeValidArg,
 ) -> ChainState<KvChainStore<'a>> {
     let test_id = rand::random::<u64>();
-    let chainstore = KvChainStore::new(format!("./data/{test_id}/")).unwrap();
+    let chainstore = KvChainStore::new(format!("./tmp-db/{test_id}/")).unwrap();
     ChainState::new(chainstore, network, assume_valid_arg)
 }
 

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1355,7 +1355,7 @@ mod test {
         assume_valid_arg: AssumeValidArg,
     ) -> ChainState<KvChainStore<'a>> {
         let test_id = rand::random::<u64>();
-        let chainstore = KvChainStore::new(format!("./data/{test_id}/")).unwrap();
+        let chainstore = KvChainStore::new(format!("./tmp-db/{test_id}/")).unwrap();
         ChainState::new(chainstore, network, assume_valid_arg)
     }
 

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
             false => debug_path,
         };
 
-        // makes a temporary directory
+        // Makes a temporary directory to store the chain db, SSL certificates, logs, etc.
         let test_code = rand::random::<u64>();
         let dirname = format!("{root}/tmp/floresta.{test_code}");
         fs::DirBuilder::new()

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -968,7 +968,7 @@ mod test {
 
     fn get_test_cache() -> Arc<AddressCache<KvDatabase>> {
         let test_id: u32 = rand::random();
-        let cache = KvDatabase::new(format!("./data/{test_id}.floresta")).unwrap();
+        let cache = KvDatabase::new(format!("./tmp-db/{test_id}.floresta")).unwrap();
         let cache = AddressCache::new(cache);
 
         // Inserting test transactions in the wallet
@@ -1032,7 +1032,7 @@ mod test {
 
         // Create test_chain_state
         let test_id = rand::random::<u32>();
-        let chainstore = KvChainStore::new(format!("./data/{test_id}.floresta/")).unwrap();
+        let chainstore = KvChainStore::new(format!("./tmp-db/{test_id}.floresta/")).unwrap();
         let chain =
             ChainState::<KvChainStore>::new(chainstore, Network::Signet, AssumeValidArg::Hardcoded);
 
@@ -1045,7 +1045,7 @@ mod test {
             network: bitcoin::Network::Signet,
             pow_fraud_proofs: true,
             proxy: None,
-            datadir: "/data".to_string(),
+            datadir: "/tmp-db".to_string(),
             fixed_peer: None,
             max_banscore: 50,
             compact_filters: false,

--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -184,7 +184,7 @@ mod test {
     fn get_test_db() -> KvDatabase {
         let test_id = rand::random::<u32>();
 
-        KvDatabase::new(format!("./data/{test_id}.floresta/")).unwrap()
+        KvDatabase::new(format!("./tmp-db/{test_id}.floresta/")).unwrap()
     }
     fn get_test_address() -> (Address<NetworkChecked>, sha256::Hash) {
         let address = Address::from_str("tb1q9d4zjf92nvd3zhg6cvyckzaqumk4zre26x02q9")

--- a/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
@@ -31,7 +31,7 @@ mod tests_utils {
         pow_fraud_proofs: bool,
         network: floresta_chain::Network,
     ) -> Arc<ChainState<KvChainStore<'static>>> {
-        let datadir = format!("./data/{}.sync_node", rand::random::<u32>());
+        let datadir = format!("./tmp-db/{}.sync_node", rand::random::<u32>());
         let chainstore = KvChainStore::new(datadir.clone()).unwrap();
         let mempool = Arc::new(RwLock::new(Mempool::new()));
         let chain = ChainState::new(chainstore, network, AssumeValidArg::Disabled);

--- a/crates/floresta/examples/chainstate-builder.rs
+++ b/crates/floresta/examples/chainstate-builder.rs
@@ -15,7 +15,7 @@ use floresta_chain::pruned_utreexo::chain_state_builder::ChainStateBuilder;
 use floresta_chain::ChainParams;
 use rustreexo::accumulator::stump::Stump;
 
-const DATA_DIR: &str = "./data";
+const DATA_DIR: &str = "./tmp-db";
 
 #[tokio::main]
 async fn main() {

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -21,7 +21,7 @@ use floresta_wire::running_node::RunningNode;
 use floresta_wire::UtreexoNodeConfig;
 use tokio::sync::RwLock;
 
-const DATA_DIR: &str = "./data";
+const DATA_DIR: &str = "./tmp-db";
 
 #[tokio::main]
 async fn main() {

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ test name="":
 
 # Execute doc tests
 test-doc name="":
-    cargo  test {{name}} --doc
+    cargo test {{name}} --doc
 
 # Execute unit tests
 test-unit name="":
@@ -57,8 +57,11 @@ fmt:
 format:
     cargo +nightly fmt --all --check
 
-# Test all feature combinations for each crate using cargo hack (arg: optional, e.g., --quiet or --verbose)
-# Will try to install or update the cargo-hack package
+# Test all feature combinations for each crate using cargo-hack (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     cargo install cargo-hack --locked
     ./contrib/test_features.sh {{arg}}
+
+# Remove test-generated data
+clean-data:
+    ./contrib/clean_data.sh


### PR DESCRIPTION
The `data` directory was used for ChainStore databases generated during testing. It has been renamed to `tmp-db` to explicitly signal it's a temporary log (we are using another `tests/data` directory for python tests but this one is non-generated and permanent).

A new shell script and just recipe have been added in order to delete all test-generated data. It prompts the user for confirmation with the found `tmp` and `tmp-db` directories.