### PR TITLE
[Fix] Import sync_node and chain_selector

### DIFF
--- a/crates/floresta-wire/src/lib.rs
+++ b/crates/floresta-wire/src/lib.rs
@@ -18,6 +18,8 @@ use bitcoin::Transaction;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::address_man;
 #[cfg(not(target_arch = "wasm32"))]
+pub use p2p_wire::chain_selector;
+#[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::mempool;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::node;
@@ -27,6 +29,8 @@ pub use p2p_wire::node_context;
 pub use p2p_wire::node_interface;
 #[cfg(not(target_arch = "wasm32"))]
 pub use p2p_wire::running_node;
+#[cfg(not(target_arch = "wasm32"))]
+pub use p2p_wire::sync_node;
 pub use p2p_wire::UtreexoNodeConfig;
 /// NodeHooks is a trait that defines the hooks that a node can use to interact with the network
 /// and the blockchain. Every time an event happens, the node will call the corresponding hook.

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -209,7 +209,18 @@ pub struct NodeCommon<Chain: BlockchainInterface + UpdatableChainstate> {
     pub(crate) kill_signal: Arc<tokio::sync::RwLock<bool>>,
 }
 
-pub struct UtreexoNode<Chain: BlockchainInterface + UpdatableChainstate, Context> {
+/// The main node that operates while florestad is up.
+///
+/// [`UtreexoNode`] aims to be modular where `Chain` can be any implementation
+/// of a [`BlockchainInterface`] and [`UpdatableChainstate`].
+///
+/// `Context` refers to which state the [`UtreexoNode`] is on, being
+/// [`RunningNode`], [`SyncNode`], and [`ChainSelector`]. Defaults to
+/// [`RunningNode`] which automatically transitions between contexts.
+///
+/// [`SyncNode`]: super::sync_node::SyncNode
+/// [`ChainSelector`]: super::chain_selector::ChainSelector
+pub struct UtreexoNode<Chain: BlockchainInterface + UpdatableChainstate, Context = RunningNode> {
     pub(crate) common: NodeCommon<Chain>,
     pub(crate) context: Context,
 }

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -1,3 +1,6 @@
+//! node_interface, which holds [`NodeInterface`] and related methods
+//! that define the API to interact with the floresta node
+
 use std::net::IpAddr;
 use std::time::Instant;
 
@@ -96,9 +99,7 @@ impl NodeInterface {
 
         rx.await
     }
-}
 
-impl NodeInterface {
     /// Connects to a specified address and port.
     ///
     /// This function will return a boolean indicating whether the connection was successful. It

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -1,6 +1,6 @@
-/// After a node catches-up with the network, we can start listening for new blocks, handing any
-/// request our user might make and keep our peers alive. This mode requires way less bandwidth and
-/// CPU to run, being bound by the number of blocks found in a given period.
+//! After a node catches-up with the network, we can start listening for new blocks, handing any
+//! request our user might make and keep our peers alive. This mode requires way less bandwidth and
+//! CPU to run, being bound by the number of blocks found in a given period.
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::time::Duration;


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [X] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

This Changes only add `sync_node` and `chain_selector` to `lib.rs` of `crates/floresta-wire/src/lib.rs` so them can be detected by docs.

### Notes to the reviewers

it was 

![image](https://github.com/user-attachments/assets/e010176a-20f5-47df-9075-d5f72cad757f)

and you can see the difference running `cargo doc --open` in 3aa72032a78ade5ea728546e6fc7c887c0c7b462

### Checklist

- [X] I've signed all my commits
- [ ] I ran `just lint`
- [ ] I ran `cargo test`
- [ ] I've checked the integration tests
- [ ] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
