### PR TITLE
consensus: fix a problem with script sizes

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -106,13 +106,12 @@ impl Consensus {
                 continue;
             }
 
-            // Sum tx output amounts, check their locking script sizes (scriptpubkey)
-            let mut out_value = 0;
-            for output in transaction.output.iter() {
-                out_value += output.value.to_sat();
-
-                Self::validate_script_size(&output.script_pubkey, txid)?;
-            }
+            // Sum tx output amounts. This will be used for the fee calculation
+            let out_value: u64 = transaction
+                .output
+                .iter()
+                .map(|out| out.value.to_sat())
+                .sum();
 
             // Sum tx input amounts, check their unlocking script sizes (scriptsig and TODO witness)
             let mut in_value = 0;


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

A output's script may be bigger than 10k bytes, it just can't be spent. We incorrectly check the script pubkey size when it gets created, causing floresta to break out of consensus if such an output is mined.

Fixes #393

### Notes to the reviewers

Tests for this will be integrated on #387

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I'm linking the issue being fixed by this PR (if any)
