### PR TITLE
Simplify hash and error conversions

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -84,10 +84,9 @@ impl ChainParams {
         let genesis = genesis_block(Params::new(network.into()));
         match network {
             Network::Bitcoin => AssumeUtreexoValue {
-                block_hash: BlockHash::from_str(
-                    "00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9",
-                )
-                .unwrap(),
+                block_hash: "00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9"
+                    .parse()
+                    .unwrap(),
                 height: 855571,
                 roots: [
                     "4dcc014cc23611dda2dcf0f34a3e62e7d302146df4b0b01ac701d440358c19d6",
@@ -108,9 +107,8 @@ impl ChainParams {
                     "67ba89afe6bce9bafbf0b88013e4446c861e6c746e291c3921e0b65c93671ba3",
                     "972ea2c7472c22e4eab49e9c2db5757a048b271b6251883ce89ccfeaa38b47ab",
                 ]
-                .into_iter()
-                .map(|x| BitcoinNodeHash::from_str(x).unwrap())
-                .collect(),
+                .map(|s| s.parse().unwrap())
+                .to_vec(),
                 leaves: 2587882501,
             },
             Network::Testnet => AssumeUtreexoValue {

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -19,7 +19,6 @@ use bitcoin::TxIn;
 use bitcoin::TxOut;
 use bitcoin::Txid;
 use floresta_common::prelude::*;
-use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use rustreexo::accumulator::proof::Proof;
 use rustreexo::accumulator::stump::Stump;
 
@@ -258,10 +257,8 @@ impl Consensus {
         del_hashes: Vec<sha256::Hash>,
     ) -> Result<Stump, BlockchainError> {
         let block_hash = block.block_hash();
-        let del_hashes = del_hashes
-            .iter()
-            .map(|hash| BitcoinNodeHash::from(hash.as_byte_array()))
-            .collect::<Vec<_>>();
+        // Convert to BitcoinNodeHashes, from rustreexo
+        let del_hashes: Vec<_> = del_hashes.into_iter().map(Into::into).collect();
 
         let adds = udata::proof_util::get_block_adds(block, height, block_hash);
 

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -421,16 +421,13 @@ pub mod proof_util {
                 if !is_unspendable(&output.script_pubkey)
                     && !block_inputs.contains(&(transaction.compute_txid(), i as u32))
                 {
-                    leaf_hashes.push(get_leaf_hashes(transaction, i as u32, height, block_hash))
+                    leaf_hashes
+                        .push(get_leaf_hashes(transaction, i as u32, height, block_hash).into())
                 }
             }
         }
 
-        // Convert the leaf hashes to NodeHashes used in Rustreexo
         leaf_hashes
-            .iter()
-            .map(|&hash| BitcoinNodeHash::from(hash.as_byte_array()))
-            .collect()
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/floresta-wire/src/p2p_wire/mempool.rs
+++ b/crates/floresta-wire/src/p2p_wire/mempool.rs
@@ -906,9 +906,8 @@ mod tests {
             "6096c8421c1f86a9caa26e972dccdb964e280164fb060a576d51f5844e259569",
             "fd46029ebb0c19e2d468a9b24d20519c64ccc342e6a32b95c86a57489b6d2504",
         ]
-        .into_iter()
-        .map(|x| BitcoinNodeHash::from_str(x).unwrap())
-        .collect::<Vec<BitcoinNodeHash>>();
+        .map(|s| s.parse().unwrap())
+        .to_vec();
 
         let acc = Pollard::from_roots(roots, 169);
         let proof_hashes = [
@@ -920,15 +919,12 @@ mod tests {
             "15aba691713052033954935777d8089f4ca6b0573c7ad89fe1d0d85bbbe21846",
             "8f22055465f568fd2bf9d19b285fcf2539ffea59a3cb096a3a0645366adea1b0",
         ]
-        .into_iter()
-        .map(|x| BitcoinNodeHash::from_str(x).unwrap())
-        .collect::<Vec<BitcoinNodeHash>>();
+        .map(|s| s.parse().unwrap())
+        .to_vec();
 
         let proof = Proof::new(vec![8], proof_hashes);
         let del_hashes = ["427aceafd82c11cb53a2b78f408ece6fcacf2a5b9feb5fc45cdcf36627d68d76"]
-            .into_iter()
-            .map(|x| BitcoinNodeHash::from_str(x).unwrap())
-            .collect::<Vec<BitcoinNodeHash>>();
+            .map(|s| s.parse().unwrap());
 
         let prevout: LeafData = deserialize_hex("0508085c47cc849eb80ea905cc7800a3be674ffc57263cf210c59d8d00000000c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd3704000000001300000000f2052a0100000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac").unwrap();
 

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 use std::time::Instant;
 
 use bitcoin::bip158::BlockFilter;
-use bitcoin::hashes::Hash;
 use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::message_blockdata::Inventory;
@@ -718,10 +717,8 @@ where
             }
 
             if !self.chain.is_in_idb() {
-                let del_hashes: Vec<BitcoinNodeHash> = del_hashes
-                    .iter()
-                    .map(|hash| BitcoinNodeHash::from(hash.as_byte_array()))
-                    .collect();
+                // Convert to BitcoinNodeHashes, from rustreexo
+                let del_hashes: Vec<_> = del_hashes.into_iter().map(Into::into).collect();
 
                 let block_height = self
                     .chain


### PR DESCRIPTION
### Description

Since `BitcoinNodeHash` implements `From<bitcoin_hashes::sha256::Hash>`, we can directly apply `Into::into`. Then for str conversions we can use `parse` instead, and map the arrays directly.

Finally in `chain_state.rs` and `partial_chain.rs` I simplify `BlockchainError::BlockValidation` conversions with `?`.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Simplification

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.