### PR TITLE
code quality- Fixing serde clippy warning

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -50,7 +50,7 @@ const PING_TIMEOUT: u64 = 30;
 /// If the last message we've got was more than XX, send out a ping
 const SEND_PING_TIMEOUT: u64 = 60;
 /// The inv element type for a utreexo block with witness data
-const INV_UTREEXO_BLOCK: u32 = 0x40000002 | 1 << 24;
+const INV_UTREEXO_BLOCK: u32 = 0x40000002 | (1 << 24);
 
 #[derive(Debug, PartialEq)]
 enum State {

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -55,7 +55,6 @@ impl NodeContext for SyncNode {
 
 /// Node methods for a [`UtreexoNode`] where its Context is a [`SyncNode`].
 /// See [node](crates/floresta-wire/src/p2p_wire/node.rs) for more information.
-
 impl<Chain> UtreexoNode<Chain, SyncNode>
 where
     WireError: From<<Chain as BlockchainInterface>::Error>,

--- a/florestad/src/slip132.rs
+++ b/florestad/src/slip132.rs
@@ -14,6 +14,8 @@ use bitcoin::base58;
 use bitcoin::bip32;
 use bitcoin::bip32::Xpriv;
 use bitcoin::bip32::Xpub;
+use serde::Deserialize;
+use serde::Serialize;
 
 /// Magical version bytes for xpub: bitcoin mainnet public key for P2PKH or P2SH
 pub const VERSION_MAGIC_XPUB: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
@@ -147,36 +149,31 @@ pub struct DefaultResolver;
 
 /// SLIP 132-defined key applications defining types of scriptPubkey descriptors
 /// in which they can be used
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_crate")
-)]
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum KeyApplication {
     /// xprv/xpub: keys that can be used for P2PKH and multisig P2SH
     /// scriptPubkey descriptors.
-    #[cfg_attr(feature = "serde", serde(rename = "bip44"))]
+    #[serde(rename = "bip44")]
     Hashed,
 
     /// zprv/zpub: keys that can be used for P2WPKH scriptPubkey descriptors
-    #[cfg_attr(feature = "serde", serde(rename = "bip84"))]
+    #[serde(rename = "bip84")]
     SegWit,
 
     /// Zprv/Zpub: keys that can be used for multisig P2WSH scriptPubkey
     /// descriptors
-    #[cfg_attr(feature = "serde", serde(rename = "bip48-native"))]
+    #[serde(rename = "bip48-native")]
     SegWitMultisig,
 
     /// yprv/ypub: keys that can be used for P2WPKH-in-P2SH scriptPubkey
     /// descriptors
-    #[cfg_attr(feature = "serde", serde(rename = "bip49"))]
+    #[serde(rename = "bip49")]
     Nested,
 
     /// Yprv/Ypub: keys that can be used for multisig P2WSH-in-P2SH
     /// scriptPubkey descriptors
-    #[cfg_attr(feature = "serde", serde(rename = "bip48-nested"))]
+    #[serde(rename = "bip48-nested")]
     NestedMultisig,
 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?
This PR fixed issue #361 part 2 fixing serde clippy warning.


- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Code Quality

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: 

### Description

The purpose of PR is to fix clippy warning related to serde in slip132 and improving code quality along with applying fix to empty line.


### Notes to the reviewers

As per recommendation the serde import can be simplified, and serde is always available so we can have a direct way by importing. 
Simplifying serde in [slip132.rs]

Fix the clippy warning - 
```consider parenthesizing your expression: `0x40000002 | (1 << 24)`  ```
```empty line after doc comment```

### Checklist

- [ ] I've signed all my commits
- [x] I ran `just lint`
- [x] I ran `cargo test`
- [x] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
