### PR TITLE
Add pre-contributing just recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ Here's some Guidelines:
 - Has to run.
 - Use [pre-commit](https://pre-commit.com/) for the language that you're using (if possible 👍).
 
-You can accomplish that using our flake.nix for development.
+You can run `just pre-contributing` to make it easier to check everything is correct before opening a pull request.
+
+You can also accomplish that using our flake.nix for development.
 
 ## Developing on Floresta with Nix
 

--- a/justfile
+++ b/justfile
@@ -65,3 +65,6 @@ test-features arg="":
 # Remove test-generated data
 clean-data:
     ./contrib/clean_data.sh
+
+# Run all needed checks before contributing code
+pre-contributing: lint fmt test build-release


### PR DESCRIPTION
Most of the times when contributing code to the repo I find myself only realising that I missed some linting, formatting or checking after the Github Actions job is triggered and fails.

This adds a new `just` recipe called `pre-contributing` that aims to help contributors to run a single command before opening a PR, making sure that everything is working correctly and nothing is missing.