### PR TITLE
fix,log: remove unresponsive peers, better DNS logging

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -293,17 +293,7 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
                 x9, // no COMPACT_FILTERS
             ));
             seeds.push(DnsSeed::new(Network::Bitcoin, "dnsseed.bluematt.me", x49));
-            seeds.push(DnsSeed::new(
-                Network::Bitcoin,
-                "dnsseed.bitcoin.dashjr.org",
-                none, // no filter
-            ));
             seeds.push(DnsSeed::new(Network::Bitcoin, "seed.bitcoinstats.com", x49));
-            seeds.push(DnsSeed::new(
-                Network::Bitcoin,
-                "seed.bitcoin.jonasschnelli.ch",
-                x49,
-            ));
             seeds.push(DnsSeed::new(
                 Network::Bitcoin,
                 "seed.btc.petertodd.org",

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -449,16 +449,23 @@ impl AddressMan {
         self.push_addresses(&persisted_peers);
 
         let mut peers_from_dns = 0;
+        info!("Starting peer discovery via DNS seeds");
         for seed in dns_seeds {
             match self.get_seeds_from_dns(seed, default_port) {
-                Ok(peers) => peers_from_dns += peers,
+                Ok(peers) => {
+                    peers_from_dns += peers;
+                    info!("Got {} peers from {}", peers, seed.seed);
+                }
                 Err(e) => {
                     info!("Error getting peers from DNS seed {}: {e:?}", seed.seed);
                 }
             }
         }
-
-        info!("Got {peers_from_dns} peers from DNS Seeds",);
+        info!(
+            "Got {} peers from {} DNS seeds",
+            peers_from_dns,
+            dns_seeds.len()
+        );
 
         let anchors = std::fs::read_to_string(format!("{datadir}/anchors.json"))?;
         let anchors = serde_json::from_str::<Vec<DiskLocalAddress>>(&anchors)?;


### PR DESCRIPTION
This PR removes the unresponsive `seed.bitcoin.jonasschnelli.ch` and `dnsseed.bitcoin.dashjr.org` DNS seeds, and also adds better logging on the peer discovery phase.