### PR TITLE
Backport of #343 #344

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -277,6 +277,11 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
         Network::Bitcoin => {
             seeds.push(DnsSeed::new(
                 Network::Bitcoin,
+                "seed.bitcoin.luisschwab.com",
+                x1000049,
+            ));
+            seeds.push(DnsSeed::new(
+                Network::Bitcoin,
                 "seed.bitcoin.sipa.be",
                 x9, // no COMPACT_FILTERS
             ));

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -286,17 +286,7 @@ pub fn get_chain_dns_seeds(network: Network) -> Vec<DnsSeed> {
                 x9, // no COMPACT_FILTERS
             ));
             seeds.push(DnsSeed::new(Network::Bitcoin, "dnsseed.bluematt.me", x49));
-            seeds.push(DnsSeed::new(
-                Network::Bitcoin,
-                "dnsseed.bitcoin.dashjr.org",
-                none, // no filter
-            ));
             seeds.push(DnsSeed::new(Network::Bitcoin, "seed.bitcoinstats.com", x49));
-            seeds.push(DnsSeed::new(
-                Network::Bitcoin,
-                "seed.bitcoin.jonasschnelli.ch",
-                x49,
-            ));
             seeds.push(DnsSeed::new(
                 Network::Bitcoin,
                 "seed.btc.petertodd.org",

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -449,16 +449,23 @@ impl AddressMan {
         self.push_addresses(&persisted_peers);
 
         let mut peers_from_dns = 0;
+        info!("Starting peer discovery via DNS seeds");
         for seed in dns_seeds {
             match self.get_seeds_from_dns(seed, default_port) {
-                Ok(peers) => peers_from_dns += peers,
+                Ok(peers) => {
+                    peers_from_dns += peers;
+                    info!("Got {} peers from {}", peers, seed.seed);
+                }
                 Err(e) => {
                     info!("Error getting peers from DNS seed {}: {e:?}", seed.seed);
                 }
             }
         }
-
-        info!("Got {peers_from_dns} peers from DNS Seeds",);
+        info!(
+            "Got {} peers from {} DNS seeds",
+            peers_from_dns,
+            dns_seeds.len()
+        );
 
         let anchors = std::fs::read_to_string(format!("{datadir}/anchors.json"))?;
         let anchors = serde_json::from_str::<Vec<DiskLocalAddress>>(&anchors)?;


### PR DESCRIPTION
### What is this PR for?

This PR backports two dns seed related PRs to versions 0.7.x.

### What is the purpose of this pull request?

- [X] Bug fix;
- [ ] New feature;
- [ ] Docs update;
- [ ] Test;
- [ ] Other

### Which aspect of floresta its being addresed?

- [ ] Blockchain;
- [ ] Nodes communication;
- [ ] User consumption;
- [ ] Utreexo accumulator; 
- [ ] Other

### Checklists

- [X] I've signed all my commits;
- [X] I ran `just lint`;
- [X] I ran `cargo test`;
- [X] I checked the integration tests;
- [X] I'm linking the issue being fixed by this PR (if any).

### Description

Due to some peers in `mainnet-seeds.json` going offline, anyone running `0.7.0` or lower won't be able to connect. They will just stay stuck forever. #343 and #344 solves this on `master`, but this commit backports to our latest stable release, so we can make a new minor release fixing the problem.

### Notes to the reviewers

These are the exact same changes made by #343 and #344.

