### PR TITLE
ci: use 'published' event for triggering docker.yml workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION

Not sure it is completly relevant here because I do not now about the release process.
According to the [Github Actions documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release)

>Workflows are not triggered for the created, edited, or deleted activity types for draft releases. When you create your release through the GitHub UI, your release may automatically be saved as a draft.

In that case, it's maybe better to rely on the `published` trigger for the docker action