### PR TITLE
jsonrpc: add control commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "floresta-wire",
  "futures",
  "kv",
+ "libc",
  "log",
  "metrics",
  "miniscript 12.2.0",
@@ -1448,9 +1449,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
         let (mut _proc, client) = start_florestad();
 
         let stop = client.stop().expect("rpc not working");
-        assert!(stop);
+        assert_eq!(stop.as_str(), "florestad stopping");
     }
 
     #[test]

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -102,6 +102,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_memory_info(mode)?)?
         }
         Methods::GetRpcInfo => serde_json::to_string_pretty(&client.get_rpc_info()?)?,
+        Methods::Uptime => serde_json::to_string_pretty(&client.uptime()?)?,
     })
 }
 
@@ -199,4 +200,7 @@ pub enum Methods {
     /// Returns information about the RPC server
     #[command(name = "getrpcinfo")]
     GetRpcInfo,
+    /// Returns for how long the node has been running, in seconds
+    #[command(name = "uptime")]
+    Uptime,
 }

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -97,6 +97,10 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             script,
             height_hint.unwrap_or(0),
         )?)?,
+        Methods::GetMemoryInfo { mode } => {
+            let mode = mode.unwrap_or("stats".to_string());
+            serde_json::to_string_pretty(&client.get_memory_info(mode)?)?
+        }
     })
 }
 
@@ -188,4 +192,7 @@ pub enum Methods {
         script: String,
         height_hint: Option<u32>,
     },
+    /// Returns stats about our memory usage
+    #[command(name = "getmemoryinfo")]
+    GetMemoryInfo { mode: Option<String> },
 }

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -101,6 +101,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             let mode = mode.unwrap_or("stats".to_string());
             serde_json::to_string_pretty(&client.get_memory_info(mode)?)?
         }
+        Methods::GetRpcInfo => serde_json::to_string_pretty(&client.get_rpc_info()?)?,
     })
 }
 
@@ -195,4 +196,7 @@ pub enum Methods {
     /// Returns stats about our memory usage
     #[command(name = "getmemoryinfo")]
     GetMemoryInfo { mode: Option<String> },
+    /// Returns information about the RPC server
+    #[command(name = "getrpcinfo")]
+    GetRpcInfo,
 }

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -119,6 +119,8 @@ pub trait FlorestaRPC {
     ) -> Result<Value>;
     /// Returns stats about our memory usage
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
+    /// Returns stats about our RPC server
+    fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -154,6 +156,10 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
 
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes> {
         self.call("getmemoryinfo", &[Value::String(mode)])
+    }
+
+    fn get_rpc_info(&self) -> Result<GetRpcInfoRes> {
+        self.call("getrpcinfo", &[])
     }
 
     fn add_node(&self, node: String) -> Result<bool> {

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -117,6 +117,8 @@ pub trait FlorestaRPC {
         script: String,
         height_hint: u32,
     ) -> Result<Value>;
+    /// Returns stats about our memory usage
+    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -149,6 +151,11 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
             ],
         )
     }
+
+    fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes> {
+        self.call("getmemoryinfo", &[Value::String(mode)])
+    }
+
     fn add_node(&self, node: String) -> Result<bool> {
         self.call("addnode", &[Value::String(node)])
     }

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -121,6 +121,8 @@ pub trait FlorestaRPC {
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes>;
     /// Returns stats about our RPC server
     fn get_rpc_info(&self) -> Result<GetRpcInfoRes>;
+    /// Returns for how long florestad has been running, in seconds
+    fn uptime(&self) -> Result<u32>;
 }
 
 /// Since the workflow for jsonrpc is the same for all methods, we can implement a trait
@@ -152,6 +154,10 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
                 Value::Number(Number::from(height_hint)),
             ],
         )
+    }
+
+    fn uptime(&self) -> Result<u32> {
+        self.call("uptime", &[])
     }
 
     fn get_memory_info(&self, mode: String) -> Result<GetMemInfoRes> {

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -100,7 +100,7 @@ pub trait FlorestaRPC {
     /// Stops the florestad process
     ///
     /// This can be used to gracefully stop the florestad process.
-    fn stop(&self) -> Result<bool>;
+    fn stop(&self) -> Result<String>;
     /// Tells florestad to connect with a peer
     ///
     /// You can use this to connect with a given node, providing it's IP address and port.
@@ -166,7 +166,7 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("addnode", &[Value::String(node)])
     }
 
-    fn stop(&self) -> Result<bool> {
+    fn stop(&self) -> Result<String> {
         self.call("stop", &[])
     }
 

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -306,4 +306,34 @@ impl Display for Error {
     }
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct GetMemInfoStats {
+    locked: MemInfoLocked,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct MemInfoLocked {
+    /// Memory currently in use, in bytes
+    used: u64,
+    /// Memory currently free, in bytes
+    free: u64,
+    /// Total memory allocated, in bytes
+    total: u64,
+    /// Total memory locked, in bytes
+    ///
+    /// If total is less than total, then some pages may be on swap or not philysically allocated
+    /// yet
+    locked: u64,
+    /// How many chunks are currently in use
+    chunks_used: u64,
+    /// How many chunks are currently free
+    chunks_free: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GetMemInfoRes {
+    Stats(GetMemInfoStats),
+    MallocInfo(String),
+}
 impl std::error::Error for Error {}

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -336,4 +336,17 @@ pub enum GetMemInfoRes {
     Stats(GetMemInfoStats),
     MallocInfo(String),
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActiveCommand {
+    method: String,
+    duration: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetRpcInfoRes {
+    active_commands: Vec<ActiveCommand>,
+    logpath: String,
+}
+
 impl std::error::Error for Error {}

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -38,6 +38,9 @@ tower-http = { version = "0.6.2", optional = true, features = ["cors"] }
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }
 
+[target.'cfg(target_env = "gnu")'.dependencies]
+libc = "0.2.169"
+
 [lib]
 name = "florestad"
 path = "src/lib.rs"

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -200,6 +200,11 @@ impl Florestad {
         });
     }
 
+    pub fn should_stop(&self) -> bool {
+        let stop_signal = self.stop_signal.clone();
+        block_on(async { *stop_signal.read().await })
+    }
+
     pub fn get_stop_signal(&self) -> Arc<RwLock<bool>> {
         self.stop_signal.clone()
     }

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -335,9 +335,8 @@ impl Florestad {
         }
 
         info!("Loading blockchain database");
-        let datadir2 = data_dir.clone();
         let blockchain_state = Arc::new(Self::load_chain_state(
-            datadir2,
+            data_dir.clone(),
             Self::get_net(&self.config.network),
             self.config
                 .assume_valid
@@ -442,6 +441,7 @@ impl Florestad {
                     .json_rpc_address
                     .as_ref()
                     .map(|x| Self::get_ip_address(x, 8332)),
+                data_dir.clone() + "/output.log",
             ));
 
             if self.json_rpc.set(server).is_err() {

--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -54,6 +54,26 @@ impl RpcImpl {
             _ => Err(Error::InvalidMemInfoMode),
         }
     }
+
+    pub(super) async fn get_rpc_info(&self) -> Result<GetRpcInfoRes, Error> {
+        let active_commands = self
+            .inflight
+            .read()
+            .await
+            .values()
+            .map(|req| ActiveCommand {
+                method: req.method.clone(),
+                duration: req.when.elapsed().as_secs(),
+            })
+            .collect();
+
+        let logpath = self.log_dir.clone();
+
+        Ok(GetRpcInfoRes {
+            active_commands,
+            logpath,
+        })
+    }
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -76,4 +96,16 @@ pub struct MemInfoLocked {
 pub enum GetMemInfoRes {
     Stats(GetMemInfoStats),
     MallocInfo(String),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ActiveCommand {
+    method: String,
+    duration: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetRpcInfoRes {
+    active_commands: Vec<ActiveCommand>,
+    logpath: String,
 }

--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -1,0 +1,79 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::res::Error;
+use super::server::RpcImpl;
+
+impl RpcImpl {
+    pub(super) fn get_memory_info(&self, mode: &str) -> Result<GetMemInfoRes, Error> {
+        #[cfg(target_env = "gnu")]
+        match mode {
+            // only available for glibc
+            "stats" => {
+                let info = unsafe { libc::mallinfo() };
+
+                let stats = GetMemInfoStats {
+                    locked: MemInfoLocked {
+                        used: info.uordblks as u64,
+                        free: info.fordblks as u64,
+                        total: (info.uordblks + info.fordblks) as u64,
+                        locked: info.hblkhd as u64,
+                        chunks_used: info.ordblks as u64,
+                        chunks_free: info.smblks as u64,
+                    },
+                };
+
+                Ok(GetMemInfoRes::Stats(stats))
+            }
+
+            "mallocinfo" => {
+                // a xml with the allocator statistics
+                let info = unsafe { libc::mallinfo() };
+                let info_str = format!(
+                    "<malloc version=\"2.0\"><heap nr=\"1\"><allocated>{}</allocated><free>{}</free><total>{}</total><locked>{}</locked><chunks nr=\"{}\"><used>{}</used><free>{}</free></chunks></heap></malloc>",
+                    info.hblkhd,
+                    info.uordblks,
+                    info.fordblks,
+                    info.uordblks + info.fordblks,
+                    info.hblkhd,
+                    info.ordblks,
+                    info.smblks,
+                );
+
+                Ok(GetMemInfoRes::MallocInfo(info_str))
+            }
+
+            _ => Err(Error::InvalidMemInfoMode),
+        }
+
+        #[cfg(not(target_env = "gnu"))]
+        // just return zeroed stats
+        match mode {
+            "stats" => Ok(GetMemInfoRes::Stats(GetMemInfoStats::default())),
+            "mallocinfo" => Ok(GetMemInfoRes::MallocInfo(String::new())),
+            _ => Err(Error::InvalidMemInfoMode),
+        }
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct GetMemInfoStats {
+    locked: MemInfoLocked,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct MemInfoLocked {
+    used: u64,
+    free: u64,
+    total: u64,
+    locked: u64,
+    chunks_used: u64,
+    chunks_free: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GetMemInfoRes {
+    Stats(GetMemInfoStats),
+    MallocInfo(String),
+}

--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -78,10 +78,16 @@ impl RpcImpl {
     // help
     // logging
 
+    // stop
     pub(super) async fn stop(&self) -> Result<&str, Error> {
         *self.kill_signal.write().await = true;
 
         Ok("florestad stopping")
+    }
+
+    // uptime
+    pub(super) fn uptime(&self) -> u64 {
+        self.start_time.elapsed().as_secs()
     }
 }
 

--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -74,6 +74,15 @@ impl RpcImpl {
             logpath,
         })
     }
+
+    // help
+    // logging
+
+    pub(super) async fn stop(&self) -> Result<&str, Error> {
+        *self.kill_signal.write().await = true;
+
+        Ok("florestad stopping")
+    }
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/florestad/src/json_rpc/mod.rs
+++ b/florestad/src/json_rpc/mod.rs
@@ -1,3 +1,6 @@
-pub mod blockchain;
 pub mod res;
 pub mod server;
+
+// endpoint impls
+mod blockchain;
+mod control;

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -194,6 +194,7 @@ pub enum Error {
     InvalidHex,
     InInitialBlockDownload,
     Encode,
+    InvalidMemInfoMode,
 }
 
 impl Display for Error {
@@ -221,6 +222,7 @@ impl Display for Error {
             Error::MissingParams => write!(f, "Missing params field"),
             Error::MissingReq => write!(f, "Missing request field"),
             Error::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
+            Error::InvalidMemInfoMode => write!(f, "Invalid meminfo mode, should be stats or mallocinfo"),
         }
     }
 }

--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -316,6 +316,15 @@ async fn handle_json_rpc_request(req: Value, state: Arc<RpcImpl>) -> Result<serd
                 .map(|v| ::serde_json::to_value(v).unwrap())
         }
 
+        // control
+        "getmemoryinfo" => {
+            let mode = params.first().and_then(|v| v.as_str()).unwrap_or("stats");
+
+            state
+                .get_memory_info(mode)
+                .map(|v| ::serde_json::to_value(v).unwrap())
+        }
+
         // network
         "getpeerinfo" => state
             .get_peer_info()
@@ -381,7 +390,8 @@ fn get_http_error_code(err: &Error) -> u16 {
         | Error::Decode(_)
         | Error::MissingParams
         | Error::MissingReq
-        | Error::NoBlockFilters => 400,
+        | Error::NoBlockFilters
+        | Error::InvalidMemInfoMode => 400,
 
         // idunnolol
         Error::MethodNotFound | Error::BlockNotFound | Error::TxNotFound => 404,
@@ -410,7 +420,8 @@ fn get_json_rpc_error_code(err: &Error) -> i32 {
         | Error::InvalidNetwork
         | Error::InvalidVerbosityLevel
         | Error::TxNotFound
-        | Error::BlockNotFound => -32600,
+        | Error::BlockNotFound 
+        | Error::InvalidMemInfoMode => -32600,
 
         // server error
         Error::InInitialBlockDownload

--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::extract::State;
 use axum::http::Method;
@@ -49,6 +51,11 @@ use super::res::ScriptSigJson;
 use super::res::TxInJson;
 use super::res::TxOutJson;
 
+pub(super) struct InflightRpc {
+    pub method: String,
+    pub when: Instant,
+}
+
 pub struct RpcImpl {
     pub(super) block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
     pub(super) network: Network,
@@ -56,6 +63,8 @@ pub struct RpcImpl {
     pub(super) wallet: Arc<AddressCache<KvDatabase>>,
     pub(super) node: Arc<NodeInterface>,
     pub(super) kill_signal: Arc<RwLock<bool>>,
+    pub(super) inflight: Arc<RwLock<HashMap<Value, InflightRpc>>>,
+    pub(super) log_dir: String,
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -205,10 +214,19 @@ async fn handle_json_rpc_request(req: Value, state: Arc<RpcImpl>) -> Result<serd
     let method = req["method"].as_str().ok_or(Error::MethodNotFound)?;
     let params = req["params"].as_array().ok_or(Error::MissingParams)?;
     let version = req["jsonrpc"].as_str().ok_or(Error::MissingReq)?;
+    let id = req["id"].clone();
 
     if version != "2.0" {
         return Err(Error::InvalidRequest);
     }
+
+    state.inflight.write().await.insert(
+        id.clone(),
+        InflightRpc {
+            method: req["method"].as_str().unwrap().to_string(),
+            when: Instant::now(),
+        },
+    );
 
     match method {
         // blockchain
@@ -324,6 +342,11 @@ async fn handle_json_rpc_request(req: Value, state: Arc<RpcImpl>) -> Result<serd
                 .get_memory_info(mode)
                 .map(|v| ::serde_json::to_value(v).unwrap())
         }
+
+        "getrpcinfo" => state
+            .get_rpc_info()
+            .await
+            .map(|v| ::serde_json::to_value(v).unwrap()),
 
         // network
         "getpeerinfo" => state
@@ -455,7 +478,9 @@ async fn json_rpc_request(
             .unwrap();
     };
 
-    let res = handle_json_rpc_request(req, state).await;
+    let res = handle_json_rpc_request(req, state.clone()).await;
+
+    state.inflight.write().await.remove(&id);
 
     match res {
         Ok(res) => {
@@ -656,6 +681,7 @@ impl RpcImpl {
         network: Network,
         block_filter_storage: Option<Arc<NetworkFilters<FlatFiltersStore>>>,
         address: Option<SocketAddr>,
+        log_path: String,
     ) {
         let address = address.unwrap_or_else(|| {
             format!("127.0.0.1:{}", Self::get_port(&network))
@@ -681,6 +707,8 @@ impl RpcImpl {
                 kill_signal,
                 network,
                 block_filter_storage,
+                inflight: Arc::new(RwLock::new(HashMap::new())),
+                log_dir: log_path,
             }));
 
         axum::serve(listener, router)

--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -203,11 +203,6 @@ impl RpcImpl {
         .await
         .map_err(|e| Error::Node(e.to_string()))?
     }
-
-    async fn stop(&self) -> Result<bool> {
-        *self.kill_signal.write().await = true;
-        Ok(true)
-    }
 }
 
 async fn handle_json_rpc_request(req: Value, state: Arc<RpcImpl>) -> Result<serde_json::Value> {
@@ -348,6 +343,15 @@ async fn handle_json_rpc_request(req: Value, state: Arc<RpcImpl>) -> Result<serd
             .await
             .map(|v| ::serde_json::to_value(v).unwrap()),
 
+        // help
+        // logging
+
+        // control
+        "stop" => state
+            .stop()
+            .await
+            .map(|v| ::serde_json::to_value(v).unwrap()),
+
         // network
         "getpeerinfo" => state
             .get_peer_info()
@@ -382,12 +386,6 @@ async fn handle_json_rpc_request(req: Value, state: Arc<RpcImpl>) -> Result<serd
                 .send_raw_transaction(tx.to_string())
                 .map(|v| ::serde_json::to_value(v).unwrap())
         }
-
-        // control
-        "stop" => state
-            .stop()
-            .await
-            .map(|v| ::serde_json::to_value(v).unwrap()),
 
         _ => {
             let error = Error::MethodNotFound;


### PR DESCRIPTION
This PR implements the following RPCs:

`getmeminfo`: Returns information about our memory usage
`getrpcinfo`: Stats about our jsonrpc server
`uptime`: How long our daemon has been running, in seconds

It also updates `stop` to make it return a string "florestad stopping" just like core's "Bitcoin Core stopping".

I'm not implementing `help` and `logging` from the control category
`help` is already implemented in `floresta-cli` by `clap`
`logging` requires a level of logs filtering we don't really have