### PR TITLE
code quality:Fix code simplification clippy warnings

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -227,7 +227,7 @@ where
             .fixed_peer
             .as_ref()
             .map(|address| {
-                Self::resolve_connect_host(&address, Self::get_port(config.network.into()))
+                Self::resolve_connect_host(address, Self::get_port(config.network.into()))
             })
             .transpose()?;
 

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -28,11 +28,14 @@ use crate::p2p_wire::node::ConnectionKind;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
 use crate::UtreexoNodeConfig;
+
 /// A list of headers, used to represent the collection of headers.
 pub type HeaderList = Vec<Header>;
+
 /// A map that associates block hashes with their corresponding `UtreexoBlock` objects.
 /// This is useful for efficiently looking up blocks by their hash.
 pub type BlockHashMap = HashMap<BlockHash, UtreexoBlock>;
+
 /// A map of block hashes to raw block data (represented as bytes vector).
 pub type BlockDataMap = HashMap<BlockHash, Vec<u8>>;
 
@@ -42,6 +45,7 @@ pub struct Essentials {
     pub blocks: BlockHashMap,
     pub invalid_block: UtreexoBlock,
 }
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct UtreexoRoots {
     roots: Option<Vec<String>>,


### PR DESCRIPTION
### What is the purpose of this pull request?
This PR is realted to #358 . Fixing and removing remaining code simplification clippy warnings.

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other:Code Quality

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed. If there is an open issue for it, link it here -->
Fixing and removing remaing code simplification clippy warnings.
No clippy warning can be seen now

Created type aliase ```type PeerData = (HeaderList, BlockHashMap, BlockDataMap);```  for ```very complex type used``` warning.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Checklist

- [x] I've signed all my commits
- [x] I ran `just lint`
- [x] I ran `cargo test`
- [x] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
