### PR TITLE
Make CI fail on clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ jobs:
         run: cargo +nightly fmt --all --check
 
       - name: Run cargo clippy
-        run: cargo +nightly clippy --all-targets
+        run: cargo +nightly clippy --all-targets -- -D warnings
 
   cross-testing:
     strategy:

--- a/crates/floresta-watch-only/src/merkle.rs
+++ b/crates/floresta-watch-only/src/merkle.rs
@@ -120,7 +120,8 @@ impl MerkleProof {
         let pairs = if node_count % 2 == 0 {
             node_count / 2
         } else {
-            (node_count + 1) / 2
+            // (node_count + 1) / 2
+            node_count.div_ceil(2)
         };
 
         for idx in 0..pairs {

--- a/crates/floresta-wire/src/p2p_wire/node_context.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_context.rs
@@ -8,16 +8,21 @@
 //! parameter by the caller.
 //!
 //! The three flavors of node are:
-//!  - ChainSelector: This finds the best PoW chain, by downloading multiple candidates and taking
-//!                   the one with more PoW. It should do it's job quickly, as it blocks our main
-//!                   client and can't proceed without this information.
-//!  - SyncNode: Used to download and verify all blocks in a chain. This is computationally
-//!              expensive and may take a while to run. After this ends it's job, it gives us 100%
-//!              centanty that this chain is valid.
-//!  - Running Node: This is the one that users interacts with, and should be the one running most
-//!                  of the time. This node is started right after `ChainSelector` returns, and
-//!                  will handle new blocks (even if `SyncNode` haven't returned) and handle
-//!                  requests by users.
+//!  - ChainSelector:
+//!    This finds the best PoW chain, by downloading multiple candidates and taking
+//!    the one with more PoW. It should do its job quickly, as it blocks our main
+//!    client and can't proceed without this information.
+//!
+//!  - SyncNode:
+//!    Used to download and verify all blocks in a chain. This is computationally
+//!    expensive and may take a while to run. After this ends its job, it gives us 100%
+//!    certainty that this chain is valid.
+//!
+//!  - Running Node:
+//!    This is the one that users interacts with, and should be the one running most
+//!    of the time. This node is started right after `ChainSelector` returns, and
+//!    will handle new blocks (even if `SyncNode` haven't returned) and handle
+//!    requests by users.
 
 use bitcoin::p2p::ServiceFlags;
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: CI

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [x] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: .github/

### Description

I have fixed the remaining clippy warnings, and now CI fails if there are any. If new nightly clippy issues are added over time our CI will fail (unrelated to the specific PR) but I guess it is fine as it notifies us the new recommendations.