### PR TITLE
Fix release and PGP maintainer links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,7 +189,7 @@ pub fn validate_block_time(
 Security
 --------
 
-Given the critical nature of Floresta as a node implementation, we take security very serious. If you have any security vulnerability to report, please send it to `me AT dlsouza DOT lol` preferentially using my [PGP key `2C8E0F 836FD7D BBBB9E 9B2EF899 64EC3AB 22B2E3`](https://blog.dlsouza.lol/assets/pgp.asc).
+Given the critical nature of Floresta as a node implementation, we take security very serious. If you have any security vulnerability to report, please send it to `me AT dlsouza DOT lol` preferentially using my [PGP key `2C8E0F 836FD7D BBBB9E 9B2EF899 64EC3AB 22B2E3`](https://blog.dlsouza.lol/assets/gpg.asc).
 
 Testing
 -------

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you want to use `libfloresta` to build your own Bitcoin application, you can 
 ## Community
 
 If you want to discuss this project, you can join our Discord server [here](https://discord.gg/5Wj8fjjS93). If you want to disclose
-a security vulnerability, please email `Davidson Souza at me AT dlsouza DOT lol`, using the PGP key [`2C8E0F 836FD7D BBBB9E 9B2EF899 64EC3AB 22B2E3`](https://blog.dlsouza.lol/assets/pgp.asc).
+a security vulnerability, please email `Davidson Souza at me AT dlsouza DOT lol`, using the PGP key [`2C8E0F 836FD7D BBBB9E 9B2EF899 64EC3AB 22B2E3`](https://blog.dlsouza.lol/assets/gpg.asc).
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Welcome to Floresta, a lightweight Bitcoin full node implementation written in Rust, powered by [Utreexo](https://eprint.iacr.org/2019/611) a novel dynamic accumulator  designed for the Bitcoin UTXO set.
 
 This project is composed of two parts, `libfloresta` and `florestad`. `libfloresta` is
-a set of reusable components that can be used to build Bitcoin applications. `florestad` is built on top of `libfloresta` to provide a full node implementation, including a watch-only wallet and an Electrum server. If you just want to run a full node, you can use `florestad` directly, either by building it from source or by downloading a pre-built binary from the [releases](https://github.com/vinteumorg/Floresta/releases/tag/v0.4.0).
+a set of reusable components that can be used to build Bitcoin applications. `florestad` is built on top of `libfloresta` to provide a full node implementation, including a watch-only wallet and an Electrum server. If you just want to run a full node, you can use `florestad` directly, either by building it from source or by downloading a pre-built binary from the [releases](https://github.com/vinteumorg/Floresta/releases/latest).
 
 If you want to use `libfloresta` to build your own Bitcoin application, you can find the documentation [here](https://docs.getfloresta.sh/floresta/).
 


### PR DESCRIPTION
### What is this PR for?

This PR fixes issue  https://github.com/vinteumorg/Floresta/issues/354

### What is the purpose of this pull request?

- [ ] Bug fix;
- [ ] New feature;
- [x] Docs update;
- [ ] Test;
- [ ] Other: <!-- Please describe it -->.

### Which aspect of floresta its being addresed?

- [ ] Blockchain;
- [ ] Nodes communication;
- [ ] User consumption;
- [ ] Utreexo accumulator; 
- [ ] Other: .

### Checklists

- [x] I've signed all my commits;
- [x] I ran `just lint`;
- [x] I ran `cargo test`;
- [x] I checked the integration tests;
- [ ] I'm linking the issue being fixed by this PR (if any).

### Description

The README.md and CONTRIBUTING.md need a little fix in some links. Both either point to wrong or invalid resources.

### Notes to the reviewers

In the introductory section of README.md, the pre-built binaries link was pointing to version `v0.4.0` and the current version is `0.7.0`.

It would be better to have a dynamic pointing to releases using github's `/releases/latest` endpoint.

The maintainer PGP key link pointee to a invalid link (blog.dlsouzadot.lol/assets/pgp.asc give a 404 HTTP error).

This PR simple changes `pgp.asc` to `gpg.asc` in the refered link in both README.md and CONTRIBUTING.md.
