### PR TITLE
wire: make all nodes reply to user requests

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -51,12 +51,14 @@ use std::time::Instant;
 
 use bitcoin::block::Header;
 use bitcoin::consensus::deserialize;
+use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
 use floresta_chain::pruned_utreexo::BlockchainInterface;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
 use floresta_chain::UtreexoBlock;
 use floresta_common::service_flags;
+use log::debug;
 use log::info;
 use log::warn;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
@@ -66,6 +68,7 @@ use tokio::time::timeout;
 
 use super::error::WireError;
 use super::node::PeerStatus;
+use super::node_interface::UserRequest;
 use super::peer::PeerMessages;
 use crate::address_man::AddressState;
 use crate::node::periodic_job;
@@ -76,6 +79,7 @@ use crate::node::NodeRequest;
 use crate::node::UtreexoNode;
 use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
+use crate::node_interface::NodeResponse;
 
 #[derive(Debug, Default, Clone)]
 /// A p2p driver that attempts to connect with multiple peers, ask which chain are them following
@@ -645,6 +649,11 @@ where
                         .insert(InflightRequests::Headers, (new_sync_peer, Instant::now()));
                 }
             }
+
+            if let InflightRequests::UserRequest(req) = request {
+                self.user_requests.send_answer(req, None);
+            }
+
             self.inflight.remove(&request);
         }
 
@@ -689,6 +698,8 @@ where
             {
                 try_and_log!(self.handle_notification(notification).await);
             }
+
+            try_and_log!(self.handle_user_request().await);
 
             periodic_job!(
                 self.maybe_open_connection().await,
@@ -842,6 +853,45 @@ where
             PeerMessages::Addr(addresses) => {
                 let addresses: Vec<_> = addresses.iter().cloned().map(|addr| addr.into()).collect();
                 self.address_man.push_addresses(&addresses);
+            }
+
+            PeerMessages::Block(block) => {
+                if self.check_is_user_block_and_reply(block).await?.is_some() {
+                    log::error!("peer {peer} sent us a block we didn't request");
+                    self.increase_banscore(peer, 5).await?;
+                }
+            }
+
+            PeerMessages::NotFound(inv) => match inv {
+                Inventory::Error => {}
+                Inventory::Block(block)
+                | Inventory::WitnessBlock(block)
+                | Inventory::CompactBlock(block) => {
+                    self.user_requests
+                        .send_answer(UserRequest::Block(block), None);
+                }
+
+                Inventory::WitnessTransaction(tx) | Inventory::Transaction(tx) => {
+                    self.user_requests
+                        .send_answer(UserRequest::MempoolTransaction(tx), None);
+                }
+                _ => {}
+            },
+
+            PeerMessages::Transaction(tx) => {
+                debug!("saw a mempool transaction with txid={}", tx.compute_txid());
+                self.user_requests.send_answer(
+                    UserRequest::MempoolTransaction(tx.compute_txid()),
+                    Some(NodeResponse::MempoolTransaction(tx)),
+                );
+            }
+
+            PeerMessages::UtreexoState(_) => {
+                warn!(
+                    "Utreexo state received from peer {}, but we didn't ask",
+                    peer
+                );
+                self.increase_banscore(peer, 5).await?;
             }
 
             _ => {}

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -51,6 +51,7 @@ use super::mempool::Mempool;
 use super::mempool::MempoolProof;
 use super::node_context::NodeContext;
 use super::node_interface::NodeInterface;
+use super::node_interface::NodeResponse;
 use super::node_interface::PeerInfo;
 use super::node_interface::UserRequest;
 use super::peer::create_tcp_stream_actor;
@@ -134,9 +135,6 @@ impl Default for RunningNode {
         RunningNode {
             last_feeler: Instant::now(),
             last_address_rearrange: Instant::now(),
-            user_requests: Arc::new(NodeInterface {
-                requests: std::sync::Mutex::new(Vec::new()),
-            }),
             last_invs: HashMap::default(),
             inflight_filters: BTreeMap::new(),
         }
@@ -183,6 +181,9 @@ pub struct NodeCommon<Chain: BlockchainInterface + UpdatableChainstate> {
     pub(crate) config: UtreexoNodeConfig,
     pub(crate) datadir: String,
     pub(crate) network: Network,
+
+    // 7. Stuff used by the node handle
+    pub(crate) user_requests: Arc<NodeInterface>,
 }
 
 pub struct UtreexoNode<Chain: BlockchainInterface + UpdatableChainstate, Context> {
@@ -263,9 +264,138 @@ where
                 max_banscore: config.max_banscore,
                 fixed_peer,
                 config,
+                user_requests: Arc::new(NodeInterface {
+                    requests: std::sync::Mutex::new(Vec::new()),
+                }),
             },
             context: T::default(),
         })
+    }
+
+    /// Returns a handle to the node interface that we can use to request data from our
+    /// node. This struct is thread safe, so we can use it from multiple threads and have
+    /// multiple handles. It also doesn't require a mutable reference to the node, or any
+    /// synchronization mechanism.
+    pub fn get_handle(&self) -> Arc<NodeInterface> {
+        self.user_requests.clone()
+    }
+
+    pub(crate) async fn handle_user_request(&mut self) -> Result<(), WireError> {
+        let requests = self
+            .user_requests
+            .requests
+            .lock()
+            .map_err(|_| WireError::PoisonedLock)?
+            .iter()
+            .filter(|req| {
+                !self
+                    .inflight
+                    .contains_key(&InflightRequests::UserRequest(req.req))
+            })
+            .map(|req| req.req)
+            .collect();
+
+        self.perform_user_request(requests).await;
+
+        Ok(())
+    }
+
+    fn handle_get_peer_info(&self) {
+        let mut peers = Vec::new();
+        for peer in self.peer_ids.iter() {
+            peers.push(self.get_peer_info(peer));
+        }
+        let peers = peers.into_iter().flatten().collect();
+        self.user_requests.send_answer(
+            UserRequest::GetPeerInfo,
+            Some(NodeResponse::GetPeerInfo(peers)),
+        );
+    }
+
+    async fn perform_user_request(&mut self, user_req: Vec<UserRequest>) {
+        for user_req in user_req {
+            debug!("Performing user request {user_req:?}");
+            if self.inflight.len() >= RunningNode::MAX_INFLIGHT_REQUESTS {
+                return;
+            }
+
+            let req = match user_req {
+                UserRequest::Block(block) => NodeRequest::GetBlock((vec![block], false)),
+                UserRequest::UtreexoBlock(block) => NodeRequest::GetBlock((vec![block], true)),
+                UserRequest::MempoolTransaction(txid) => NodeRequest::MempoolTransaction(txid),
+                UserRequest::GetPeerInfo => {
+                    self.handle_get_peer_info();
+                    continue;
+                }
+                UserRequest::Connect((addr, port)) => {
+                    let addr_v2 = match addr {
+                        IpAddr::V4(addr) => AddrV2::Ipv4(addr),
+                        IpAddr::V6(addr) => AddrV2::Ipv6(addr),
+                    };
+                    let local_addr = LocalAddress::new(
+                        addr_v2,
+                        0,
+                        AddressState::NeverTried,
+                        0.into(),
+                        port,
+                        self.peer_id_count as usize,
+                    );
+                    self.open_connection(ConnectionKind::Regular, 0, local_addr)
+                        .await;
+                    self.peer_id_count += 1;
+                    self.user_requests.send_answer(
+                        UserRequest::Connect((addr, port)),
+                        Some(NodeResponse::Connect(true)),
+                    );
+                    continue;
+                }
+            };
+            let peer = self.send_to_random_peer(req, ServiceFlags::NONE).await;
+            if let Ok(peer) = peer {
+                self.inflight.insert(
+                    InflightRequests::UserRequest(user_req),
+                    (peer, Instant::now()),
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn check_is_user_block_and_reply(
+        &mut self,
+        block: UtreexoBlock,
+    ) -> Result<Option<UtreexoBlock>, WireError> {
+        // If this block is a request made through the user interface, send it back to the
+        // user.
+        if self
+            .inflight
+            .remove(&InflightRequests::UserRequest(UserRequest::Block(
+                block.block.block_hash(),
+            )))
+            .is_some()
+        {
+            debug!(
+                "answering user request for block {}",
+                block.block.block_hash()
+            );
+
+            if block.udata.is_some() {
+                self.user_requests.send_answer(
+                    UserRequest::UtreexoBlock(block.block.block_hash()),
+                    Some(NodeResponse::UtreexoBlock(block)),
+                );
+
+                return Ok(None);
+            }
+
+            self.user_requests.send_answer(
+                UserRequest::Block(block.block.block_hash()),
+                Some(NodeResponse::Block(block.block)),
+            );
+
+            return Ok(None);
+        }
+
+        Ok(Some(block))
     }
 
     fn get_port(network: Network) -> u16 {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -3,13 +3,11 @@
 /// CPU to run, being bound by the number of blocks found in a given period.
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
 use bitcoin::bip158::BlockFilter;
-use bitcoin::p2p::address::AddrV2;
 use bitcoin::p2p::address::AddrV2Message;
 use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::p2p::ServiceFlags;
@@ -34,7 +32,6 @@ use tokio::time::timeout;
 use super::error::WireError;
 use super::peer::PeerMessages;
 use crate::address_man::AddressState;
-use crate::address_man::LocalAddress;
 use crate::node::periodic_job;
 use crate::node::try_and_log;
 use crate::node::ConnectionKind;
@@ -44,7 +41,6 @@ use crate::node::NodeRequest;
 use crate::node::UtreexoNode;
 use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
-use crate::node_interface::NodeInterface;
 use crate::node_interface::NodeResponse;
 use crate::node_interface::UserRequest;
 use crate::p2p_wire::chain_selector::ChainSelector;
@@ -54,7 +50,6 @@ use crate::p2p_wire::sync_node::SyncNode;
 pub struct RunningNode {
     pub(crate) last_feeler: Instant,
     pub(crate) last_address_rearrange: Instant,
-    pub(crate) user_requests: Arc<NodeInterface>,
     /// To find peers with a good connectivity, keep track of what peers sent us an inv message
     /// for a block, in the first 5 seconds after we get the first inv message. If we ever decide
     /// to disconnect a peer, we should disconnect the ones that didn't send us an inv message
@@ -79,93 +74,6 @@ where
     WireError: From<<Chain as BlockchainInterface>::Error>,
     Chain: BlockchainInterface + UpdatableChainstate + 'static,
 {
-    /// Returns a handle to the node interface that we can use to request data from our
-    /// node. This struct is thread safe, so we can use it from multiple threads and have
-    /// multiple handles. It also doesn't require a mutable reference to the node, or any
-    /// synchronization mechanism.
-    pub fn get_handle(&self) -> Arc<NodeInterface> {
-        self.context.user_requests.clone()
-    }
-
-    async fn handle_user_request(&mut self) -> Result<(), WireError> {
-        let requests = self
-            .context
-            .user_requests
-            .requests
-            .lock()
-            .map_err(|_| WireError::PoisonedLock)?
-            .iter()
-            .filter(|req| {
-                !self
-                    .inflight
-                    .contains_key(&InflightRequests::UserRequest(req.req))
-            })
-            .map(|req| req.req)
-            .collect();
-        self.perform_user_request(requests).await;
-        Ok(())
-    }
-
-    fn handle_get_peer_info(&self) {
-        let mut peers = Vec::new();
-        for peer in self.peer_ids.iter() {
-            peers.push(self.get_peer_info(peer));
-        }
-        let peers = peers.into_iter().flatten().collect();
-        self.context.user_requests.send_answer(
-            UserRequest::GetPeerInfo,
-            Some(NodeResponse::GetPeerInfo(peers)),
-        );
-    }
-
-    async fn perform_user_request(&mut self, user_req: Vec<UserRequest>) {
-        for user_req in user_req {
-            debug!("Performing user request {user_req:?}");
-            if self.inflight.len() >= RunningNode::MAX_INFLIGHT_REQUESTS {
-                return;
-            }
-
-            let req = match user_req {
-                UserRequest::Block(block) => NodeRequest::GetBlock((vec![block], false)),
-                UserRequest::UtreexoBlock(block) => NodeRequest::GetBlock((vec![block], true)),
-                UserRequest::MempoolTransaction(txid) => NodeRequest::MempoolTransaction(txid),
-                UserRequest::GetPeerInfo => {
-                    self.handle_get_peer_info();
-                    continue;
-                }
-                UserRequest::Connect((addr, port)) => {
-                    let addr_v2 = match addr {
-                        IpAddr::V4(addr) => AddrV2::Ipv4(addr),
-                        IpAddr::V6(addr) => AddrV2::Ipv6(addr),
-                    };
-                    let local_addr = LocalAddress::new(
-                        addr_v2,
-                        0,
-                        AddressState::NeverTried,
-                        0.into(),
-                        port,
-                        self.peer_id_count as usize,
-                    );
-                    self.open_connection(ConnectionKind::Regular, 0, local_addr)
-                        .await;
-                    self.peer_id_count += 1;
-                    self.context.user_requests.send_answer(
-                        UserRequest::Connect((addr, port)),
-                        Some(NodeResponse::Connect(true)),
-                    );
-                    continue;
-                }
-            };
-            let peer = self.send_to_random_peer(req, ServiceFlags::NONE).await;
-            if let Ok(peer) = peer {
-                self.inflight.insert(
-                    InflightRequests::UserRequest(user_req),
-                    (peer, Instant::now()),
-                );
-            }
-        }
-    }
-
     async fn send_addresses(&mut self) -> Result<(), WireError> {
         let addresses = self
             .address_man
@@ -233,7 +141,7 @@ where
                         .insert(InflightRequests::Headers, (peer, Instant::now()));
                 }
                 InflightRequests::UserRequest(req) => {
-                    self.context.user_requests.send_answer(req, None);
+                    self.user_requests.send_answer(req, None);
                 }
                 InflightRequests::Connect(peer) => {
                     self.peers.remove(&peer);
@@ -597,32 +505,9 @@ where
     /// This block may be a rescan block, a user request or a new block that we
     /// need to process.
     async fn handle_block_data(&mut self, block: UtreexoBlock, peer: u32) -> Result<(), WireError> {
-        // If this block is a request made through the user interface, send it back to the
-        // user.
-        if self
-            .inflight
-            .remove(&InflightRequests::UserRequest(UserRequest::Block(
-                block.block.block_hash(),
-            )))
-            .is_some()
-        {
-            debug!(
-                "answering user request for block {}",
-                block.block.block_hash()
-            );
-            if block.udata.is_some() {
-                self.context.user_requests.send_answer(
-                    UserRequest::UtreexoBlock(block.block.block_hash()),
-                    Some(NodeResponse::UtreexoBlock(block)),
-                );
-                return Ok(());
-            }
-            self.context.user_requests.send_answer(
-                UserRequest::Block(block.block.block_hash()),
-                Some(NodeResponse::Block(block.block)),
-            );
+        let Some(block) = self.check_is_user_block_and_reply(block).await? else {
             return Ok(());
-        }
+        };
 
         // If none of the above, it means that this block is a new block that we need to
         // process.
@@ -811,6 +696,7 @@ where
 
                     self.handle_new_block(block, peer).await?;
                 }
+
                 PeerMessages::Block(block) => {
                     debug!(
                         "Got data for block {} from peer {peer}",
@@ -819,6 +705,7 @@ where
 
                     self.handle_block_data(block, peer).await?;
                 }
+
                 PeerMessages::Headers(headers) => {
                     debug!(
                         "Got headers from peer {peer} with {} headers",
@@ -865,6 +752,7 @@ where
                         self.request_blocks(blocks).await?;
                     }
                 }
+
                 PeerMessages::Ready(version) => {
                     debug!(
                         "handshake with peer={peer} succeeded feeler={:?}",
@@ -872,15 +760,18 @@ where
                     );
                     self.handle_peer_ready(peer, &version).await?;
                 }
+
                 PeerMessages::Disconnected(idx) => {
                     self.handle_disconnection(peer, idx).await?;
                 }
+
                 PeerMessages::Addr(addresses) => {
                     debug!("Got {} addresses from peer {}", addresses.len(), peer);
                     let addresses: Vec<_> =
                         addresses.iter().cloned().map(|addr| addr.into()).collect();
                     self.address_man.push_addresses(&addresses);
                 }
+
                 PeerMessages::BlockFilter((hash, filter)) => {
                     debug!("Got a block filter for block {hash} from peer {peer}");
 
@@ -916,30 +807,31 @@ where
                         }
                     }
                 }
+
                 PeerMessages::NotFound(inv) => match inv {
                     Inventory::Error => {}
                     Inventory::Block(block)
                     | Inventory::WitnessBlock(block)
                     | Inventory::CompactBlock(block) => {
-                        self.context
-                            .user_requests
+                        self.user_requests
                             .send_answer(UserRequest::Block(block), None);
                     }
 
                     Inventory::WitnessTransaction(tx) | Inventory::Transaction(tx) => {
-                        self.context
-                            .user_requests
+                        self.user_requests
                             .send_answer(UserRequest::MempoolTransaction(tx), None);
                     }
                     _ => {}
                 },
+
                 PeerMessages::Transaction(tx) => {
                     debug!("saw a mempool transaction with txid={}", tx.compute_txid());
-                    self.context.user_requests.send_answer(
+                    self.user_requests.send_answer(
                         UserRequest::MempoolTransaction(tx.compute_txid()),
                         Some(NodeResponse::MempoolTransaction(tx)),
                     );
                 }
+
                 PeerMessages::UtreexoState(_) => {
                     warn!(
                         "Utreexo state received from peer {}, but we didn't ask",

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
+use bitcoin::p2p::message_blockdata::Inventory;
 use bitcoin::p2p::ServiceFlags;
 use floresta_chain::pruned_utreexo::BlockchainInterface;
 use floresta_chain::pruned_utreexo::UpdatableChainstate;
@@ -19,6 +20,7 @@ use tokio::sync::RwLock;
 use tokio::time::timeout;
 
 use super::error::WireError;
+use super::node_interface::UserRequest;
 use super::peer::PeerMessages;
 use crate::address_man::AddressState;
 use crate::node::periodic_job;
@@ -30,6 +32,7 @@ use crate::node::NodeRequest;
 use crate::node::UtreexoNode;
 use crate::node_context::NodeContext;
 use crate::node_context::PeerId;
+use crate::node_interface::NodeResponse;
 
 /// [`SyncNode`] is a node that downloads and validates the blockchain.
 /// This node implements:
@@ -94,7 +97,7 @@ where
 
         loop {
             while let Ok(Some(msg)) = timeout(Duration::from_secs(1), self.node_rx.recv()).await {
-                self.handle_message(msg).await;
+                try_and_log!(self.handle_message(msg).await);
             }
 
             if *kill_signal.read().await {
@@ -152,13 +155,19 @@ where
             .map(|(req, (peer, _))| (req.clone(), *peer))
             .collect::<Vec<_>>();
 
-        for (block, peer) in to_remove {
-            self.inflight.remove(&block);
+        for (request, peer) in to_remove {
+            self.inflight.remove(&request);
             try_and_log!(self.increase_banscore(peer, 1).await);
 
-            let InflightRequests::Blocks(block) = block else {
+            if let InflightRequests::UserRequest(req) = request {
+                self.user_requests.send_answer(req, None);
+                continue;
+            }
+
+            let InflightRequests::Blocks(block) = request else {
                 continue;
             };
+
             try_and_log!(self.request_blocks(vec![block]).await);
         }
     }
@@ -172,6 +181,10 @@ where
         peer: PeerId,
         block: UtreexoBlock,
     ) -> Result<(), WireError> {
+        let Some(block) = self.check_is_user_block_and_reply(block).await? else {
+            return Ok(());
+        };
+
         self.inflight
             .remove(&InflightRequests::Blocks(block.block.block_hash()));
 
@@ -284,7 +297,7 @@ where
         Ok(())
     }
     /// Process a message from a peer and handle it accordingly between the variants of [`PeerMessages`].
-    async fn handle_message(&mut self, msg: NodeNotification) {
+    async fn handle_message(&mut self, msg: NodeNotification) -> Result<(), WireError> {
         #[cfg(feature = "metrics")]
         self.register_message_time(&msg);
 
@@ -295,9 +308,11 @@ where
                         error!("Error processing block: {:?}", e);
                     }
                 }
+
                 PeerMessages::Ready(version) => {
                     try_and_log!(self.handle_peer_ready(peer, &version).await);
                 }
+
                 PeerMessages::Disconnected(idx) => {
                     try_and_log!(self.handle_disconnection(peer, idx).await);
 
@@ -309,8 +324,43 @@ where
                         self.inflight.clear();
                     }
                 }
+
+                PeerMessages::NotFound(inv) => match inv {
+                    Inventory::Error => {}
+                    Inventory::Block(block)
+                    | Inventory::WitnessBlock(block)
+                    | Inventory::CompactBlock(block) => {
+                        self.user_requests
+                            .send_answer(UserRequest::Block(block), None);
+                    }
+
+                    Inventory::WitnessTransaction(tx) | Inventory::Transaction(tx) => {
+                        self.user_requests
+                            .send_answer(UserRequest::MempoolTransaction(tx), None);
+                    }
+                    _ => {}
+                },
+
+                PeerMessages::Transaction(tx) => {
+                    debug!("saw a mempool transaction with txid={}", tx.compute_txid());
+                    self.user_requests.send_answer(
+                        UserRequest::MempoolTransaction(tx.compute_txid()),
+                        Some(NodeResponse::MempoolTransaction(tx)),
+                    );
+                }
+
+                PeerMessages::UtreexoState(_) => {
+                    warn!(
+                        "Utreexo state received from peer {}, but we didn't ask",
+                        peer
+                    );
+                    self.increase_banscore(peer, 5).await?;
+                }
+
                 _ => {}
             },
         }
+
+        Ok(())
     }
 }

--- a/florestad/src/json_rpc/blockchain.rs
+++ b/florestad/src/json_rpc/blockchain.rs
@@ -21,9 +21,6 @@ use super::server::RpcImpl;
 impl RpcImpl {
     async fn get_block_inner(&self, hash: BlockHash) -> Result<Block, RpcError> {
         let is_genesis = self.chain.get_block_hash(0).unwrap().eq(&hash);
-        if self.chain.is_in_idb() && !is_genesis {
-            return Err(RpcError::InInitialBlockDownload);
-        }
 
         if is_genesis {
             return Ok(genesis_block(self.network));
@@ -230,6 +227,7 @@ impl RpcImpl {
             return Ok(serde_json::to_value(txout).unwrap());
         }
 
+        // if we are on ibd, we don't have any filters to find this txout.
         if self.chain.is_in_idb() {
             return Err(RpcError::InInitialBlockDownload);
         }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [X] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

Until now, only the running_node could reply to user request. However, that's cumbersome and limiting. After this commit, both sync_node and chain_selector can handle user requests made from the handle.


### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
