### PR TITLE
Added test for getblockheader JSONRPC call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ example-test = "python tests/run_tests.py --test-name example_test"
 restart-test = "python tests/run_tests.py --test-name restart"
 florestacli-getblockchaininfo-test = "python tests/run_tests.py --test-name floresta_cli_getblockchaininfo"
 florestacli-getblockhash-test = "python tests/run_tests.py --test-name floresta_cli_getblockhash"
+florestacli-getblockheader-test = "python tests/run_tests.py --test-name floresta_cli_getblockheader"
 florestacli-getblock-test = "python tests/run_tests.py --test-name floresta_cli_getblock"
 florestacli-getpeerinfo-test = "python tests/run_tests.py --test-name floresta_cli_getpeerinfo"
 florestacli-addnode-test = "python tests/run_tests.py --test-name floresta_cli_addnode"
@@ -49,6 +50,7 @@ tests = [
   "restart-test",
   "florestacli-getblockchaininfo-test",
   "florestacli-getblockhash-test",
+  "florestacli-getblockheader-test",
   "florestacli-getblock-test",
   "florestacli-getpeerinfo-test",
   "florestacli-addnode-test",

--- a/tests/floresta_cli_getblockheader.py
+++ b/tests/floresta_cli_getblockheader.py
@@ -1,0 +1,69 @@
+"""
+floresta_cli_getblockheader.py
+
+This functional test cli utility to interact with a Floresta node with `getblockheader`
+"""
+
+from test_framework.test_framework import FlorestaTestFramework
+from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+
+
+class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
+    """
+    Test `getblockheader` with a fresh node and expect a result like this:
+    
+    ````bash
+    $> ./target/release floresta_cli --network=regtest getblockheader \
+        0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+    {
+       "version": 1,
+       "prev_blockhash": "0000000000000000000000000000000000000000000000000000000000000000",
+       "merkle_root": "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+       "time": 1296688602,
+       "bits": 545259519,
+       "nonce": 2
+    }
+    ```
+    """
+
+    nodes = [-1]
+    version = 1
+    blockhash = "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
+    prev_blockhash = "0000000000000000000000000000000000000000000000000000000000000000"
+    merkle_root = "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+    time = 1296688602
+    bits = 545259519
+    nonce = 2
+
+    def set_test_params(self):
+        """
+        Setup a single node
+        """
+        GetBlockheaderHeightZeroTest.nodes[0] = self.add_node_settings(
+            chain="regtest", extra_args=[], rpcserver=REGTEST_RPC_SERVER
+        )
+
+    def run_test(self):
+        """
+        Run JSONRPC and get the header of the genesis block
+        """
+        # Start node
+        self.run_node(GetBlockheaderHeightZeroTest.nodes[0])
+        self.wait_for_rpc_connection(GetBlockheaderHeightZeroTest.nodes[0])
+
+        # Test assertions
+        node = self.get_node(GetBlockheaderHeightZeroTest.nodes[0])
+        response = node.get_blockheader(GetBlockheaderHeightZeroTest.blockhash)
+        assert response["version"] == GetBlockheaderHeightZeroTest.version
+        assert response["prev_blockhash"] == GetBlockheaderHeightZeroTest.prev_blockhash
+        assert response["merkle_root"] == GetBlockheaderHeightZeroTest.merkle_root
+        assert response["time"] == GetBlockheaderHeightZeroTest.time
+        assert response["bits"] == GetBlockheaderHeightZeroTest.bits
+        assert response["nonce"] == GetBlockheaderHeightZeroTest.nonce
+
+        # Shutdown node
+        self.stop_node(GetBlockheaderHeightZeroTest.nodes[0])
+
+
+if __name__ == "__main__":
+    GetBlockheaderHeightZeroTest().main()

--- a/tests/test_framework/floresta_rpc.py
+++ b/tests/test_framework/floresta_rpc.py
@@ -224,6 +224,16 @@ class FlorestaRPC:
         """
         return self.perform_request("getblockhash", params=[height])
 
+    def get_blockheader(self, blockhash: str) -> dict:
+        """
+        Get the header of a block, giving its hash performing
+        `perform_request('getblockheader', params=[<str>])`
+        """
+        if not bool(re.fullmatch(r"^[a-f0-9]{64}$", blockhash)):
+            raise ValueError(f"Invalid blockhash '{blockhash}'.")
+
+        return self.perform_request("getblockheader", params=[blockhash])
+
     def get_block(self, blockhash: str, verbosity: int = 1):
         """
         Get a full block, given its hash performing


### PR DESCRIPTION
Add a test for #252

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

This PR add a structure to test calls of `getblockheader` in `tests/test_framework/floresta_rpc.py`, a simple test in `tests/floresta_cli_getblockheader.py` and a helper in pyproject.toml as `florestacli-getblockheader-test`.

This simple test just call the `getblockheader` with the hash of regtest's genesis block and expect, among some data, a prev_blockhash full of zeros.

### Notes to the reviewers

It's important to note that this PR can be closely related to PR [#391](https://github.com/vinteumorg/Floresta/pull/391).

### Checklist

- [x] I've signed all my commits
- [ ] I ran `just lint`
- [ ] I ran `cargo test`
- [ ] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
