### PR TITLE
Return tx validation errors, fix max script size

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -20,7 +20,6 @@ use bitcoin::Transaction;
 use bitcoin::TxIn;
 use bitcoin::TxOut;
 use bitcoin::Txid;
-use bitcoin::WitnessVersion;
 use floresta_common::prelude::*;
 use rustreexo::accumulator::node_hash::NodeHash;
 use rustreexo::accumulator::proof::Proof;
@@ -120,64 +119,76 @@ impl Consensus {
         verify_script: bool,
         flags: c_uint,
     ) -> Result<(), BlockchainError> {
-        // TODO: RETURN A GENERIC WRAPPER TYPE.
-        // Blocks must contain at least one transaction
+        // Blocks must contain at least one transaction (i.e. the coinbase)
         if transactions.is_empty() {
             return Err(BlockValidationErrors::EmptyBlock.into());
         }
         let mut fee = 0;
         let mut wu: u64 = 0;
-        // Skip the coinbase tx
+
         for (n, transaction) in transactions.iter().enumerate() {
-            // We don't need to verify the coinbase inputs, as it spends newly generated coins
-            if transaction.is_coinbase() && n == 0 {
-                Self::verify_coinbase(transaction.clone(), n as u16).map_err(|err| {
+            if n == 0 {
+                if transaction.is_coinbase() {
+                    Self::verify_coinbase(transaction).map_err(|error| TransactionError {
+                        txid: transaction.compute_txid(),
+                        error,
+                    })?;
+                    // Skip the rest of checks for the coinbase transaction
+                    continue;
+                } else {
+                    // First tx not coinbase
+                    return Err(BlockValidationErrors::FirstTxIsnNotCoinbase.into());
+                }
+            }
+
+            // Sum tx output amounts, check their locking script sizes (scriptpubkey)
+            let mut out_value = 0;
+            for output in transaction.output.iter() {
+                out_value += output.value.to_sat();
+
+                Self::validate_script_size(&output.script_pubkey).map_err(|error| {
                     TransactionError {
                         txid: transaction.compute_txid(),
-                        error: err,
+                        error,
                     }
-                });
-                continue;
+                })?;
             }
-            // Amount of all outputs
-            let mut output_value = 0;
-            for output in transaction.output.iter() {
-                Self::get_out_value(output, &mut output_value).map_err(|err| TransactionError {
-                    txid: transaction.compute_txid(),
-                    error: err,
-                });
-                Self::validate_script_size(&output.script_pubkey).map_err(|err| TransactionError {
-                    txid: transaction.compute_txid(),
-                    error: err,
-                });
-            }
-            // Amount of all inputs
+
+            // Sum tx input amounts, check their unlocking script sizes (scriptsig and TODO witness)
             let mut in_value = 0;
             for input in transaction.input.iter() {
-                Self::consume_utxos(input, &mut utxos, &mut in_value).map_err(|err| {
+                let txo = Self::get_utxo(input, &utxos).map_err(|error| TransactionError {
+                    txid: transaction.compute_txid(),
+                    error,
+                })?;
+
+                in_value += txo.value.to_sat();
+
+                Self::validate_script_size(&input.script_sig).map_err(|error| {
                     TransactionError {
                         txid: transaction.compute_txid(),
-                        error: err,
+                        error,
                     }
-                });
-                Self::validate_script_size(&input.script_sig).map_err(|err| TransactionError {
-                    txid: transaction.compute_txid(),
-                    error: err,
-                });
+                })?;
+                // TODO check also witness script size
             }
+
             // Value in should be greater or equal to value out. Otherwise, inflation.
-            if output_value > in_value {
+            if out_value > in_value {
                 return Err(TransactionError {
                     txid: transaction.compute_txid(),
                     error: BlockValidationErrors::NotEnoughMoney,
                 }
                 .into());
             }
-            if output_value > 21_000_000 * 100_000_000 {
+            // Sanity check
+            if out_value > 21_000_000 * COIN_VALUE {
                 return Err(BlockValidationErrors::TooManyCoins.into());
             }
+
             // Fee is the difference between inputs and outputs
-            fee += in_value - output_value;
+            fee += in_value - out_value;
+
             // Verify the tx script
             #[cfg(feature = "bitcoinconsensus")]
             if verify_script {
@@ -186,17 +197,18 @@ impl Consensus {
                     .map_err(|err| TransactionError {
                         txid: transaction.compute_txid(),
                         error: BlockValidationErrors::ScriptValidationError(err.to_string()),
-                    });
+                    })?;
             };
 
-            //checks vbytes validation
-            //After all the checks, we sum the transaction weight to the block weight
+            // Sum the transaction weights to get the total block weight
             wu += transaction.weight().to_wu();
         }
-        //checks if the block weight is fine.
+
+        // Checks if the block weight is fine
         if wu > 4_000_000 {
             return Err(BlockValidationErrors::BlockTooBig.into());
         }
+
         // Checks if the miner isn't trying to create inflation
         if fee + subsidy
             < transactions[0]
@@ -206,31 +218,25 @@ impl Consensus {
         {
             return Err(BlockValidationErrors::BadCoinbaseOutValue.into());
         }
+
         Ok(())
     }
-    /// Consumes the UTXOs from the hashmap, and returns the value of the consumed UTXOs.
-    /// If we do not find the UTXO, we return an error invalidating the input that tried to
-    /// consume that UTXO.
-    fn consume_utxos(
+    /// Returns the TxOut being spent by the given input.
+    ///
+    /// Fails if the UTXO is not present in the given hashmap.
+    fn get_utxo<'a>(
         input: &TxIn,
-        utxos: &mut HashMap<OutPoint, TxOut>,
-        value_var: &mut u64,
-    ) -> Result<(), BlockValidationErrors> {
+        utxos: &'a HashMap<OutPoint, TxOut>,
+    ) -> Result<&'a TxOut, BlockValidationErrors> {
         match utxos.get(&input.previous_output) {
-            Some(prevout) => {
-                *value_var += prevout.value.to_sat();
-                utxos.remove(&input.previous_output);
-            }
-            None => {
-                return Err(BlockValidationErrors::UtxoAlreadySpent(
-                    //This is the case when the spender:
-                    // - Spends an UTXO that doesn't exist
-                    // - Spends an UTXO that was already spent
-                    input.previous_output.txid,
-                ));
-            }
-        };
-        Ok(())
+            Some(txout) => Ok(txout),
+            None => Err(
+                // This is the case when the spender:
+                // - Spends an UTXO that doesn't exist
+                // - Spends an UTXO that was already spent
+                BlockValidationErrors::UtxoNotFound(input.previous_output),
+            ),
+        }
     }
     #[allow(unused)]
     fn validate_locktime(
@@ -240,13 +246,11 @@ impl Consensus {
     ) -> Result<(), BlockValidationErrors> {
         unimplemented!("validate_locktime")
     }
-    /// Validates the script size and the number of sigops in a script.
+    /// Validates the script size and the number of sigops in a scriptpubkey or scriptsig.
     fn validate_script_size(script: &ScriptBuf) -> Result<(), BlockValidationErrors> {
-        let scriptpubkeysize = script.len();
-        let is_taproot =
-            script.witness_version() == Some(WitnessVersion::V1) && scriptpubkeysize == 32;
-        if scriptpubkeysize > 520 || scriptpubkeysize < 2 && !is_taproot {
-            //the scriptsig size must be between 2 and 100 bytes unless is taproot
+        // The maximum script size for non-taproot spends is 10,000 bytes
+        // https://github.com/bitcoin/bitcoin/blob/v28.0/src/script/script.h#L39
+        if script.len() > 10_000 {
             return Err(BlockValidationErrors::ScriptError);
         }
         if script.count_sigops() > 80_000 {
@@ -254,29 +258,17 @@ impl Consensus {
         }
         Ok(())
     }
-    fn get_out_value(out: &TxOut, value_var: &mut u64) -> Result<(), BlockValidationErrors> {
-        if out.value.to_sat() > 0 {
-            *value_var += out.value.to_sat()
-        } else {
-            return Err(BlockValidationErrors::InvalidOutput);
-        }
-        Ok(())
-    }
-    fn verify_coinbase(transaction: Transaction, index: u16) -> Result<(), BlockValidationErrors> {
-        if index != 0 {
-            // A block must contain only one coinbase, and it should be the fist thing inside it
-            return Err(BlockValidationErrors::FirstTxIsnNotCoinbase);
-        }
-        //the prevout input of a coinbase must be all zeroes
+    fn verify_coinbase(transaction: &Transaction) -> Result<(), BlockValidationErrors> {
+        // The prevout input of a coinbase must be all zeroes
         if transaction.input[0].previous_output.txid != Txid::all_zeros() {
             return Err(BlockValidationErrors::InvalidCoinbase(
                 "Invalid coinbase txid".to_string(),
             ));
         }
-        let scriptsig = transaction.input[0].script_sig.clone();
-        let scriptsigsize = scriptsig.clone().into_bytes().len();
-        if !(2..=100).contains(&scriptsigsize) {
-            //the scriptsig size must be between 2 and 100 bytes
+        let scriptsig_size = transaction.input[0].script_sig.len();
+
+        // The scriptsig size must be between 2 and 100 bytes (https://github.com/bitcoin/bitcoin/blob/v28.0/src/consensus/tx_check.cpp#L49)
+        if !(2..=100).contains(&scriptsig_size) {
             return Err(BlockValidationErrors::InvalidCoinbase(
                 "Invalid ScriptSig size".to_string(),
             ));
@@ -377,7 +369,7 @@ mod tests {
     use super::*;
 
     fn coinbase(is_valid: bool) -> Transaction {
-        //This coinbase transactions was retrieved from https://learnmeabitcoin.com/explorer/block/0000000000000a0f82f8be9ec24ebfca3d5373fde8dc4d9b9a949d538e9ff679
+        // This coinbase transactions was retrieved from https://learnmeabitcoin.com/explorer/block/0000000000000a0f82f8be9ec24ebfca3d5373fde8dc4d9b9a949d538e9ff679
         // Create inputs
         let input_txid = Txid::from_raw_hash(Hash::from_str(&format!("{:0>64}", "")).unwrap());
 
@@ -386,7 +378,7 @@ mod tests {
         let input_script_sig = if is_valid {
             ScriptBuf::from_hex("03f0a2a4d9f0a2").unwrap()
         } else {
-            //This should invalidate the coinbase transaction since is a big, really big, script.
+            // This should invalidate the coinbase transaction since is a big, really big, script.
             ScriptBuf::from_hex(&format!("{:0>420}", "")).unwrap()
         };
 
@@ -419,88 +411,72 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_get_out_value() {
-        let output = TxOut {
-            value: Amount::from_sat(5_000_350_000),
-            script_pubkey: ScriptBuf::from_hex("41047eda6bd04fb27cab6e7c28c99b94977f073e912f25d1ff7165d9c95cd9bbe6da7e7ad7f2acb09e0ced91705f7616af53bee51a238b7dc527f2be0aa60469d140ac").unwrap(),
-        };
-        let mut value_var = 0;
-        assert!(Consensus::get_out_value(&output, &mut value_var).is_ok());
-        assert_eq!(value_var, 5_000_350_000);
-    }
-
-    #[test]
     fn test_validate_script_size() {
-        //the case when the script is too big
-        let invalid_script = ScriptBuf::from_hex(&format!("{:0>1220}", "")).unwrap();
-        //the valid script < 520 bytes
-        let valid_script =
+        // Generate a script larger than 10,000 bytes (e.g., 10,001 bytes)
+        let large_script = ScriptBuf::from_hex(&format!("{:0>20002}", "")).unwrap();
+        assert_eq!(large_script.len(), 10_001);
+
+        let small_script =
             ScriptBuf::from_hex("76a9149206a30c09cc853bb03bd917a4f9f29b089c1bc788ac").unwrap();
-        assert!(Consensus::validate_script_size(&valid_script).is_ok());
-        assert!(Consensus::validate_script_size(&invalid_script).is_err());
+
+        assert!(Consensus::validate_script_size(&small_script).is_ok());
+        assert!(Consensus::validate_script_size(&large_script).is_err());
     }
 
     #[test]
     fn test_validate_coinbase() {
         let valid_one = coinbase(true);
         let invalid_one = coinbase(false);
-        //The case that should be valid
-        assert!(Consensus::verify_coinbase(valid_one.clone(), 0).is_ok());
-        //Coinbase at wrong index
+        // The case that should be valid
+        assert!(Consensus::verify_coinbase(&valid_one).is_ok());
+        // Invalid coinbase script
         assert_eq!(
-            Consensus::verify_coinbase(valid_one, 1)
-                .unwrap_err()
-                .to_string(),
-            "The first transaction in a block isn't a coinbase"
-        );
-        //Invalid coinbase script
-        assert_eq!(
-            Consensus::verify_coinbase(invalid_one, 0)
+            Consensus::verify_coinbase(&invalid_one)
                 .unwrap_err()
                 .to_string(),
             "Invalid coinbase: \"Invalid ScriptSig size\""
         );
     }
+
     #[test]
+    #[cfg(feature = "bitcoinconsensus")]
     fn test_consume_utxos() {
         // Transaction extracted from https://learnmeabitcoin.com/explorer/tx/0094492b6f010a5e39c2aacc97396ce9b6082dc733a7b4151ccdbd580f789278
         // Mock data for testing
 
         let mut utxos = HashMap::new();
-        let outpoint1 = OutPoint::new(
-            Txid::from_raw_hash(
-                Hash::from_str("5baf640769ebdf2b79868d0a259db69a2c1587232f83ba226ecf3dd0737759bd")
-                    .unwrap(),
-            ),
+        let tx: Transaction = bitcoin::consensus::deserialize(
+            &hex::decode("0100000001bd597773d03dcf6e22ba832f2387152c9ab69d250a8d86792bdfeb690764af5b010000006c493046022100841d4f503f44dd6cef8781270e7260db73d0e3c26c4f1eea61d008760000b01e022100bc2675b8598773984bcf0bb1a7cad054c649e8a34cb522a118b072a453de1bf6012102de023224486b81d3761edcd32cedda7cbb30a4263e666c87607883197c914022ffffffff021ee16700000000001976a9144883bb595608dcfe882aea5f7c579ef107a4fb5b88ac52a0aa00000000001976a914782231de72adb5c9df7367ab0c21c7b44bbd743188ac00000000").unwrap()
+        ).unwrap();
+
+        assert_eq!(
+            tx.input.len(),
             1,
+            "We only spend one utxo in this transaction"
         );
-        let input = TxIn {
-            previous_output: outpoint1,
-            script_sig: ScriptBuf::from_hex("493046022100841d4f503f44dd6cef8781270e7260db73d0e3c26c4f1eea61d008760000b01e022100bc2675b8598773984bcf0bb1a7cad054c649e8a34cb522a118b072a453de1bf6012102de023224486b81d3761edcd32cedda7cbb30a4263e666c87607883197c914022").unwrap(),
-            sequence: Sequence::MAX,
-            witness: Witness::new(),
-        };
-        let prevout = TxOut {
+        let outpoint = tx.input[0].previous_output;
+
+        let txout = TxOut {
             value: Amount::from_sat(18000000),
             script_pubkey: ScriptBuf::from_hex(
                 "76a9149206a30c09cc853bb03bd917a4f9f29b089c1bc788ac",
             )
             .unwrap(),
         };
-
-        utxos.insert(outpoint1, prevout.clone());
+        utxos.insert(outpoint, txout);
 
         // Test consuming UTXOs
-        let mut value_var: u64 = 0;
-        assert!(Consensus::consume_utxos(&input, &mut utxos, &mut value_var).is_ok());
-        assert_eq!(value_var, prevout.value.to_sat());
+        let flags = bitcoinconsensus::VERIFY_P2SH;
+        tx.verify_with_flags(|outpoint| utxos.remove(outpoint), flags)
+            .unwrap();
 
+        assert!(utxos.is_empty(), "Utxo should have been consumed");
         // Test double consuming UTXOs
         assert_eq!(
-            Consensus::consume_utxos(&input, &mut utxos, &mut value_var)
-                .unwrap_err()
-                .to_string(),
-            "Utxo 5baf640769ebdf2b79868d0a259db69a2c1587232f83ba226ecf3dd0737759bd already spent"
+            tx.verify_with_flags(|outpoint| utxos.remove(outpoint), flags),
+            Err(bitcoin::transaction::TxVerifyError::UnknownSpentOutput(
+                outpoint
+            )),
         );
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -1,6 +1,7 @@
 use core::fmt::Debug;
 
 use bitcoin::blockdata::script;
+use bitcoin::OutPoint;
 use bitcoin::Txid;
 #[cfg(feature = "cli-blockchain")]
 use btcd_rpc::error::UtreexodError;
@@ -35,7 +36,7 @@ pub struct TransactionError {
 #[derive(Clone, Debug, PartialEq)]
 pub enum BlockValidationErrors {
     InvalidCoinbase(String),
-    UtxoAlreadySpent(Txid),
+    UtxoNotFound(OutPoint),
     ScriptValidationError(String),
     InvalidOutput,
     ScriptError,
@@ -66,8 +67,8 @@ impl Display for BlockValidationErrors {
             BlockValidationErrors::ScriptValidationError(e) => {
                 write!(f, "{}", e)
             }
-            BlockValidationErrors::UtxoAlreadySpent(utxo) => {
-                write!(f, "Utxo {:?} already spent", utxo)
+            BlockValidationErrors::UtxoNotFound(outpoint) => {
+                write!(f, "Utxo referenced by {:?} not found", outpoint)
             }
             BlockValidationErrors::InvalidOutput => {
                 write!(f, "Invalid output, verify spending values")

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -677,7 +677,7 @@ where
                     // to be invalidated.
                     match e {
                         BlockValidationErrors::InvalidCoinbase(_)
-                        | BlockValidationErrors::UtxoAlreadySpent(_)
+                        | BlockValidationErrors::UtxoNotFound(_)
                         | BlockValidationErrors::ScriptValidationError(_)
                         | BlockValidationErrors::InvalidOutput
                         | BlockValidationErrors::ScriptError

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -220,7 +220,7 @@ where
                     // to be invalidated.
                     match e {
                         BlockValidationErrors::InvalidCoinbase(_)
-                        | BlockValidationErrors::UtxoAlreadySpent(_)
+                        | BlockValidationErrors::UtxoNotFound(_)
                         | BlockValidationErrors::ScriptValidationError(_)
                         | BlockValidationErrors::InvalidOutput
                         | BlockValidationErrors::ScriptError


### PR DESCRIPTION
Proposing these changes as the BlockRules PR was closed.

- Added a few `?` when needed.
- Corrected the non-taproot max script size to 10,000 bytes. `validate_script_size` now takes a `taproot_spend` bool.

Then also fix some error return cases:
- Check if the first tx is coinbase and return `FirstTxIsNotCoinbase` if it is not. `verify_coinbase` was previously only called if `transaction.is_coinbase() && n == 0` and the not coinbase case was not handled.
- Previous `get_out_value` returned error when output had 0 sats value, but this is valid under the consensus rules. Removed it.
- `consume_utxos` changed to `get_utxo`: the utxos are already consumed by the `verify_with_flags` method, since it takes a `utxos.remove(outpoint)` closure.