### PR TITLE
doc: make template more concise, add ref to CONTRIBUTING.md on template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,13 +8,13 @@ assignees: ''
 ---
 
 **Describe the bug**  
-<!-- A clear and concise description of what the bug is. -->
+<!-- A clear and concise description of what the bug is -->
 
-**To Reproduce**  
-<!-- Steps or code to reproduce the behavior. -->
+**Steps to Reproduce**  
+<!-- Steps or code to reproduce the behavior -->
 
 **Expected behavior**  
-<!-- A clear and concise description of what you expected to happen. -->
+<!-- A clear and concise description of what you expected to happen -->
 
 **Build environment**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,37 @@
-### What is this PR for?
-
-This PR fixes issue  <!-- insert the issue link or #<issue number> -->
-
 ### What is the purpose of this pull request?
 
-- [ ] Bug fix;
-- [ ] New feature;
-- [ ] Docs update;
-- [ ] Test;
+- [ ] Bug fix
+- [ ] Documentation update
+- [ ] New feature
+- [ ] Test
+- [ ] Other: <!-- Please describe it -->
+
+### Which crates are being modified?
+
+- [ ] floresta-chain
+- [ ] floresta-cli
+- [ ] floresta-common
+- [ ] floresta-compact-filters
+- [ ] floresta-electrum
+- [ ] floresta-watch-only
+- [ ] floresta-wire
+- [ ] floresta
+- [ ] florestad
 - [ ] Other: <!-- Please describe it -->.
-
-### Which aspect of floresta its being addresed?
-
-- [ ] Blockchain;
-- [ ] Nodes communication;
-- [ ] User consumption;
-- [ ] Utreexo accumulator; 
-- [ ] Other: <!-- Please describe it -->.
-
-### Checklists
-
-- [ ] I've signed all my commits;
-- [ ] I ran `just lint`;
-- [ ] I ran `cargo test`;
-- [ ] I checked the integration tests;
-- [ ] I'm linking the issue being fixed by this PR (if any).
 
 ### Description
 
-<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
+<!-- Describe the purpose of this PR, what's being adding and/or fixed. If there is an open issue for it, link it here -->
 
 ### Notes to the reviewers
 
 <!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->
 
+### Checklist
 
+- [ ] I've signed all my commits
+- [ ] I ran `just lint`
+- [ ] I ran `cargo test`
+- [ ] I've checked the integration tests
+- [ ] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
+- [ ] I'm linking the issue being fixed by this PR (if any)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,16 +45,17 @@ messages follow the ["Conventional Commits 1.0.0"](https://www.conventionalcommi
 Peer review
 -----------
 
-To make sure our code has the highest quality and is maintainable for the posterity, we have a thorough peer review process, where pull requests needs to be reviewed by at least one maintainer, and must not have any outstanding comment from regular contributors.
+To make sure our code has the highest quality and is maintainable for posterity, we have a thorough peer review process, where pull requests need to be reviewed by at least one maintainer, and must not have any outstanding comment from regular contributors.
 
-We welcome everyone to review and give their feedbacks on changes to Floresta. The conventions on how to communicate in a code review are based on[Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/v23.0/CONTRIBUTING.md#peer-review)
+We welcome everyone to review and give their feedback on changes to Floresta. The conventions on how to communicate in a code review are based on [Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/v23.0/CONTRIBUTING.md#peer-review)
 
 ### Conceptual Review
 
-A review can be a conceptual review, where the reviewer leaves a comment
+A review can be a conceptual review, where the reviewer leaves a comment:
 
-Concept (N)ACK, meaning "I do (not) agree with the general goal of this pull request",
-Approach (N)ACK, meaning Concept ACK, but "I do (not) agree with the approach of this change".
+- Concept (N)ACK: "I do (not) agree with the general goal of this pull request",
+- Approach (N)ACK: Concept (N)ACK, but "I do (not) agree with the approach of this change".
+
 A NACK needs to include a rationale why the change is not worthwhile. NACKs without accompanying reasoning may be disregarded.
 
 ### Code Review


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [X] Other: not a crate: `.github/`

### Description

Made the PR template cleaner: the description section should be enough (`Which aspect of floresta its being addresed?` is redundant).

Added CONTRIBUTING.md to checklist section

Fixed typos on CONTIBUTING.md

### Checklist

- [X] I've signed all my commits
- [ ] I ran `just lint`
- [ ] I ran `cargo test`
- [ ] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)

PS: this PR is using the new template
