### PR TITLE
Blockchain rpcs

### DIFF
--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -36,6 +36,7 @@ mod tests {
 
     use crate::jsonrpc_client::Client;
     use crate::rpc::FlorestaRPC;
+    use crate::rpc_types::GetBlockRes;
 
     struct Florestad {
         proc: Child,
@@ -172,7 +173,11 @@ mod tests {
             "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
                 .parse()
                 .unwrap();
-        let block = client.get_block(block_hash).unwrap();
+
+        let block = client.get_block(block_hash, Some(1)).unwrap();
+        let GetBlockRes::Verbose(block) = block else {
+            panic!("Expected verbose block");
+        };
 
         assert_eq!(
             block.hash,

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -208,7 +208,7 @@ mod tests {
     fn test_get_height() {
         let (_proc, client) = start_florestad();
 
-        let height = client.get_height().unwrap();
+        let height = client.get_block_count().unwrap();
         assert_eq!(height, 0);
     }
 

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -90,7 +90,7 @@ pub trait FlorestaRPC {
     /// This method returns a block, given a block hash. If the verbosity flag is 0, the block
     /// is returned as a hexadecimal string. If the verbosity flag is 1, the block is returned
     /// as a json object.
-    fn get_block(&self, hash: BlockHash) -> Result<GetBlockRes>;
+    fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes>;
     /// Return a cached transaction output
     ///
     /// This method returns a cached transaction output. If the output is not in the cache,
@@ -165,15 +165,34 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("getroots", &[])
     }
 
-    fn get_block(&self, hash: BlockHash) -> Result<GetBlockRes> {
-        let verbosity = 1; // Return the block in json format
-        self.call(
-            "getblock",
-            &[
-                Value::String(hash.to_string()),
-                Value::Number(Number::from(verbosity)),
-            ],
-        )
+    fn get_block(&self, hash: BlockHash, verbosity: Option<u32>) -> Result<GetBlockRes> {
+        let verbosity = verbosity.unwrap_or(0);
+
+        match verbosity {
+            0 => {
+                let block = self.call(
+                    "getblock",
+                    &[
+                        Value::String(hash.to_string()),
+                        Value::Number(Number::from(verbosity)),
+                    ],
+                )?;
+                Ok(GetBlockRes::Serialized(block))
+            }
+
+            1 => {
+                let block = self.call(
+                    "getblock",
+                    &[
+                        Value::String(hash.to_string()),
+                        Value::Number(Number::from(verbosity)),
+                    ],
+                )?;
+                Ok(GetBlockRes::Verbose(block))
+            }
+
+            _ => Err(rpc_types::Error::InvalidVerbosity),
+        }
     }
 
     fn get_block_count(&self) -> Result<u32> {

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -66,7 +66,7 @@ pub trait FlorestaRPC {
     /// as old as the oldest transaction this descriptor could have been used in.
     fn rescan(&self, rescan: u32) -> Result<bool>;
     /// Returns the current height of the blockchain
-    fn get_height(&self) -> Result<u32>;
+    fn get_block_count(&self) -> Result<u32>;
     /// Sends a hex-encoded transaction to the network
     ///
     /// This method sends a transaction to the network. The transaction should be encoded as a
@@ -176,8 +176,8 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         )
     }
 
-    fn get_height(&self) -> Result<u32> {
-        self.call("getheight", &[])
+    fn get_block_count(&self) -> Result<u32> {
+        self.call("getblockcount", &[])
     }
 
     fn get_tx_out(&self, tx_id: Txid, outpoint: u32) -> Result<Value> {

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -173,9 +173,15 @@ pub struct PeerInfo {
     pub state: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub enum GetBlockRes {
+    Verbose(Box<GetBlockResVerbose>),
+    Serialized(String),
+}
+
 /// A full bitcoin block, returned by get_block
 #[derive(Debug, Deserialize, Serialize)]
-pub struct GetBlockRes {
+pub struct GetBlockResVerbose {
     /// This block's hash.
     pub hash: String,
     /// How many blocks have been added to the chain, after this one have been found. This is
@@ -270,6 +276,8 @@ pub enum Error {
     Api(serde_json::Value),
     /// The server sent an empty response
     EmptyResponse,
+    /// The provided verbosity level is invalid
+    InvalidVerbosity,
 }
 
 impl From<serde_json::Error> for Error {
@@ -293,6 +301,7 @@ impl Display for Error {
             Error::Api(e) => write!(f, "general jsonrpc error: {e}"),
             Error::Serde(e) => write!(f, "error while deserializing the response: {e}"),
             Error::EmptyResponse => write!(f, "got an empty response from server"),
+            Error::InvalidVerbosity => write!(f, "invalid verbosity level"),
         }
     }
 }

--- a/florestad/src/json_rpc/blockchain.rs
+++ b/florestad/src/json_rpc/blockchain.rs
@@ -18,7 +18,7 @@ use super::res::GetBlockchainInfoRes;
 use super::server::RpcImpl;
 
 impl RpcImpl {
-    pub fn get_block_inner(&self, hash: BlockHash) -> Result<Block, RpcError> {
+    async fn get_block_inner(&self, hash: BlockHash) -> Result<Block, RpcError> {
         let is_genesis = self.chain.get_block_hash(0).unwrap().eq(&hash);
         if self.chain.is_in_idb() && !is_genesis {
             return Err(RpcError::InInitialBlockDownload);
@@ -45,8 +45,8 @@ impl RpcImpl {
     }
 
     // getblock
-    pub(super) fn get_block(&self, hash: BlockHash) -> Result<BlockJson, RpcError> {
-        let block = self.get_block_inner(hash)?;
+    pub(super) async fn get_block(&self, hash: BlockHash) -> Result<BlockJson, RpcError> {
+        let block = self.get_block_inner(hash).await?;
         let tip = self.chain.get_height().map_err(|_| RpcError::Chain)?;
         let height = self
             .chain
@@ -102,8 +102,8 @@ impl RpcImpl {
         Ok(block)
     }
 
-    pub(super) fn get_block_serialized(&self, hash: BlockHash) -> Result<String, RpcError> {
-        let block = self.get_block_inner(hash)?;
+    pub(super) async fn get_block_serialized(&self, hash: BlockHash) -> Result<String, RpcError> {
+        let block = self.get_block_inner(hash).await?;
         Ok(serialize_hex(&block))
     }
 

--- a/florestad/src/json_rpc/blockchain.rs
+++ b/florestad/src/json_rpc/blockchain.rs
@@ -1,0 +1,235 @@
+use bitcoin::block::Header;
+use bitcoin::consensus::encode::serialize_hex;
+use bitcoin::constants::genesis_block;
+use bitcoin::Block;
+use bitcoin::BlockHash;
+use bitcoin::OutPoint;
+use bitcoin::ScriptBuf;
+use bitcoin::Txid;
+use floresta_chain::pruned_utreexo::BlockchainInterface;
+use floresta_chain::pruned_utreexo::UpdatableChainstate;
+use floresta_wire::node_interface::NodeMethods;
+use serde_json::json;
+use serde_json::Value;
+
+use super::res::BlockJson;
+use super::res::Error as RpcError;
+use super::res::GetBlockchainInfoRes;
+use super::server::RpcImpl;
+
+impl RpcImpl {
+    pub fn get_block_inner(&self, hash: BlockHash) -> Result<Block, RpcError> {
+        let is_genesis = self.chain.get_block_hash(0).unwrap().eq(&hash);
+        if self.chain.is_in_idb() && !is_genesis {
+            return Err(RpcError::InInitialBlockDownload);
+        }
+
+        if is_genesis {
+            Ok(genesis_block(self.network))
+        } else {
+            self.node
+                .get_block(hash)
+                .map_err(|_| RpcError::Chain)?
+                .ok_or(RpcError::BlockNotFound)
+        }
+    }
+}
+
+// blockchain rpcs
+impl RpcImpl {
+    pub fn get_block_serialized(&self, hash: BlockHash) -> Result<String, RpcError> {
+        let block = self.get_block_inner(hash)?;
+        Ok(serialize_hex(&block))
+    }
+
+    pub fn find_tx_out(
+        &self,
+        txid: Txid,
+        vout: u32,
+        script: ScriptBuf,
+        height: u32,
+    ) -> Result<Value, RpcError> {
+        if let Some(txout) = self.wallet.get_utxo(&OutPoint { txid, vout }) {
+            return Ok(serde_json::to_value(txout).unwrap());
+        }
+
+        if self.chain.is_in_idb() {
+            return Err(RpcError::InInitialBlockDownload);
+        }
+
+        // can't proceed without block filters
+        let Some(cfilters) = self.block_filter_storage.as_ref() else {
+            return Err(RpcError::NoBlockFilters);
+        };
+
+        self.wallet.cache_address(script.clone());
+        let filter_key = script.to_bytes();
+        let candidates = cfilters.match_any(
+            vec![filter_key.as_slice()],
+            Some(height as usize),
+            self.chain.clone(),
+        );
+
+        let candidates = candidates
+            .unwrap_or_default()
+            .into_iter()
+            .map(|hash| self.node.get_block(hash));
+
+        for candidate in candidates {
+            let candidate = match candidate {
+                Err(e) => {
+                    return Err(RpcError::Node(e.to_string()));
+                }
+                Ok(None) => {
+                    return Err(RpcError::Node(format!(
+                        "BUG: block {candidate:?} is a match in our filters, but we can't get it?"
+                    )));
+                }
+                Ok(Some(candidate)) => candidate,
+            };
+
+            let Ok(Some(height)) = self.chain.get_block_height(&candidate.block_hash()) else {
+                return Err(RpcError::BlockNotFound);
+            };
+
+            self.wallet.block_process(&candidate, height);
+        }
+
+        self.get_tx_out(txid, vout)
+    }
+
+    pub(super) fn get_tx_proof(&self, tx_id: Txid) -> Result<Vec<String>, RpcError> {
+        Ok(self
+            .wallet
+            .get_merkle_proof(&tx_id)
+            .ok_or(RpcError::TxNotFound)?
+            .0)
+    }
+
+    pub(super) fn get_roots(&self) -> Result<Vec<String>, RpcError> {
+        let hashes = self.chain.get_root_hashes();
+        Ok(hashes.iter().map(|h| h.to_string()).collect())
+    }
+
+    pub(super) fn get_block_hash(&self, height: u32) -> Result<BlockHash, RpcError> {
+        self.chain
+            .get_block_hash(height)
+            .map_err(|_| RpcError::BlockNotFound)
+    }
+
+    pub(super) fn get_block_header(&self, hash: BlockHash) -> Result<Header, RpcError> {
+        self.chain
+            .get_block_header(&hash)
+            .map_err(|_| RpcError::BlockNotFound)
+    }
+
+    pub(super) fn get_height(&self) -> Result<u32, RpcError> {
+        Ok(self.chain.get_best_block().unwrap().0)
+    }
+
+    pub(super) fn get_tx_out(&self, txid: Txid, outpoint: u32) -> Result<Value, RpcError> {
+        let utxo = self.wallet.get_utxo(&OutPoint {
+            txid,
+            vout: outpoint,
+        });
+
+        let res = match utxo {
+            Some(utxo) => ::serde_json::to_value(utxo),
+            None => Ok(json!({})),
+        };
+
+        res.map_err(|_e| RpcError::Encode)
+    }
+
+    pub(super) fn get_block(&self, hash: BlockHash) -> Result<BlockJson, RpcError> {
+        let block = self.get_block_inner(hash)?;
+        let tip = self.chain.get_height().map_err(|_| RpcError::Chain)?;
+        let height = self
+            .chain
+            .get_block_height(&hash)
+            .map_err(|_| RpcError::Chain)?
+            .unwrap();
+
+        let median_time_past = if height > 11 {
+            let mut last_block_times: Vec<_> = ((height - 11)..height)
+                .map(|h| {
+                    self.chain
+                        .get_block_header(&self.chain.get_block_hash(h).unwrap())
+                        .unwrap()
+                        .time
+                })
+                .collect();
+            last_block_times.sort();
+            last_block_times[5]
+        } else {
+            block.header.time
+        };
+
+        let block = BlockJson {
+            bits: serialize_hex(&block.header.bits),
+            chainwork: block.header.work().to_string(),
+            confirmations: (tip - height) + 1,
+            difficulty: block.header.difficulty(self.chain.get_params()),
+            hash: block.header.block_hash().to_string(),
+            height,
+            merkleroot: block.header.merkle_root.to_string(),
+            nonce: block.header.nonce,
+            previousblockhash: block.header.prev_blockhash.to_string(),
+            size: block.total_size(),
+            time: block.header.time,
+            tx: block
+                .txdata
+                .iter()
+                .map(|tx| tx.compute_txid().to_string())
+                .collect(),
+            version: block.header.version.to_consensus(),
+            version_hex: serialize_hex(&block.header.version),
+            weight: block.weight().to_wu() as usize,
+            mediantime: median_time_past,
+            n_tx: block.txdata.len(),
+            nextblockhash: self
+                .chain
+                .get_block_hash(height + 1)
+                .ok()
+                .map(|h| h.to_string()),
+            strippedsize: block.total_size(),
+        };
+
+        Ok(block)
+    }
+
+    pub(super) fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes, RpcError> {
+        let (height, hash) = self.chain.get_best_block().unwrap();
+        let validated = self.chain.get_validation_index().unwrap();
+        let ibd = self.chain.is_in_idb();
+        let latest_header = self.chain.get_block_header(&hash).unwrap();
+        let latest_work = latest_header.work();
+        let latest_block_time = latest_header.time;
+        let leaf_count = self.chain.acc().leaves as u32;
+        let root_count = self.chain.acc().roots.len() as u32;
+        let root_hashes = self
+            .chain
+            .acc()
+            .roots
+            .into_iter()
+            .map(|r| r.to_string())
+            .collect();
+
+        let validated_blocks = self.chain.get_validation_index().unwrap();
+
+        Ok(GetBlockchainInfoRes {
+            best_block: hash.to_string(),
+            height,
+            ibd,
+            validated,
+            latest_work: latest_work.to_string(),
+            latest_block_time,
+            leaf_count,
+            root_count,
+            root_hashes,
+            chain: self.network.to_string(),
+            difficulty: latest_header.difficulty(self.chain.get_params()) as u64,
+            progress: validated_blocks as f32 / height as f32,
+        })
+    }
+}

--- a/florestad/src/json_rpc/blockchain.rs
+++ b/florestad/src/json_rpc/blockchain.rs
@@ -37,110 +37,14 @@ impl RpcImpl {
 
 // blockchain rpcs
 impl RpcImpl {
-    pub fn get_block_serialized(&self, hash: BlockHash) -> Result<String, RpcError> {
-        let block = self.get_block_inner(hash)?;
-        Ok(serialize_hex(&block))
+    // dumputxoutset
+
+    // getbestblockhash
+    pub(super) fn get_best_block_hash(&self) -> Result<BlockHash, RpcError> {
+        Ok(self.chain.get_best_block().unwrap().1)
     }
 
-    pub fn find_tx_out(
-        &self,
-        txid: Txid,
-        vout: u32,
-        script: ScriptBuf,
-        height: u32,
-    ) -> Result<Value, RpcError> {
-        if let Some(txout) = self.wallet.get_utxo(&OutPoint { txid, vout }) {
-            return Ok(serde_json::to_value(txout).unwrap());
-        }
-
-        if self.chain.is_in_idb() {
-            return Err(RpcError::InInitialBlockDownload);
-        }
-
-        // can't proceed without block filters
-        let Some(cfilters) = self.block_filter_storage.as_ref() else {
-            return Err(RpcError::NoBlockFilters);
-        };
-
-        self.wallet.cache_address(script.clone());
-        let filter_key = script.to_bytes();
-        let candidates = cfilters.match_any(
-            vec![filter_key.as_slice()],
-            Some(height as usize),
-            self.chain.clone(),
-        );
-
-        let candidates = candidates
-            .unwrap_or_default()
-            .into_iter()
-            .map(|hash| self.node.get_block(hash));
-
-        for candidate in candidates {
-            let candidate = match candidate {
-                Err(e) => {
-                    return Err(RpcError::Node(e.to_string()));
-                }
-                Ok(None) => {
-                    return Err(RpcError::Node(format!(
-                        "BUG: block {candidate:?} is a match in our filters, but we can't get it?"
-                    )));
-                }
-                Ok(Some(candidate)) => candidate,
-            };
-
-            let Ok(Some(height)) = self.chain.get_block_height(&candidate.block_hash()) else {
-                return Err(RpcError::BlockNotFound);
-            };
-
-            self.wallet.block_process(&candidate, height);
-        }
-
-        self.get_tx_out(txid, vout)
-    }
-
-    pub(super) fn get_tx_proof(&self, tx_id: Txid) -> Result<Vec<String>, RpcError> {
-        Ok(self
-            .wallet
-            .get_merkle_proof(&tx_id)
-            .ok_or(RpcError::TxNotFound)?
-            .0)
-    }
-
-    pub(super) fn get_roots(&self) -> Result<Vec<String>, RpcError> {
-        let hashes = self.chain.get_root_hashes();
-        Ok(hashes.iter().map(|h| h.to_string()).collect())
-    }
-
-    pub(super) fn get_block_hash(&self, height: u32) -> Result<BlockHash, RpcError> {
-        self.chain
-            .get_block_hash(height)
-            .map_err(|_| RpcError::BlockNotFound)
-    }
-
-    pub(super) fn get_block_header(&self, hash: BlockHash) -> Result<Header, RpcError> {
-        self.chain
-            .get_block_header(&hash)
-            .map_err(|_| RpcError::BlockNotFound)
-    }
-
-    pub(super) fn get_height(&self) -> Result<u32, RpcError> {
-        Ok(self.chain.get_best_block().unwrap().0)
-    }
-
-    pub(super) fn get_tx_out(&self, txid: Txid, outpoint: u32) -> Result<Value, RpcError> {
-        let utxo = self.wallet.get_utxo(&OutPoint {
-            txid,
-            vout: outpoint,
-        });
-
-        let res = match utxo {
-            Some(utxo) => ::serde_json::to_value(utxo),
-            None => Ok(json!({})),
-        };
-
-        res.map_err(|_e| RpcError::Encode)
-    }
-
+    // getblock
     pub(super) fn get_block(&self, hash: BlockHash) -> Result<BlockJson, RpcError> {
         let block = self.get_block_inner(hash)?;
         let tip = self.chain.get_height().map_err(|_| RpcError::Chain)?;
@@ -198,6 +102,12 @@ impl RpcImpl {
         Ok(block)
     }
 
+    pub(super) fn get_block_serialized(&self, hash: BlockHash) -> Result<String, RpcError> {
+        let block = self.get_block_inner(hash)?;
+        Ok(serialize_hex(&block))
+    }
+
+    // getblockchaininfo
     pub(super) fn get_blockchain_info(&self) -> Result<GetBlockchainInfoRes, RpcError> {
         let (height, hash) = self.chain.get_best_block().unwrap();
         let validated = self.chain.get_validation_index().unwrap();
@@ -231,5 +141,138 @@ impl RpcImpl {
             difficulty: latest_header.difficulty(self.chain.get_params()) as u64,
             progress: validated_blocks as f32 / height as f32,
         })
+    }
+
+    // getblockcount
+    pub(super) fn get_block_count(&self) -> Result<u32, RpcError> {
+        Ok(self.chain.get_height().unwrap())
+    }
+
+    // getblockfilter
+    // getblockfrompeer (just call getblock)
+
+    // getblockhash
+    pub(super) fn get_block_hash(&self, height: u32) -> Result<BlockHash, RpcError> {
+        self.chain
+            .get_block_hash(height)
+            .map_err(|_| RpcError::BlockNotFound)
+    }
+
+    // getblockheader
+    pub(super) fn get_block_header(&self, hash: BlockHash) -> Result<Header, RpcError> {
+        self.chain
+            .get_block_header(&hash)
+            .map_err(|_| RpcError::BlockNotFound)
+    }
+
+    // getblockstats
+    // getchainstates
+    // getchaintips
+    // getchaintxstats
+    // getdeploymentinfo
+    // getdifficulty
+    // getmempoolancestors
+    // getmempooldescendants
+    // getmempoolentry
+    // getmempoolinfo
+    // getrawmempool
+    // gettxout
+    pub(super) fn get_tx_out(&self, txid: Txid, outpoint: u32) -> Result<Value, RpcError> {
+        let utxo = self.wallet.get_utxo(&OutPoint {
+            txid,
+            vout: outpoint,
+        });
+
+        let res = match utxo {
+            Some(utxo) => ::serde_json::to_value(utxo),
+            None => Ok(json!({})),
+        };
+
+        res.map_err(|_e| RpcError::Encode)
+    }
+
+    // gettxoutproof
+    pub(super) fn get_tx_proof(&self, tx_id: Txid) -> Result<Vec<String>, RpcError> {
+        Ok(self
+            .wallet
+            .get_merkle_proof(&tx_id)
+            .ok_or(RpcError::TxNotFound)?
+            .0)
+    }
+
+    // gettxoutsetinfo
+    // gettxspendigprevout
+    // importmempool
+    // loadtxoutset
+    // preciousblock
+    // pruneblockchain
+    // savemempool
+    // scanblocks
+    // scantxoutset
+    // verifychain
+    // verifytxoutproof
+
+    // floresta flavored rpcs. These are not part of the bitcoin rpc spec
+    // findtxout
+    pub(super) fn find_tx_out(
+        &self,
+        txid: Txid,
+        vout: u32,
+        script: ScriptBuf,
+        height: u32,
+    ) -> Result<Value, RpcError> {
+        if let Some(txout) = self.wallet.get_utxo(&OutPoint { txid, vout }) {
+            return Ok(serde_json::to_value(txout).unwrap());
+        }
+
+        if self.chain.is_in_idb() {
+            return Err(RpcError::InInitialBlockDownload);
+        }
+
+        // can't proceed without block filters
+        let Some(cfilters) = self.block_filter_storage.as_ref() else {
+            return Err(RpcError::NoBlockFilters);
+        };
+
+        self.wallet.cache_address(script.clone());
+        let filter_key = script.to_bytes();
+        let candidates = cfilters.match_any(
+            vec![filter_key.as_slice()],
+            Some(height as usize),
+            self.chain.clone(),
+        );
+
+        let candidates = candidates
+            .unwrap_or_default()
+            .into_iter()
+            .map(|hash| self.node.get_block(hash));
+
+        for candidate in candidates {
+            let candidate = match candidate {
+                Err(e) => {
+                    return Err(RpcError::Node(e.to_string()));
+                }
+                Ok(None) => {
+                    return Err(RpcError::Node(format!(
+                        "BUG: block {candidate:?} is a match in our filters, but we can't get it?"
+                    )));
+                }
+                Ok(Some(candidate)) => candidate,
+            };
+
+            let Ok(Some(height)) = self.chain.get_block_height(&candidate.block_hash()) else {
+                return Err(RpcError::BlockNotFound);
+            };
+
+            self.wallet.block_process(&candidate, height);
+        }
+
+        self.get_tx_out(txid, vout)
+    }
+
+    // getroots
+    pub(super) fn get_roots(&self) -> Result<Vec<String>, RpcError> {
+        let hashes = self.chain.get_root_hashes();
+        Ok(hashes.iter().map(|h| h.to_string()).collect())
     }
 }

--- a/florestad/src/json_rpc/mod.rs
+++ b/florestad/src/json_rpc/mod.rs
@@ -1,2 +1,3 @@
+pub mod blockchain;
 pub mod res;
 pub mod server;

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -78,6 +78,13 @@ pub enum GetBlockRes {
     Serialized(String),
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RpcError {
+    pub code: i32,
+    pub message: String,
+    pub data: Option<String>,
+}
+
 /// A full bitcoin block, returned by get_block
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetBlockResVerbose {

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -100,6 +100,7 @@ pub struct BlockJson {
 pub enum Error {
     MissingParams,
     MissingReq,
+    InvalidVerbosityLevel,
     TxNotFound,
     InvalidScript,
     InvalidDescriptor,
@@ -145,6 +146,7 @@ impl Display for Error {
             Error::InvalidScript => write!(f, "Invalid script"),
             Error::MissingParams => write!(f, "Missing params field"),
             Error::MissingReq => write!(f, "Missing request field"),
+            Error::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
         }
     }
 }

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -71,28 +71,95 @@ pub struct ScriptSigJson {
     pub hex: String,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct BlockJson {
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetBlockRes {
+    Verbose(Box<GetBlockResVerbose>),
+    Serialized(String),
+}
+
+/// A full bitcoin block, returned by get_block
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetBlockResVerbose {
+    /// This block's hash.
     pub hash: String,
+    /// How many blocks have been added to the chain, after this one have been found. This is
+    /// inclusive, so it starts with one when this block is the latest. If another one is found,
+    /// then it increments to 2 and so on...
     pub confirmations: u32,
+    /// The size of this block, without the witness
     pub strippedsize: usize,
+    /// This block's size, with the witness
     pub size: usize,
+    /// This block's weight.
+    ///
+    /// Data inside a segwit block is counted differently, 'base data' has a weight of 4, while
+    /// witness only counts 1. This is (3 * base_size) + size
     pub weight: usize,
+    /// How many blocks there are before this block
     pub height: u32,
+    /// This block's version field
+    ///
+    /// Currently, blocks have version 2 (see BIP34), but it may also flip some of the LSB for
+    /// either consensus reason (see BIPs 8 and 9) or for version rolling mining, usually bits
+    /// after the 24th are not touched. Therefore, the actual version is likely the result of
+    /// version & ~(1 << 24).
+    /// This is encoded as a number, see `version_hex` for a hex-encoded version
     pub version: i32,
     #[serde(rename = "versionHex")]
+    /// Same as `version` by hex-encoded
     pub version_hex: String,
+    /// This block's merkle root
+    ///
+    /// A Merkle Tree is a binary tree where every leaf is some data, and the branches are pairwise
+    /// hashes util reaching the root. This allows for compact proof of inclusion in the original
+    /// set. This merkle tree commits to the txid of all transactions in a block, and is used by
+    /// some light clients to determine whether a transaction is in a given block
     pub merkleroot: String,
+    /// A list of hex-encoded transaction id for the tx's in this block
     pub tx: Vec<String>,
+    /// The timestamp committed to in this block's header
+    ///
+    /// Since there's no central clock that can tell time precisely in Bitcoin, this value is
+    /// reported by miners and only constrained by a couple of consensus rules. More sensibly, it
+    /// is **not** guaranteed to be monotonical. So a block n might have a lower timestamp than
+    /// block `n - 1`.
+    /// If you need it to be monotonical, see `mediantime` instead
     pub time: u32,
+    /// The meadian of the last 11 blocktimes.
+    ///
+    /// This is a monotonically increasing number that bounds how old a block can be. Blocks may
+    /// not have a timestamp less than the current `mediantime`. This is also used in relative
+    /// timelocks.
     pub mediantime: u32,
+    /// The nonce used to mine this block.
+    ///
+    /// Blocks are mined by increasing this value until you find a hash that is less than a network
+    /// defined target. This number has no meaning in itself and is just a random u32.
     pub nonce: u32,
+    /// Bits is a compact representation for the target.
+    ///
+    /// This is a exponential format (with well-define rounding) used by openssl that Satoshi
+    /// decided to make consensus critical :/
     pub bits: String,
+    /// The difficulty is derived from the current target and is defined as how many hashes, on
+    /// average, one has to make before finding a valid block
+    ///
+    /// This is computed as 1 / (target / 2 ^ 256). In most software (this one included) the
+    /// difficulty is a multiple of the smallest possible difficulty. So to find the actual
+    /// difficulty you have to multiply this by the min_diff.
+    /// For mainnet, mindiff is 2 ^ 32
     pub difficulty: u128,
+    /// Commullative work in this network
+    ///
+    /// This is a estimate of how many hashes the network has ever made to produce this chain
     pub chainwork: String,
+    /// How many transactions in this block
     pub n_tx: usize,
+    /// The hash of the block coming before this one
     pub previousblockhash: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// The hash of the block coming after this one, if any
     pub nextblockhash: Option<String>,
 }
 


### PR DESCRIPTION
Depends on #322 

This is the first step towards a core-compatible(ish) json rpc. This should help other applications to integrate with `florestad` without requiring any additional work.

List of things achieved here:
  - [x] Refactor node to have RPCs grouped per file (done for blockchain)
  - [x] Rename RPCs to allign with core (done for blockchain)
  - [x] Implement all RPCs that are trivial to (if it needs more work, they'll have their own PR)

Things that we'll need to build next (not done here):
  - [ ] Make sure all RPCs return the same thing as core `v28`
  - [ ] Non-trivial RPCs
  - [ ] A cross-test between floresta and core. Ideally, we would have a test that sends the same RPCs to `core` and `florestad`, checks if they return the same. We should have one that does that against different versions of core, and one that runs every week or something like this, testing our master and theirs.