### PR TITLE
wire: refactor the handle to use notifications

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -44,6 +44,8 @@ pub enum WireError {
     InvalidAddress(AddrParseError),
     #[error("Transport error: {0}")]
     Transport(TransportError),
+    #[error("Can't send back response for user request")]
+    ResponseSendError,
 }
 
 impl_error_from!(WireError, PeerError, PeerError);
@@ -64,6 +66,12 @@ impl From<tokio::sync::mpsc::error::SendError<NodeRequest>> for WireError {
 impl From<io::Error> for WireError {
     fn from(err: io::Error) -> WireError {
         WireError::Io(err)
+    }
+}
+
+impl From<tokio::sync::oneshot::error::RecvError> for WireError {
+    fn from(_: tokio::sync::oneshot::error::RecvError) -> Self {
+        WireError::ResponseSendError
     }
 }
 

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -17,7 +17,6 @@ use floresta::wire::mempool::Mempool;
 use floresta::wire::node::UtreexoNode;
 use floresta_chain::AssumeValidArg;
 use floresta_wire::address_man::AddressMan;
-use floresta_wire::node_interface::NodeMethods;
 use floresta_wire::running_node::RunningNode;
 use floresta_wire::UtreexoNodeConfig;
 use rustreexo::accumulator::pollard::Pollard;
@@ -103,6 +102,8 @@ async fn main() {
             BlockHash::from_str("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f")
                 .unwrap(),
         )
+        .await
         .unwrap();
+
     println!("Block: {:?}", block);
 }

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -196,6 +196,7 @@ pub enum Error {
     Encode,
     InvalidMemInfoMode,
     Wallet(String),
+    Filters(String),
 }
 
 impl Display for Error {
@@ -225,6 +226,7 @@ impl Display for Error {
             Error::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
             Error::InvalidMemInfoMode => write!(f, "Invalid meminfo mode, should be stats or mallocinfo"),
             Error::Wallet(e) => write!(f, "Wallet error: {}", e),
+            Error::Filters(e) => write!(f, "Error with filters: {}", e),
         }
     }
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: Refactor and bugfix

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [X] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [X] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

This commit changes the node interface to send a notification, instead of waiting for the node to check on it.

This simplifies some of the code and solves the problem with the handle being unresponsive if the node is under a lot of load.

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
