### PR TITLE
Add prometheus support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,10 +133,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding 2.3.1",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -742,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,9 +881,10 @@ dependencies = [
  "hex",
  "kv",
  "log",
+ "metrics",
  "rand 0.8.5",
  "rustreexo",
- "secp256k1 0.28.2",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "sha2",
@@ -961,6 +1034,7 @@ dependencies = [
  "jsonrpc-http-server",
  "kv",
  "log",
+ "metrics",
  "miniscript 12.2.0",
  "pretty_assertions",
  "rand 0.8.5",
@@ -979,6 +1053,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding 2.3.1",
+]
 
 [[package]]
 name = "fs2"
@@ -1230,13 +1313,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.2.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1262,8 +1379,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1273,6 +1390,41 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.5.1",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1286,7 +1438,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1398,7 +1550,7 @@ checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
  "futures 0.3.31",
- "hyper",
+ "hyper 0.14.31",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
@@ -1452,7 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
  "futures 0.3.31",
- "hyper",
+ "hyper 0.14.31",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -1525,9 +1677,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1579,10 +1731,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "metrics"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "prometheus-client",
+ "sysinfo",
+ "tokio",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniscript"
@@ -1658,6 +1832,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1777,6 +1960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +2052,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot 0.12.3",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -2123,6 +2335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,11 +2449,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2357,6 +2597,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "sysinfo"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
 ]
 
 [[package]]
@@ -2564,6 +2824,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2857,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2647,7 +2930,7 @@ checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding",
+ "percent-encoding 1.0.1",
 ]
 
 [[package]]
@@ -2806,10 +3089,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.85",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "florestad",
     "fuzz",
+    "metrics",
     "crates/floresta",
     "crates/floresta-chain",
     "crates/floresta-cli",
@@ -15,6 +16,7 @@ members = [
 
 default-members = [ 
     "florestad",
+    "metrics",
     "crates/floresta",
     "crates/floresta-chain",
     "crates/floresta-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ members = [
 
 default-members = [ 
     "florestad",
-    "metrics",
     "crates/floresta",
     "crates/floresta-chain",
     "crates/floresta-cli",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:11.6-slim@sha256:171530d298096f0697da36b3324182e872db77c66452b85783ea893680cc1b62 AS builder
 
+ARG BUILD_FEATURES=""
+
 RUN apt-get update && apt-get install -y \
   build-essential \
   cmake \
@@ -20,7 +22,11 @@ COPY crates/ crates/
 COPY fuzz/ fuzz/
 COPY metrics/ metrics/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
-  cargo build --release
+    if [ -n "$BUILD_FEATURES" ]; then \
+      cargo build --release --features "$BUILD_FEATURES"; \
+    else \
+      cargo build --release; \
+    fi
 
 FROM debian:11.6-slim@sha256:171530d298096f0697da36b3324182e872db77c66452b85783ea893680cc1b62
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY Cargo.* ./
 COPY florestad/ florestad/
 COPY crates/ crates/
 COPY fuzz/ fuzz/
+COPY metrics/ metrics/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
   cargo build --release
 
@@ -29,5 +30,6 @@ RUN chmod +x /usr/local/bin/florestad
 
 EXPOSE 50001
 EXPOSE 8332
+EXPOSE 3333
 
 CMD [ "florestad" ]

--- a/README.md
+++ b/README.md
@@ -284,6 +284,24 @@ cargo +nightly fuzz run local_address_str
 
 You can replace `local_address_str` with the name of any other target you want to run.
 
+## Metrics
+
+This project uses [`Prometheus`](https://prometheus.io/) as a monitoring system. To enable it you must build the project with the `metrics` feature enabled:
+
+```sh
+cargo build --release --features metrics
+```
+
+The easiest way to visualize those metrics is by using some observability graphic tool like [Grafana](https://grafana.com/). To make it easier, you can also straight away use the `docker-compose.yml` file to spin up an infrastructure that will run the project with Prometheus and Grafana.
+
+To run it, first make sure you have [Docker Compose](https://docs.docker.com/compose/) installed and then:
+
+```sh
+docker-compose up -d --build
+```
+
+Grafana should now be available to you at http://localhost:3000. To log in, please check the credentials defined in the `docker-compose.yml` file.
+
 ## Contributing
 Contributions are welcome, feel free to open an issue or a pull request.
 

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -31,7 +31,7 @@ hashbrown = { version = "0.14.0", optional = true }
 secp256k1 = { version = "*", features = ["alloc"], optional = true }
 floresta-common = { path = "../floresta-common", default-features = false, features = ["std"] }
 bitcoinconsensus = { version = "0.106.0", optional = true, default-features = false }
-metrics = { path = "../../metrics" }
+metrics = { path = "../../metrics", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
@@ -44,6 +44,7 @@ hex = "0.4.3"
 [features]
 default = []
 bitcoinconsensus = ["bitcoin/bitcoinconsensus", "dep:bitcoinconsensus"]
+metrics = ["dep:metrics"]
 
 [[bench]]
 name = "chain_state_bench"

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -31,6 +31,7 @@ hashbrown = { version = "0.14.0", optional = true }
 secp256k1 = { version = "*", features = ["alloc"], optional = true }
 floresta-common = { path = "../floresta-common", default-features = false, features = ["std"] }
 bitcoinconsensus = { version = "0.106.0", optional = true, default-features = false }
+metrics = { path = "../../metrics" }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1102,6 +1102,8 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
             block.txdata.len()
         );
 
+        metrics::get_metrics().block_height.set(height.into());
+
         if !self.is_in_idb() || height % 10_000 == 0 {
             self.flush()?;
         }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -30,6 +30,8 @@ use floresta_common::Channel;
 use log::info;
 use log::trace;
 use log::warn;
+#[cfg(feature = "metrics")]
+use metrics;
 use rustreexo::accumulator::node_hash::NodeHash;
 use rustreexo::accumulator::proof::Proof;
 use rustreexo::accumulator::stump::Stump;
@@ -1102,6 +1104,7 @@ impl<PersistedState: ChainStore> UpdatableChainstate for ChainState<PersistedSta
             block.txdata.len()
         );
 
+        #[cfg(feature = "metrics")]
         metrics::get_metrics().block_height.set(height.into());
 
         if !self.is_in_idb() || height % 10_000 == 0 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,13 @@ services:
     container_name: floresta
     build:
       context: .
+      args:
+        BUILD_FEATURES: "metrics"
     ports:
       - 50001:50001
       - 8332:8332
       - 3333:3333
     restart: unless-stopped
-    deploy:
-      resources:
-        reservations:
-          memory: 16G
   prometheus:
     image: prom/prometheus
     container_name: prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  floresta:
+    container_name: floresta
+    build:
+      context: .
+    ports:
+      - 50001:50001
+      - 8332:8332
+      - 3333:3333
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          memory: 16G
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./metrics/prometheus:/etc/prometheus
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./metrics/grafana:/etc/grafana/provisioning/datasources

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -28,6 +28,7 @@ floresta-electrum = { path = "../crates/floresta-electrum" }
 floresta-watch-only = { path = "../crates/floresta-watch-only" }
 floresta-wire = { path = "../crates/floresta-wire" }
 floresta-compact-filters = { path = "../crates/floresta-compact-filters", optional = true }
+metrics = { path = "../metrics", optional = true }
 
 anyhow = "1.0.40"
 jsonrpc-http-server = { version = "18.0.0", optional = true }
@@ -38,7 +39,6 @@ jsonrpc-core-client = { version = "18.0.0", features = [
 ], optional = true }
 zmq = { version = "0.10.0", optional = true }
 dns-lookup = "2.0.4"
-metrics = { path = "../metrics" }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }
@@ -66,6 +66,7 @@ json-rpc = [
     "compact-filters"
 ]
 default = ["experimental-p2p", "json-rpc"]
+metrics = ["dep:metrics"]
 
 [build-dependencies]
 toml = "0.5.10"

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -38,6 +38,7 @@ jsonrpc-core-client = { version = "18.0.0", features = [
 ], optional = true }
 zmq = { version = "0.10.0", optional = true }
 dns-lookup = "2.0.4"
+metrics = { path = "../metrics" }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -3,6 +3,7 @@ use std::fmt::Arguments;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;
+use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process::exit;
@@ -41,9 +42,12 @@ use log::error;
 use log::info;
 use log::warn;
 use log::Record;
+use metrics;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tokio::task;
+use tokio::time::Duration;
+use tokio::time::{self};
 use tokio_rustls::rustls::internal::pemfile::certs;
 use tokio_rustls::rustls::internal::pemfile::pkcs8_private_keys;
 use tokio_rustls::rustls::NoClientAuth;
@@ -525,6 +529,26 @@ impl Florestad {
         *recv = Some(receiver);
 
         task::spawn(chain_provider.run(kill_signal, sender));
+
+        // Metrics
+        let metrics_server_address =
+            SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3333);
+        task::spawn(metrics::metrics_server(metrics_server_address));
+        info!(
+            "Started metrics server on: {}",
+            metrics_server_address.to_string()
+        );
+
+        // Periodically update memory usage
+        tokio::spawn(async {
+            let interval = Duration::from_secs(5);
+            let mut ticker = time::interval(interval);
+
+            loop {
+                ticker.tick().await;
+                metrics::get_metrics().update_memory_usage();
+            }
+        });
     }
 
     fn setup_logger(

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -3,6 +3,7 @@ use std::fmt::Arguments;
 use std::fs::File;
 use std::io;
 use std::io::BufReader;
+#[cfg(feature = "metrics")]
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -42,11 +43,14 @@ use log::error;
 use log::info;
 use log::warn;
 use log::Record;
+#[cfg(feature = "metrics")]
 use metrics;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
 use tokio::task;
+#[cfg(feature = "metrics")]
 use tokio::time::Duration;
+#[cfg(feature = "metrics")]
 use tokio::time::{self};
 use tokio_rustls::rustls::internal::pemfile::certs;
 use tokio_rustls::rustls::internal::pemfile::pkcs8_private_keys;
@@ -531,24 +535,27 @@ impl Florestad {
         task::spawn(chain_provider.run(kill_signal, sender));
 
         // Metrics
-        let metrics_server_address =
-            SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3333);
-        task::spawn(metrics::metrics_server(metrics_server_address));
-        info!(
-            "Started metrics server on: {}",
-            metrics_server_address.to_string()
-        );
+        #[cfg(feature = "metrics")]
+        {
+            let metrics_server_address =
+                SocketAddr::new(std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 3333);
+            task::spawn(metrics::metrics_server(metrics_server_address));
+            info!(
+                "Started metrics server on: {}",
+                metrics_server_address.to_string()
+            );
 
-        // Periodically update memory usage
-        tokio::spawn(async {
-            let interval = Duration::from_secs(5);
-            let mut ticker = time::interval(interval);
+            // Periodically update memory usage
+            tokio::spawn(async {
+                let interval = Duration::from_secs(5);
+                let mut ticker = time::interval(interval);
 
-            loop {
-                ticker.tick().await;
-                metrics::get_metrics().update_memory_usage();
-            }
-        });
+                loop {
+                    ticker.tick().await;
+                    metrics::get_metrics().update_memory_usage();
+                }
+            });
+        }
     }
 
     fn setup_logger(

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "metrics"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sysinfo = "0.33"
+axum = "0.7"
+prometheus-client = "0.22.3"
+tokio = { version = "1", features = ["full"] }
+

--- a/metrics/grafana/datasource.yml
+++ b/metrics/grafana/datasource.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    access: proxy
+    editable: true

--- a/metrics/prometheus/prometheus.yml
+++ b/metrics/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+  - job_name: prometheus
+    honor_timestamps: true
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: /
+    scheme: http
+    static_configs:
+      - targets:
+          - floresta:3333

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,0 +1,75 @@
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::OnceLock;
+
+use axum::routing::get;
+use axum::Router;
+use prometheus_client::encoding::text::encode;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use sysinfo::System;
+
+pub struct AppMetrics {
+    registry: Registry,
+    pub memory_usage: Gauge<f64, AtomicU64>,
+    pub block_height: Gauge,
+}
+
+impl AppMetrics {
+    pub fn new() -> Self {
+        let mut registry = <Registry>::default();
+        let memory_usage = Gauge::<f64, AtomicU64>::default();
+        let block_height = Gauge::default();
+
+        registry.register("block_height", "Current block height", block_height.clone());
+        registry.register(
+            "memory_usage_gigabytes",
+            "System memory usage in GB",
+            memory_usage.clone(),
+        );
+
+        Self {
+            registry,
+            block_height,
+            memory_usage,
+        }
+    }
+
+    /// Gets how much memory is being used by the system in which Floresta is
+    /// running on, not how much memory Floresta itself it's using.
+    pub fn update_memory_usage(&self) {
+        let mut system = System::new_all();
+        system.refresh_memory();
+
+        // get used memory in gigabytes                / KB    / MB    / GB
+        let used_memory = system.used_memory() as f64 / 1024. / 1024. / 1024.;
+        self.memory_usage.set(used_memory);
+    }
+}
+
+impl Default for AppMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Singleton to share metrics across crates
+static METRICS: OnceLock<AppMetrics> = OnceLock::new();
+pub fn get_metrics() -> &'static AppMetrics {
+    METRICS.get_or_init(AppMetrics::new)
+}
+
+async fn metrics_handler() -> String {
+    let mut buffer = String::new();
+    encode(&mut buffer, &get_metrics().registry).unwrap();
+
+    buffer
+}
+
+pub async fn metrics_server(metrics_server_address: SocketAddr) {
+    let app = Router::new().route("/", get(metrics_handler));
+    let listener = tokio::net::TcpListener::bind(metrics_server_address)
+        .await
+        .unwrap();
+    axum::serve(listener, app).await.unwrap();
+}


### PR DESCRIPTION
Closes #166 .

This PR adds support for [Prometheus](https://prometheus.io/), while giving an example of its integration with [Grafana](https://grafana.com/) as well.

## Summary

- Adds new (optional) cargo project named `metrics` that holds information about the Prometheus metrics and that can be used in a singleton way;
- Adds `docker-compose.yml` file to examplify how to deploy floresta+prometheus+grafana infra;
- Adds two example metrics: system memory used (GB) and current block height.

Example of added metrics in Grafana:

<img width="889" alt="image" src="https://github.com/user-attachments/assets/e2cb96a1-a51f-41d7-85d7-17bdf323bad2" />

## Testing

> Be sure to have [Docker Compose](https://docs.docker.com/compose/)

Run `docker-compose up -d --build`, wait for it to start all services and then go to http://localhost:3000/, where you can log into Grafana using the given credentials found in the `docker-compose.yml` file.

There, you can go to Dashboards on the left, add New, select Prometheus as the data source (should be pre-selected) and then choose one of the metrics, the data visualization type and run the queries to see it in action.

## Improvements

I'm not too familiar with the codebase, therefore adding metrics to the best places would be better done by someone who has.

During the tests with the deployment of the infra with `docker-compose.yml` noticed that there is something off going on with the system, probably related to [this](https://github.com/vinteumorg/Floresta/issues/294), that it was driving the CPU usage over 100% and the memory at around 8GB, maintaining this last one during the initial block downloading at least.

The high CPU and memory usage would go off the roofs around [this part](https://github.com/vinteumorg/Floresta/blob/master/crates/floresta-wire/src/p2p_wire/chain_selector.rs#L458).
