### PR TITLE
chore: add new utreexo seed [seed.bitcoin.luisschwab.com]

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -284,6 +284,11 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
             ));
             seeds.push(DnsSeed::new(
                 Network::Bitcoin,
+                "seed.bitcoin.luisschwab.com",
+                x1000049,
+            ));
+            seeds.push(DnsSeed::new(
+                Network::Bitcoin,
                 "seed.bitcoin.sipa.be",
                 x9, // no COMPACT_FILTERS
             ));


### PR DESCRIPTION
`seed.bitcoin.luisschwab.com` implements these filters:

- **x9**: NODE_NETWORK | NODE_WITNESS
- **x49**: NODE_NETWORK | NODE_WITNESS | NODE_COMPACT_FILTERS
- **x1000009**: NODE_NETWORK | NODE_WITNESS | NODE_UTREEXO
- **x1000049**: NODE_NETWORK | NODE_WITNESS | NODE_COMPACT_FILTERS | NODE_UTREEXO
