### PR TITLE
fix(florestad): don't panic if a lock cannot be obtained to the datadir, RPC and Electrum ports

### DIFF
--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -691,9 +691,16 @@ impl RpcImpl {
                 .unwrap()
         });
 
-        let listener = tokio::net::TcpListener::bind(address)
-            .await
-            .expect("failed to bind rpc server");
+        let listener = match tokio::net::TcpListener::bind(address).await {
+            Ok(listener) => listener,
+            Err(_) => {
+                error!(
+                    "Failed to bind to address {}. Floresta is probably already running.",
+                    address
+                );
+                std::process::exit(-1);
+            }
+        };
 
         let router = Router::new()
             .route("/", post(json_rpc_request).get(cannot_get))


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->.

### Description
This PR handles errors when trying to bind to already already bound resources (datadir, RPC and Electrum ports).

It logs an error! and then exits via `std::process::exit(1)`:
```
$ ./target/debug/florestad
[2025-02-04 09:59:04 ERROR florestad::florestad] Cannot obtain a lock on data directory $HOME/.floresta/. Floresta is probably already running.
```

If using another datadir:
```
$ ./target/debug/florestad --data-dir=data
[2025-02-04 09:59:13 INFO florestad::florestad] Starting server
[2025-02-04 09:59:13 WARN florestad::florestad] Failed to load SSL certificates, ignoring SSL
[2025-02-04 09:59:13 ERROR florestad::florestad] Failed to bind to address 0.0.0.0:50001. There is probably an Electrum server already running.
```

### Notes to the reviewers

Two tests fail when running `cargo test`, but they are also failing on master:
```console
failures:

---- tests::test_get_height stdout ----
thread 'tests::test_get_height' panicked at crates/floresta-cli/src/lib.rs:216:47:
called `Result::unwrap()` on an `Err` value: JsonRpc(Rpc(RpcError { code: -32601, message: "Method not found", data: None }))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::test_stop stdout ----
thread 'tests::test_stop' panicked at crates/floresta-cli/src/lib.rs:142:34:
rpc not working: JsonRpc(Json(Error("invalid type: boolean `true`, expected a string", line: 1, column: 4)))
```


### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [ ] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
