### PR TITLE
Validate hash literals at compile time

### DIFF
--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -12,6 +12,17 @@
 //! ready-to-use implementation, see the [KvChainStore] struct.
 #![cfg_attr(not(test), no_std)]
 
+macro_rules! bhash {
+    ($s:expr) => {{
+        // Catch invalid literals at compile time
+        const _: () = match crate::validate_hash_compile_time($s) {
+            Ok(()) => (),
+            Err(e) => panic!("{}", e),
+        };
+        BlockHash::from_str($s).expect("Literal should be valid")
+    }};
+}
+
 pub mod pruned_utreexo;
 pub(crate) use floresta_common::prelude;
 pub use pruned_utreexo::chain_state::*;
@@ -50,16 +61,66 @@ impl From<Network> for bitcoin::network::Network {
     }
 }
 
+#[allow(dead_code)]
+/// This const function is used to validate hash literals at compile time
+const fn validate_hash_compile_time(s: &str) -> Result<(), &str> {
+    let bytes = s.as_bytes();
+
+    // Note: An ASCII character is 1 byte, so the expected byte count is 64
+    if bytes.len() != 64 {
+        return Err("Hash literal is not exactly 64 hex digits");
+    }
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if !((b >= b'0' && b <= b'9') || (b >= b'a' && b <= b'f') || (b >= b'A' && b <= b'F')) {
+            return Err("Hash literal contains an invalid ASCII hex digit");
+        }
+        i += 1;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use bitcoin::network::Network as BNetwork;
 
-    use super::*;
+    use super::validate_hash_compile_time as validate_hash;
+    use super::Network;
+
     #[test]
     fn test_network() {
         assert_eq!(Network::Bitcoin, BNetwork::Bitcoin.into());
         assert_eq!(Network::Testnet, BNetwork::Testnet.into());
         assert_eq!(Network::Regtest, BNetwork::Regtest.into());
         assert_eq!(Network::Signet, BNetwork::Signet.into());
+    }
+
+    #[test]
+    fn test_validate_hash_compile_time() {
+        // Valid: exactly 64 ASCII hex digits.
+        let valid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert!(validate_hash(valid).is_ok());
+
+        for len in 0..=128 {
+            let test_str = "a".repeat(len);
+            if len == 64 {
+                assert!(validate_hash(&test_str).is_ok());
+            } else {
+                assert!(validate_hash(&test_str).is_err());
+            }
+        }
+
+        // Invalid hex character at the end: 'g'.
+        let invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
+        assert_eq!(invalid.len(), 64);
+        assert!(validate_hash(invalid).is_err());
+
+        // Invalid ascii character in the middle: 'é'
+        let invalid_ascii = "0123456789abcdef0123456789abcdéf0123456789abcdef0123456789abcde";
+        assert_eq!(invalid_ascii.len(), 64);
+        assert!(validate_hash(invalid_ascii).is_err());
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1392,8 +1392,7 @@ mod test {
 
         assert_eq!(
             block.block_hash(),
-            BlockHash::from_str("000000000000000012ea0ca9579299ec120e3f57e7c309216884872592b29970")
-                .unwrap(),
+            bhash!("000000000000000012ea0ca9579299ec120e3f57e7c309216884872592b29970"),
         );
 
         // Check whether the block validation passes or not
@@ -1411,8 +1410,7 @@ mod test {
 
         assert_eq!(
             block.block_hash(),
-            BlockHash::from_str("000000000000000000014ce9ba7c6760053c3c82ce6ab43d60afb101d3c8f1f1")
-                .unwrap(),
+            bhash!("000000000000000000014ce9ba7c6760053c3c82ce6ab43d60afb101d3c8f1f1"),
         );
 
         // Check whether the block validation passes or not
@@ -1480,37 +1478,28 @@ mod test {
                 .unwrap();
         }
 
-        assert_eq!(
-            chain.get_best_block().unwrap(),
-            (
-                10,
-                BlockHash::from_str(
-                    "6e9c49a19038f7db8d13f6c2e70566385536ea11975528b557799e08a014e784"
-                )
-                .unwrap()
-            )
+        let expected = (
+            10,
+            bhash!("6e9c49a19038f7db8d13f6c2e70566385536ea11975528b557799e08a014e784"),
         );
+        assert_eq!(chain.get_best_block().unwrap(), expected);
 
         for fork in blocks[1].iter() {
             let block = Vec::from_hex(fork).unwrap();
             let block: Block = deserialize(&block).unwrap();
             chain.accept_header(block.header).unwrap();
         }
-        let best_block = chain.get_best_block().unwrap();
-        assert_eq!(
-            best_block,
-            (
-                16,
-                BlockHash::from_str(
-                    "4572ac401b94915dde6c4957b706abdb13b5824b000cad7f6065ebd9aea6dad1"
-                )
-                .unwrap()
-            )
+
+        let expected = (
+            16,
+            bhash!("4572ac401b94915dde6c4957b706abdb13b5824b000cad7f6065ebd9aea6dad1"),
         );
+        assert_eq!(chain.get_best_block().unwrap(), expected);
+
         for i in 1..=chain.get_height().unwrap() {
-            if let Ok(DiskBlockHeader::HeadersOnly(_, _)) =
-                chain.get_disk_block_header(&chain.get_block_hash(i).unwrap())
-            {
+            let accepted = chain.get_block_hash(i).unwrap();
+
+            if let Ok(DiskBlockHeader::HeadersOnly(..)) = chain.get_disk_block_header(&accepted) {
                 continue;
             }
             panic!("Block {} is not in the store", i);

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -84,9 +84,9 @@ impl ChainParams {
         let genesis = genesis_block(Params::new(network.into()));
         match network {
             Network::Bitcoin => AssumeUtreexoValue {
-                block_hash: "00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9"
-                    .parse()
-                    .unwrap(),
+                block_hash: bhash!(
+                    "00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9"
+                ),
                 height: 855571,
                 roots: [
                     "4dcc014cc23611dda2dcf0f34a3e62e7d302146df4b0b01ac701d440358c19d6",
@@ -133,29 +133,22 @@ impl ChainParams {
     }
 
     pub fn get_assume_valid(network: Network, arg: AssumeValidArg) -> Option<BlockHash> {
-        fn get_hash(hash: &str) -> BlockHash {
-            BlockHash::from_str(hash).expect("hardcoded hash should not fail")
-        }
         match arg {
             AssumeValidArg::Disabled => None,
             AssumeValidArg::UserInput(hash) => Some(hash),
             AssumeValidArg::Hardcoded => match network {
-                Network::Bitcoin => {
-                    get_hash("00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9")
-                        .into()
-                }
-                Network::Testnet => {
-                    get_hash("000000000000001142ad197bff16a1393290fca09e4ca904dd89e7ae98a90fcd")
-                        .into()
-                }
-                Network::Signet => {
-                    get_hash("0000003ed17b9c93954daab00d73ccbd0092074c4ebfc751c7458d58b827dfea")
-                        .into()
-                }
-                Network::Regtest => {
-                    get_hash("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")
-                        .into()
-                }
+                Network::Bitcoin => Some(bhash!(
+                    "00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9"
+                )),
+                Network::Testnet => Some(bhash!(
+                    "000000000000001142ad197bff16a1393290fca09e4ca904dd89e7ae98a90fcd"
+                )),
+                Network::Signet => Some(bhash!(
+                    "0000003ed17b9c93954daab00d73ccbd0092074c4ebfc751c7458d58b827dfea"
+                )),
+                Network::Regtest => Some(bhash!(
+                    "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"
+                )),
             },
         }
     }
@@ -171,18 +164,15 @@ fn get_exceptions() -> HashMap<BlockHash, c_uint> {
     use bitcoinconsensus::VERIFY_WITNESS;
     let mut exceptions = HashMap::new();
     exceptions.insert(
-        BlockHash::from_str("00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22")
-            .unwrap(),
+        bhash!("00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22"),
         VERIFY_NONE,
     ); // BIP16 exception on main net
     exceptions.insert(
-        BlockHash::from_str("0000000000000000000f14c35b2d841e986ab5441de8c585d5ffe55ea1e395ad")
-            .unwrap(),
+        bhash!("0000000000000000000f14c35b2d841e986ab5441de8c585d5ffe55ea1e395ad"),
         VERIFY_P2SH | VERIFY_WITNESS,
     ); // Taproot exception on main net
     exceptions.insert(
-        BlockHash::from_str("00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105")
-            .unwrap(),
+        bhash!("00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105"),
         VERIFY_NONE,
     ); // BIP16 exception on test net
     exceptions

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -572,12 +572,9 @@ mod test {
                 header_code: $height,
                 spk_ty: ScriptPubkeyType::$spk_type,
             };
-            let spk = super::proof_util::reconstruct_leaf_data(
-                &leaf,
-                &s.input[0],
-                BlockHash::from_str($block_hash).unwrap(),
-            )
-            .unwrap();
+            let spk =
+                super::proof_util::reconstruct_leaf_data(&leaf, &s.input[0], bhash!($block_hash))
+                    .unwrap();
             assert_eq!(
                 spk.utxo.script_pubkey,
                 ScriptBuf::from_hex($expected_spk).unwrap()
@@ -651,8 +648,7 @@ mod test {
         let reconstructed = reconstruct_leaf_data(
             &compact,
             &spending_tx.input[0],
-            BlockHash::from_str("000000de717aa52b6b6ffcf4e2372256a9d620f52b9b4420623c6ae9b9249ef9")
-                .unwrap(),
+            bhash!("000000de717aa52b6b6ffcf4e2372256a9d620f52b9b4420623c6ae9b9249ef9"),
         )
         .unwrap();
         assert_eq!(leaf, reconstructed);


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: New macro `bhash`

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

I have created the `bhash` macro, short for block hash, that enforces a compile time check on the literal (must be 64 hex digits).

It uses the pattern `const _: () = ...;`, where the right side is evaluated at compile time. All the `bhash!(literals)` will be checked at compile time, even if they are not accessed at runtime (see https://doc.rust-lang.org/reference/items/constant-items.html#evaluation).

In other words, code that contains invalid literals won't compile (while currently it would compile and the program would panic at runtime only if the value is used). Also an IDE with cargo check lints will now display the error immediately.

### Notes to the reviewers

You can verify that this works, you can try to mess with any hash values and then try to compile: it won't.

```bash
error[E0080]: evaluation of constant value failed
    --> crates/floresta-chain/src/pruned_utreexo/chain_state.rs:1495:13
     |
1495 | ...   bhash!("572ac401b94915dde6c4957b706abdb13b5824b000cad7f6065ebd9aea6dad1...
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Hash literal is not exactly 64 hex digits', crates/floresta-chain/src/pruned_utreexo/chain_state.rs:1495:13
     |
     = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `bhash`
```