### PR TITLE
build: also install floresta-cli to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ and build with cargo build
 
 ```bash
 cargo build --release
-# Optionally, you can add florestad to the path with
+
+# Optionally, you can add florestad and floresta-cli to the path with
 cargo install --path ./florestad
+cargo install --path ./crates/floresta-cli
 ```
 
 ### Instructions for macOS Users


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: build

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->

### Description

`cargo install --path ./florestad` now also installs `floresta-cli` to the path

### Notes to the reviewers

N/A

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [ ] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
