### PR TITLE
build: ensure dev tools available on PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
 
         libsDarwin = with pkgs.darwin.apple_sdk.frameworks; lib.optionals (system == "x86_64-darwin" || system == "aarch64-darwin") [ Security ];
 
-        #This is the dev tools used while developing in Floresta.
+        # This is the dev tools used while developing in Floresta.
         devTools = with pkgs; [
           rustup
           just
@@ -116,7 +116,7 @@
             in
             mkShell {
               inherit buildInputs;
-              inherit devTools;
+              nativeBuildInputs = devTools;
 
               shellHook = ''
                 		${ _shellHook}


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Developer environment

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: None

### Description

I noticed that the developer tools are not being added to the default developer shell. I solved this by adding them to `nativeBuildInputs`, but I am relatively new to nix and am not sure this is the best pattern.

### Checklist

- [x] I've signed all my commits
- [ ] I ran `just lint`
- [ ] I ran `cargo test`
- [ ] I've checked the integration tests
- [ ] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
