### PR TITLE
Use current txid for script errors, simplify tests

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1346,8 +1346,8 @@ mod test {
 
     use bitcoin::block::Header as BlockHeader;
     use bitcoin::consensus::deserialize;
+    use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::consensus::Decodable;
-    use bitcoin::hashes::hex::FromHex;
     use bitcoin::Block;
     use bitcoin::BlockHash;
     use bitcoin::OutPoint;
@@ -1465,11 +1465,8 @@ mod test {
 
     #[test]
     fn test_calc_next_work_required() {
-        let first_block = Vec::from_hex("0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a008f4d5fae77031e8ad22203").unwrap();
-        let first_block: BlockHeader = deserialize(&first_block).unwrap();
-
-        let last_block = Vec::from_hex("00000020dec6741f7dc5df6661bcb2d3ec2fceb14bd0e6def3db80da904ed1eeb8000000d1f308132e6a72852c04b059e92928ea891ae6d513cd3e67436f908c804ec7be51df535fae77031e4d00f800").unwrap();
-        let last_block: BlockHeader = deserialize(&last_block).unwrap();
+        let first_block: BlockHeader = deserialize_hex("0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a008f4d5fae77031e8ad22203").unwrap();
+        let last_block: BlockHeader = deserialize_hex("00000020dec6741f7dc5df6661bcb2d3ec2fceb14bd0e6def3db80da904ed1eeb8000000d1f308132e6a72852c04b059e92928ea891ae6d513cd3e67436f908c804ec7be51df535fae77031e4d00f800").unwrap();
 
         let next_target = Consensus::calc_next_work_required(
             &last_block,
@@ -1483,12 +1480,12 @@ mod test {
     #[test]
     fn test_reorg() {
         let chain = setup_test_chain(Network::Regtest, AssumeValidArg::Hardcoded);
-        let blocks = include_str!("../../testdata/test_reorg.json");
-        let blocks: Vec<Vec<&str>> = serde_json::from_str(blocks).unwrap();
+        let json_blocks = include_str!("../../testdata/test_reorg.json");
+        let blocks: Vec<Vec<&str>> = serde_json::from_str(json_blocks).unwrap();
 
+        // Connect first 10 blocks
         for block in blocks[0].iter() {
-            let block = Vec::from_hex(block).unwrap();
-            let block: Block = deserialize(&block).unwrap();
+            let block: Block = deserialize_hex(block).unwrap();
             chain.accept_header(block.header).unwrap();
             chain
                 .connect_block(&block, Proof::default(), HashMap::new(), Vec::new())
@@ -1501,9 +1498,9 @@ mod test {
         );
         assert_eq!(chain.get_best_block().unwrap(), expected);
 
+        // Then accept a fork chain with 16 blocks
         for fork in blocks[1].iter() {
-            let block = Vec::from_hex(fork).unwrap();
-            let block: Block = deserialize(&block).unwrap();
+            let block: Block = deserialize_hex(fork).unwrap();
             chain.accept_header(block.header).unwrap();
         }
 

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -151,7 +151,7 @@ impl Consensus {
             in_value += txo.value.to_sat();
 
             // Check script sizes (spent txo pubkey, and current tx scriptsig and TODO witness)
-            Self::validate_script_size(&txo.script_pubkey, || input.previous_output.txid)?;
+            Self::validate_script_size(&txo.script_pubkey, txid)?;
             Self::validate_script_size(&input.script_sig, txid)?;
             // TODO check also witness script size
         }
@@ -299,6 +299,36 @@ mod tests {
 
     use super::*;
 
+    /// Macro for creating a TxOut
+    macro_rules! txout {
+        ($sats:expr, $script:expr) => {
+            TxOut {
+                value: Amount::from_sat($sats),
+                script_pubkey: $script,
+            }
+        };
+    }
+
+    /// Macro for generating a legacy TxIn with an optional sequence number
+    macro_rules! txin {
+        ($outpoint:expr, $script:expr) => {
+            TxIn {
+                previous_output: $outpoint,
+                script_sig: $script,
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }
+        };
+        ($outpoint:expr, $script:expr, $sequence:expr) => {
+            TxIn {
+                previous_output: $outpoint,
+                script_sig: $script,
+                sequence: $sequence,
+                witness: Witness::new(),
+            }
+        };
+    }
+
     #[cfg(feature = "bitcoinconsensus")]
     /// Some made up transactions that test our script limits checks.
     /// Here's what is wrong with each transaction:
@@ -333,21 +363,11 @@ mod tests {
             ScriptBuf::from_hex(&format!("{:0>420}", "")).unwrap()
         };
 
-        let input_sequence = Sequence::MAX;
-        let input = TxIn {
-            previous_output: input_outpoint,
-            script_sig: input_script_sig,
-            sequence: input_sequence,
-            witness: Witness::new(),
-        };
+        let input = txin!(input_outpoint, input_script_sig);
 
         // Create outputs
-        let output_value = Amount::from_sat(5_000_350_000);
-        let output_script_pubkey = ScriptBuf::from_hex("41047eda6bd04fb27cab6e7c28c99b94977f073e912f25d1ff7165d9c95cd9bbe6da7e7ad7f2acb09e0ced91705f7616af53bee51a238b7dc527f2be0aa60469d140ac").unwrap();
-        let output = TxOut {
-            value: output_value,
-            script_pubkey: output_script_pubkey,
-        };
+        let output_script = ScriptBuf::from_hex("41047eda6bd04fb27cab6e7c28c99b94977f073e912f25d1ff7165d9c95cd9bbe6da7e7ad7f2acb09e0ced91705f7616af53bee51a238b7dc527f2be0aa60469d140ac").unwrap();
+        let output = txout!(5_000_350_000, output_script);
 
         // Create transaction
         let version = Version(1);
@@ -400,25 +420,14 @@ mod tests {
         // Mock data for testing
 
         let mut utxos = HashMap::new();
-        let tx: Transaction = bitcoin::consensus::deserialize(
-            &hex::decode("0100000001bd597773d03dcf6e22ba832f2387152c9ab69d250a8d86792bdfeb690764af5b010000006c493046022100841d4f503f44dd6cef8781270e7260db73d0e3c26c4f1eea61d008760000b01e022100bc2675b8598773984bcf0bb1a7cad054c649e8a34cb522a118b072a453de1bf6012102de023224486b81d3761edcd32cedda7cbb30a4263e666c87607883197c914022ffffffff021ee16700000000001976a9144883bb595608dcfe882aea5f7c579ef107a4fb5b88ac52a0aa00000000001976a914782231de72adb5c9df7367ab0c21c7b44bbd743188ac00000000").unwrap()
-        ).unwrap();
+        let tx: Transaction = deserialize_hex("0100000001bd597773d03dcf6e22ba832f2387152c9ab69d250a8d86792bdfeb690764af5b010000006c493046022100841d4f503f44dd6cef8781270e7260db73d0e3c26c4f1eea61d008760000b01e022100bc2675b8598773984bcf0bb1a7cad054c649e8a34cb522a118b072a453de1bf6012102de023224486b81d3761edcd32cedda7cbb30a4263e666c87607883197c914022ffffffff021ee16700000000001976a9144883bb595608dcfe882aea5f7c579ef107a4fb5b88ac52a0aa00000000001976a914782231de72adb5c9df7367ab0c21c7b44bbd743188ac00000000").unwrap();
 
-        assert_eq!(
-            tx.input.len(),
-            1,
-            "We only spend one utxo in this transaction"
-        );
+        assert_eq!(tx.input.len(), 1, "We only spend one utxo in this tx");
         let outpoint = tx.input[0].previous_output;
 
-        let txout = TxOut {
-            value: Amount::from_sat(18000000),
-            script_pubkey: ScriptBuf::from_hex(
-                "76a9149206a30c09cc853bb03bd917a4f9f29b089c1bc788ac",
-            )
-            .unwrap(),
-        };
-        utxos.insert(outpoint, txout);
+        let output_script =
+            ScriptBuf::from_hex("76a9149206a30c09cc853bb03bd917a4f9f29b089c1bc788ac").unwrap();
+        utxos.insert(outpoint, txout!(18000000, output_script));
 
         // Test consuming UTXOs
         let flags = bitcoinconsensus::VERIFY_P2SH;
@@ -473,78 +482,65 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_spending_script_too_big() {
-        // Bitcoin Consensus rules dictates that a scriptPubkey that's more than 10_000 bytes long
-        // won't be spendable. However, such an output **can** be created. We only check those
-        // sizes when it gets spent.
-        //
-        // This test creates an over-sized script, make sure that transaction containing it is valid. Then we try
-        // to spend this output, and verify if this causes an error.
+    pub fn true_script() -> ScriptBuf {
+        let mut script = ScriptBuf::default();
+        script.push_opcode(OP_TRUE);
+        script
+    }
+
+    pub fn oversized_script() -> ScriptBuf {
         let mut script = ScriptBuf::default();
         for _ in 0..10_000 {
             script.push_opcode(OP_NOP);
         }
-
         script.push_opcode(OP_TRUE);
+        script
+    }
 
-        let tx = Transaction {
-            version: Version(1),
-            lock_time: LockTime::from_height(0).unwrap(),
-            input: vec![TxIn {
-                previous_output: OutPoint::null(),
-                script_sig: ScriptBuf::from_hex("51").unwrap(),
-                sequence: Sequence::MAX,
-                witness: Witness::new(),
-            }],
-            output: vec![TxOut {
-                value: Amount::from_sat(0),
-                script_pubkey: script.clone(),
-            }],
-        };
-
-        let mut utxos = HashMap::new();
-        utxos.insert(
-            OutPoint::null(),
-            TxOut {
-                value: Amount::from_sat(0),
-                script_pubkey: ScriptBuf::from_hex("51").unwrap(),
-            },
-        );
+    #[test]
+    // Bitcoin Consensus rules dictate that a scriptPubkey that's more than 10_000 bytes long
+    // won't be spendable. However, such an output **can** be created. We only check those
+    // sizes when it gets spent.
+    //
+    // This test creates an over-sized script, make sure that transaction containing it is valid.
+    // Then we try to spend this output, and verify if this causes an error.
+    fn test_spending_script_too_big() {
+        fn build_tx(input: TxIn, output: TxOut) -> Transaction {
+            Transaction {
+                version: Version(1),
+                lock_time: LockTime::from_height(0).unwrap(),
+                input: vec![input],
+                output: vec![output],
+            }
+        }
 
         let flags = 0;
-        Consensus::verify_transaction(&tx, &mut utxos, false, flags).unwrap();
-
-        let spending = Transaction {
-            version: Version(1),
-            lock_time: LockTime::from_height(0).unwrap(),
-            input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: tx.compute_txid(),
-                    vout: 0,
-                },
-                script_sig: ScriptBuf::new(),
-                sequence: Sequence::MAX,
-                witness: Witness::new(),
-            }],
-            output: vec![TxOut {
-                value: Amount::from_sat(0),
-                script_pubkey: ScriptBuf::from_hex("51").unwrap(),
-            }],
-        };
-
         let mut utxos = HashMap::new();
-        utxos.insert(
-            OutPoint {
-                txid: tx.compute_txid(),
-                vout: 0,
-            },
-            TxOut {
-                value: Amount::from_sat(0),
-                script_pubkey: script,
-            },
-        );
+        utxos.insert(OutPoint::null(), txout!(0, true_script()));
 
-        Consensus::verify_transaction(&spending, &mut utxos, false, flags).unwrap_err();
+        // 1. Build a valid transaction that produces an oversized, unspendable output.
+        let dummy_in = txin!(OutPoint::null(), ScriptBuf::new());
+        let oversized_out = txout!(0, oversized_script());
+        let tx_with_oversized = build_tx(dummy_in, oversized_out.clone());
+
+        Consensus::verify_transaction(&tx_with_oversized, &mut utxos, false, flags).unwrap();
+
+        // 2. Register the oversized output as an available UTXO.
+        let prevout = OutPoint::new(tx_with_oversized.compute_txid(), 0);
+        utxos.insert(prevout, oversized_out);
+
+        // 3. Attempt to spend the oversized output.
+        let spending_in = txin!(prevout, ScriptBuf::new());
+        let spending_tx = build_tx(spending_in, txout!(0, true_script()));
+        let err =
+            Consensus::verify_transaction(&spending_tx, &mut utxos, false, flags).unwrap_err();
+
+        // Check that the error is exactly what we expect.
+        match err {
+            BlockchainError::TransactionError(inner) => {
+                assert_eq!(inner, tx_err!(|| spending_tx.compute_txid(), ScriptError));
+            }
+            e => panic!("Expected a TransactionError, but got: {:?}", e),
+        }
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -498,6 +498,7 @@ mod tests {
 
     use bitcoin::block::Header;
     use bitcoin::consensus::deserialize;
+    use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::Block;
     use rustreexo::accumulator::proof::Proof;
     use rustreexo::accumulator::stump::Stump;
@@ -529,8 +530,7 @@ mod tests {
         run("0000002000226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f40adbcd7823048d34357bdca86cd47172afe2a4af8366b5b34db36df89386d49b23ec964ffff7f20000000000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff165108feddb99c6b8435060b2f503253482f627463642fffffffff0100f2052a01000000160014806cef41295922d32ddfca09c26cc4acd36c3ed000000000", BlockValidationErrors::BadMerkleRoot);
     }
     fn parse_block(hex: &str) -> Block {
-        let block = hex::decode(hex).unwrap();
-        deserialize(&block).unwrap()
+        deserialize_hex(hex).unwrap()
     }
     fn get_empty_pchain(blocks: Vec<Header>) -> PartialChainState {
         PartialChainStateInner {

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -541,10 +541,8 @@ pub mod proof_util {
 mod test {
     extern crate std;
     use std::str::FromStr;
-    use std::vec::Vec;
 
-    use bitcoin::consensus::deserialize;
-    use bitcoin::hashes::hex::FromHex;
+    use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::Amount;
     use bitcoin::BlockHash;
     use bitcoin::ScriptBuf;
@@ -565,8 +563,7 @@ mod test {
             $spk_type:ident,
             $expected_spk:literal
         ) => {
-            let hex = Vec::from_hex($tx_hex).unwrap();
-            let s: Transaction = deserialize(&hex).unwrap();
+            let s: Transaction = deserialize_hex($tx_hex).unwrap();
             let leaf = CompactLeafData {
                 amount: Amount::from_btc($amount).unwrap().to_sat(),
                 header_code: $height,
@@ -635,10 +632,8 @@ mod test {
     }
     #[test]
     fn test_reconstruct_leaf_data() {
-        let leaf = Vec::from_hex("f99e24b9e96a3c6220449b2bf520d6a9562237e2f4fc6f6b2ba57a71de000000e6f50efb6747f836ca3510df3da120fdb2ae4cf62893cc014e08c25dab70248b01000000cc000400b429653b4f0600001600142b91c8f80b071c5f60e1a512d49a6a544e51165b").unwrap();
-        let leaf: LeafData = deserialize(&leaf).unwrap();
-        let spending_tx = Vec::from_hex("02000000000101e6f50efb6747f836ca3510df3da120fdb2ae4cf62893cc014e08c25dab70248b0100000000feffffff02dbe6553b4f0600001600148d57f8da7fc15371dc14d35e97850ab564a17b1240420f0000000000220020ed59bf193c5197a5b1dbbbc723ddeca82cdfbb188218b3ede50150e1890fc55202473044022024979ec4bda473b71288b2c15390418d7d300551aa5e463cc6b64acd5c3070b50220444c94242aff2ba1bd966308d60f537524b0755931d545d98e1fc45239ff6b08012103de7c420624c009d6a5761871e78b39ff864887f885ed313e27f778b3772e74916a000200").unwrap();
-        let spending_tx: Transaction = deserialize(&spending_tx).unwrap();
+        let leaf: LeafData = deserialize_hex("f99e24b9e96a3c6220449b2bf520d6a9562237e2f4fc6f6b2ba57a71de000000e6f50efb6747f836ca3510df3da120fdb2ae4cf62893cc014e08c25dab70248b01000000cc000400b429653b4f0600001600142b91c8f80b071c5f60e1a512d49a6a544e51165b").unwrap();
+        let spending_tx: Transaction = deserialize_hex("02000000000101e6f50efb6747f836ca3510df3da120fdb2ae4cf62893cc014e08c25dab70248b0100000000feffffff02dbe6553b4f0600001600148d57f8da7fc15371dc14d35e97850ab564a17b1240420f0000000000220020ed59bf193c5197a5b1dbbbc723ddeca82cdfbb188218b3ede50150e1890fc55202473044022024979ec4bda473b71288b2c15390418d7d300551aa5e463cc6b64acd5c3070b50220444c94242aff2ba1bd966308d60f537524b0755931d545d98e1fc45239ff6b08012103de7c420624c009d6a5761871e78b39ff864887f885ed313e27f778b3772e74916a000200").unwrap();
 
         let compact = CompactLeafData {
             amount: Amount::from_btc(69373.68668596).unwrap().to_sat(),


### PR DESCRIPTION
### Description

If a tx spends an oversized output, the error originates in this tx, not in the previous one (which is valid). So the `TransactionError` txid should, in my opinion, be from the current tx, i.e. the invalid one.

Then some minor simplification:
- Using `deserialize_hex`, rather than `Vec::from_hex` + `deserialize`
- Creating the `txout` and `txin` macros
- Refactoring `test_spending_script_too_big`

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.