### PR TITLE
Check features in the pre-commit recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Here's some Guidelines:
 - Has to run.
 - Use [pre-commit](https://pre-commit.com/) for the language that you're using (if possible 👍).
 
-You can run `just pre-contributing` to make it easier to check everything is correct before opening a pull request.
+You can run `just pcc`, which stands for pre-commit check, to check everything is correct before opening a pull request.
 
 You can also accomplish that using our flake.nix for development.
 

--- a/justfile
+++ b/justfile
@@ -66,5 +66,5 @@ test-features arg="":
 clean-data:
     ./contrib/clean_data.sh
 
-# Run all needed checks before contributing code
-pre-contributing: lint fmt test build-release
+# Run all needed checks before contributing code (pre-commit check)
+pcc: lint test-features


### PR DESCRIPTION
Renamed to `pcc` (pre-commit check). Formatting is already done as part of the `lint` recipe.