### PR TITLE
Refactor `consensus.rs` error mapping

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -50,6 +50,22 @@ pub enum BlockValidationErrors {
     CoinbaseNotMatured,
 }
 
+// Helpful macro for generating a TransactionError
+macro_rules! tx_err {
+    ($txid_fn:expr, $variant:ident, $msg:expr) => {
+        TransactionError {
+            txid: ($txid_fn)(),
+            error: BlockValidationErrors::$variant($msg.into()),
+        }
+    };
+    ($txid_fn:expr, $variant:ident) => {
+        TransactionError {
+            txid: ($txid_fn)(),
+            error: BlockValidationErrors::$variant,
+        }
+    };
+}
+
 impl Display for TransactionError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Transaction {} is invalid: {}", self.txid, self.error)

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -4,8 +4,9 @@ pub mod chain_state;
 pub mod chain_state_builder;
 pub mod chainparams;
 pub mod chainstore;
-pub mod consensus;
+#[macro_use]
 pub mod error;
+pub mod consensus;
 pub mod partial_chain;
 pub mod udata;
 


### PR DESCRIPTION
I have created a `tx_err` macro to succinctly build a `TransactionError`. This has the benefit of skipping the `BlockValidationErrors::` enum prefix when specifying the error, and flexibly taking a third argument for the inner variant value.

Instead of:

```rust
return Err(TransactionError {
    txid: transaction.compute_txid(),
    error: BlockValidationErrors::NotEnoughMoney,
}
.into());
```

We do:

```rust
return Err(tx_err!(txid, NotEnoughMoney))?;
```

The validation methods now directly return `TransactionError` and use a lazily evaluated closure to compute the `txid` if there's an error.

The `pub mod error` line is now before `pub mod consensus` to make the macro available. Finally changed the "Invalid coinbase txid" error message to "Invalid Coinbase PrevOut".

This reduces the error mapping boilerplate in the most important consensus function.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Refactor and simplification

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.