### PR TITLE
Move block weight check to `validate_block_no_acc`

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -46,7 +46,7 @@ pub enum BlockValidationErrors {
     BadMerkleRoot,
     BadWitnessCommitment,
     NotEnoughMoney,
-    FirstTxIsnNotCoinbase,
+    FirstTxIsNotCoinbase,
     BadCoinbaseOutValue,
     EmptyBlock,
     BlockExtendsAnOrphanChain,
@@ -92,7 +92,7 @@ impl Display for BlockValidationErrors {
             BlockValidationErrors::NotEnoughMoney => {
                 write!(f, "A transaction spends more than it should")
             }
-            BlockValidationErrors::FirstTxIsnNotCoinbase => {
+            BlockValidationErrors::FirstTxIsNotCoinbase => {
                 write!(f, "The first transaction in a block isn't a coinbase")
             }
             BlockValidationErrors::BadCoinbaseOutValue => {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -687,7 +687,7 @@ where
                         | BlockValidationErrors::BadMerkleRoot
                         | BlockValidationErrors::BadWitnessCommitment
                         | BlockValidationErrors::NotEnoughMoney
-                        | BlockValidationErrors::FirstTxIsnNotCoinbase
+                        | BlockValidationErrors::FirstTxIsNotCoinbase
                         | BlockValidationErrors::BadCoinbaseOutValue
                         | BlockValidationErrors::EmptyBlock
                         | BlockValidationErrors::BlockExtendsAnOrphanChain

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -230,7 +230,7 @@ where
                         | BlockValidationErrors::BadMerkleRoot
                         | BlockValidationErrors::BadWitnessCommitment
                         | BlockValidationErrors::NotEnoughMoney
-                        | BlockValidationErrors::FirstTxIsnNotCoinbase
+                        | BlockValidationErrors::FirstTxIsNotCoinbase
                         | BlockValidationErrors::BadCoinbaseOutValue
                         | BlockValidationErrors::EmptyBlock
                         | BlockValidationErrors::BlockExtendsAnOrphanChain


### PR DESCRIPTION
This is more suitable as `Block` has a method that directly computes the weight (accounting for the header and coinbase, which we didn't).

In `validate_block_no_acc` I added a few `.into()`. Renamed `FirstTxIs/n/NotCoinbase` to `FirstTxIsNotCoinbase`