### PR TITLE
Python tests in justfile with nix

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -18,9 +18,9 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: 'poetry'
-          cache-dependency-path: './poetry.lock'
+          python-version: "3.12"
+          cache: "poetry"
+          cache-dependency-path: "./poetry.lock"
 
       - name: Prepare environment
         run: poetry install --no-root
@@ -34,8 +34,8 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
 
-      - name: Build Floresta
-        run: cargo build
+      - name: Tests Setup
+        run: bash tests/prepare.sh
 
       - name: Run functional tests tasks
-        run: poetry run poe tests
+        run: bash tests/run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /builds
 /result
+/bin
 
 # Temporary files and generated data
 tmp/

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ clean:
 test name="":
     @just test-doc {{name}}
     @just test-unit {{name}}
-    @just test-int
+    @just test-wkspc
 
 # Execute doc tests
 test-doc name="":
@@ -36,9 +36,27 @@ test-doc name="":
 test-unit name="":
     cargo test --lib {{name}} -- --nocapture
 
-# Execute integration tests
-test-int:
+# Execute workspace-related tests
+test-wkspc:
     cargo test --workspace -- --nocapture
+
+# Execute our python integration tests inside /tests using nix for all setup needed.
+test-int-nix:
+    nix develop .#pythonTests
+
+# Execute tests/prepare.sh.
+test-int-setup:
+    bash tests/prepare.sh
+
+# Execute tests/run.sh
+test-int-run:
+    bash tests/run.sh
+
+# Execute our python integration tests inside /tests.
+#
+# Make sure you have done the necessary setup explained in our README.md in the root of the folder.
+test-int:
+    poetry run poe tests
 
 # Generate documentation for all crates
 doc:

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -1,41 +1,85 @@
-# Prepares our environment to run our tests
+#!/bin/bash
+# Prepares a temporary environment to run our tests
 #
-# This script shold be executed once, before running our functinal test
-# for the first time. It'll download and build all needed dependencies
-# to make sure we are not missing anything during our tests.
+# This script should be executed once, before running our functinal test
+# for the first time we are testing a specific commit or in a session, since all the created files are temporary.
+#
+# It'll download and build only utreexod and florestad, since we are not testing the other binaries.
+#
+# Make sure to have python(for the tests), golang(for building utreexod) and rust(for building florestad) installed.
+#
 
-# Check for dependencies, we need Golang for Utreexod and Rust for Floresta
+
+# We expect the current dir is the root dir of the project.
+FLORESTA_PROJ_DIR=$(pwd)
+# This helps us to keep track of the actual version being tested without conflicting with any already installed binaries.
+HEAD_COMMIT_HASH=$(git rev-parse HEAD)
+
+TEMP_DIR="/tmp/floresta-integration-tests.${HEAD_COMMIT_HASH}"
+
+
 go version &>/dev/null
 
 if [ $? -ne 0 ]
 then
 	echo "You must have golang installed to run those tests!"
+	exit 1
 fi
+
 
 cargo version &>/dev/null
 
 if [ $? -ne 0 ]
 then
-	echo "You must have cargo installed to run those tests!"
+	echo "You must have rust with cargo installed to run those tests!"
+	exit 1
+fi
+
+poetry -V  &>/dev/null
+
+if [ $? -ne 0 ]
+then
+	echo "You must have poetry installed to run those tests!"
+	exit 1
 fi
 
 
-mkdir -p ./bin
 
-cd bin
+ls $TEMP_DIR &>/dev/null
+if [ $? -ne 0 ]
+then
+	echo "The tests dir for the tests does not exist. Creating it..."
+	# Dont use mktemp so we can have deterministic results for each version of floresta.
+	mkdir -p "$TEMP_DIR"
+fi
+
+echo "$TEMP_DIR exists. Delete it with"
+echo "$ rm -rf $TEMP_DIR"
+echo "if you want to start fresh."
+
+cd $TEMP_DIR/
 
 # Download and build utreexod
 ls -la utreexod &>/dev/null
 if [ $? -ne 0 ]
 then
-	git clone https://github.com/utreexo/utreexod
+    echo "Utreexo not found on $TEMP_DIR/utreexod."
+    echo "Downloading utreexod..."
+	git clone https://github.com/utreexo/utreexod &>/dev/null
+	echo "Building utreexod..."
+	cd utreexod
+    go build . &>/dev/null
 fi
 
-cd utreexod
-go build . &>/dev/null
-
-# build floresta
-cd ../../
-cargo build --bin florestad --features json-rpc &>/dev/null
+# Checks if needed and build floresta setting the specific version of this build to the one we are testing
+ls -la florestad &>/dev/null
+if [ $? -ne 0 ]
+then
+    echo "Floresta not found on $TEMP_DIR/florestad."
+    echo "Building florestad..."
+    cd $FLORESTA_PROJ_DIR
+    cargo build --bin florestad --features json-rpc --target-dir $TEMP_DIR/florestad &>/dev/null
+fi
 
 echo "All done!"
+exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# We expect the current dir is the root dir of the project.
+FLORESTA_PROJ_DIR=$(pwd)
+
+# This helps us to keep track of the actual version being tested without conflicting with any already installed binaries.
+HEAD_COMMIT_HASH=$(git rev-parse HEAD)
+
+
+# Since its deterministic how we make the setup, we already know where to search for the binaries to be testing.
+TEMP_DIR="/tmp/floresta-integration-tests.${HEAD_COMMIT_HASH}"
+
+FLORESTA_BIN_DIR="$TEMP_DIR/florestad/debug"
+UTREEXO_BIN_DIR="$TEMP_DIR/utreexod"
+
+ls $TEMP_DIR &>/dev/null
+if [ $? -ne 0 ]
+then
+    echo "The expected test dir for this version of floresta isnt setted yet."
+    echo "Did you run prepare.sh? Please read the README.md file."
+	exit 1
+fi
+# Here we save the original path from the bash session to restore it later. Cmon, we are not savages.
+ORIGINAL_PATH=$PATH
+# We add the generated binaries for testing to the PATH.
+export PATH="$FLORESTA_BIN_DIR:$UTREEXO_BIN_DIR:$PATH"
+
+# Actually runs the tests
+poetry run poe tests
+# Restores the original PATH
+export PATH=$ORIGINAL_PATH

--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -121,16 +121,11 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
         (see florestad --help for a list of available commands)
 
         """
+
         setting = {
             "chain": chain,
             "config": [
-                "cargo",
-                "run",
-                "--features",
-                "json-rpc",
-                "--bin",
                 "florestad",
-                "--",
                 "--network",
                 chain,
                 "--no-ssl",


### PR DESCRIPTION
This piece of changes tries to automate our python tests inside our justfile.

`test-int` now just executes `"poetry run poe tests"` command defined in `pyproject.toml` and in `run_tests.py`.

the old `test-int` is renamed to `test-wkspc` to match better the internal command and to give space for the integration tests with python.

new command `test-int-nix` uses a nix-shell to setup every python crap, downloading and compiling utreexod and florestad, run the tests and exits