### PR TITLE
add fuzz testing to ci-cd

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,127 @@
+name: Fuzz Tests
+
+on:
+  push:
+  pull_request:
+    branches: ["master"]
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_FUZZ_VERSION: 0.11.4
+  APT_CONFIG: |
+    Dir::Cache "./.apt-cache";
+    Dir::Cache::archives "./.apt-cache/archives";
+    Dir::State "./.apt-state";
+    Dir::State::lists "./.apt-state/lists/";
+
+jobs:
+  fuzz:
+    name: Run Fuzzing Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install latest nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      # Calculate cache keys
+      - name: Generate cache keys
+        id: cache-keys
+        run: |
+          YEAR=$(date +%Y)
+          BIWEEK=$(( ($(date +%U) + 1) / 2 ))
+          echo "CACHE_VERSION=${YEAR}(${BIWEEK})" >> $GITHUB_ENV
+          
+          # Hash of all files that could affect the build
+          HASH=$(echo "${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '.github/workflows/**') }}")
+          echo "BUILD_HASH=${HASH}" >> $GITHUB_ENV
+          
+          # Hash of apt packages we need
+          APT_PACKAGES="build-essential cmake clang"
+          echo "APT_HASH=$(echo $APT_PACKAGES | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+        shell: bash
+
+      # Restore Rust build cache
+      - name: Restore Rust cache
+        id: cache-rust
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/bin/cargo-fuzz
+            target/
+            fuzz/target/
+          key: ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-${{ env.BUILD_HASH }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ env.CACHE_VERSION }}-
+            ${{ runner.os }}-cargo-
+
+      # Restore apt packages cache
+      - name: Restore apt cache
+        id: cache-apt
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ./.apt-cache
+            ./.apt-state
+          key: ${{ runner.os }}-apt-${{ env.APT_HASH }}
+
+      # Install system dependencies only if cache miss
+      - name: Install libfuzzer dependencies
+        if: steps.cache-apt.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ./.apt-cache/archives ./.apt-state/lists
+          sudo -E apt-get update && sudo -E apt-get install -y build-essential cmake clang
+
+      # Install cargo-fuzz only if not found in cache
+      - name: Install cargo-fuzz
+        if: steps.cache-rust.outputs.cache-hit != 'true'
+        run: cargo install cargo-fuzz --locked --force
+
+      # Run fuzzing tests
+      - name: Run fuzzing tests
+        run: |
+          cd fuzz
+          echo "Available fuzz targets:"
+          cargo +nightly fuzz list
+          for target in $(cargo fuzz list); do
+            echo "Running fuzz target: $target"
+            cargo +nightly fuzz run $target -- -max_total_time=60
+          done
+
+      # Save Rust cache if there was no exact match
+      - name: Save Rust cache
+        if: success() && steps.cache-rust.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cargo/bin/cargo-fuzz
+            target/
+            fuzz/target/
+          key: ${{ steps.cache-rust.outputs.cache-primary-key }}
+
+      # Save apt cache if there was no exact match
+      - name: Save apt cache
+        if: success() && steps.cache-apt.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ./.apt-cache
+            ./.apt-state
+          key: ${{ runner.os }}-apt-${{ env.APT_HASH }}
+
+      # Upload artifacts (if crashes are found)
+      - name: Upload artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts
+          path: fuzz/artifacts


### PR DESCRIPTION
### What is this PR for?

This PR introduces automated fuzz testing to the CI/CD pipeline. Every pull request or push to the master branch will trigger all the fuzz tests located in the floresta-fuzz directory.

### What is the purpose of this pull request?

- [ ] Bug fix;
- [ ] New feature;
- [ ] Docs update;
- [x] Test;
- [ ] Other: <!-- Please describe it -->.

### Which aspect of floresta its being addresed?

- [ ] Blockchain;
- [ ] Nodes communication;
- [ ] User consumption;
- [ ] Utreexo accumulator; 
- [x] Other: <!-- Please describe it -->.

### Checklists

- [ ] I've signed all my commits;
- [ ] I ran `just lint`;
- [ ] I ran `cargo test`;
- [ ] I checked the integration tests;
- [x] I'm linking the issue being fixed by this PR (if any).

### Description

This PR addresses the addition of fuzz testing to the CI/CD pipeline, as outlined in issue #350. The goal is to enhance the robustness and reliability of the codebase by automatically running fuzz tests on every PR and push to the master branch.

### Notes to the reviewers
- Why Fuzz Testing? 

Fuzz testing is a powerful technique to uncover edge cases and potential vulnerabilities by providing random, invalid, or unexpected inputs to the system. Integrating it into the CI/CD pipeline ensures that these tests are run consistently, catching issues early in the development process.

- Implementation Details: 

The fuzz tests are located in the floresta-fuzz directory. The CI/CD pipeline has been updated to include a step that triggers these tests automatically.

- Impact: 
 
This change should not affect the existing functionality of the codebase but will help in identifying and fixing potential issues before they reach production.

