### PR TITLE
[Fix] Add names for UtreexoNode fields 

### DIFF
--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -1057,7 +1057,7 @@ mod test {
             user_agent: "floresta".to_string(),
         };
 
-        let chain_provider: UtreexoNode<RunningNode, Arc<ChainState<KvChainStore>>> =
+        let chain_provider: UtreexoNode<Arc<ChainState<KvChainStore>>, RunningNode> =
             UtreexoNode::new(
                 u_config,
                 chain.clone(),

--- a/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/sync_node.rs
@@ -47,7 +47,7 @@ mod tests_utils {
 
         let config = get_node_config(datadir, network, pow_fraud_proofs);
 
-        let mut node = UtreexoNode::<SyncNode, Arc<ChainState<KvChainStore>>>::new(
+        let mut node = UtreexoNode::<Arc<ChainState<KvChainStore>>, SyncNode>::new(
             config,
             chain.clone(),
             mempool,
@@ -77,7 +77,7 @@ mod tests_utils {
 
         // FIXME: This doesn't look very safe, but we need to coerce a &mut reference of the node
         //        to live for the static lifetime, or it can't be spawn-ed by tokio::task
-        let _node: &'static mut UtreexoNode<SyncNode, Arc<ChainState<KvChainStore>>> =
+        let _node: &'static mut UtreexoNode<Arc<ChainState<KvChainStore>>, SyncNode> =
             unsafe { std::mem::transmute(&mut **node) };
 
         timeout(Duration::from_secs(100), _node.run(kill_signal, |_| {}))

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -57,7 +57,7 @@ async fn main() {
     // Finally, we are using the chain state created above, the node will use it to determine
     // what blocks and headers to download, and hand them to it to validate.
     let config = UtreexoNodeConfig::default();
-    let p2p: UtreexoNode<RunningNode, Arc<ChainState<KvChainStore>>> = UtreexoNode::new(
+    let p2p: UtreexoNode<Arc<ChainState<KvChainStore>>, RunningNode> = UtreexoNode::new(
         config,
         chain.clone(),
         Arc::new(RwLock::new(Mempool::new())),


### PR DESCRIPTION
While searching a way to implement `MTP`, i got myself a lot of the times with the `UtreexoNode` declaration aside my readings trough *florestad`s internals* just because

```Rust
pub struct UtreexoNode<T, Chain>(
 NodeCommon<Chain>,
 T
)
```
The generic trait declaration is inverted and the fields had no name, usually being called as `self.0` or `self.1` which is not so intuitive to look at.

>UtreexoNode Signature is `UtreexoNode<T,Chain>` but to make chain operations in (e.g. access NodeCommon) you had to use `self.0`

IMO is better to always name internal fields if they're being accessed from outside the struct and not only from internal methods for that structure