### PR TITLE
Validate utreexo node hashes at compile time

### DIFF
--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -12,17 +12,6 @@
 //! ready-to-use implementation, see the [KvChainStore] struct.
 #![cfg_attr(not(test), no_std)]
 
-macro_rules! bhash {
-    ($s:expr) => {{
-        // Catch invalid literals at compile time
-        const _: () = match crate::validate_hash_compile_time($s) {
-            Ok(()) => (),
-            Err(e) => panic!("{}", e),
-        };
-        BlockHash::from_str($s).expect("Literal should be valid")
-    }};
-}
-
 pub mod pruned_utreexo;
 pub(crate) use floresta_common::prelude;
 pub use pruned_utreexo::chain_state::*;
@@ -64,33 +53,10 @@ impl From<Network> for bitcoin::network::Network {
     }
 }
 
-#[allow(dead_code)]
-/// This const function is used to validate hash literals at compile time
-const fn validate_hash_compile_time(s: &str) -> Result<(), &str> {
-    let bytes = s.as_bytes();
-
-    // Note: An ASCII character is 1 byte, so the expected byte count is 64
-    if bytes.len() != 64 {
-        return Err("Hash literal is not exactly 64 hex digits");
-    }
-
-    let mut i = 0;
-    while i < bytes.len() {
-        let b = bytes[i];
-        if !((b >= b'0' && b <= b'9') || (b >= b'a' && b <= b'f') || (b >= b'A' && b <= b'F')) {
-            return Err("Hash literal contains an invalid ASCII hex digit");
-        }
-        i += 1;
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod test {
     use bitcoin::network::Network as BNetwork;
 
-    use super::validate_hash_compile_time as validate_hash;
     use super::Network;
 
     #[test]
@@ -99,31 +65,5 @@ mod test {
         assert_eq!(Network::Testnet, BNetwork::Testnet.into());
         assert_eq!(Network::Regtest, BNetwork::Regtest.into());
         assert_eq!(Network::Signet, BNetwork::Signet.into());
-    }
-
-    #[test]
-    fn test_validate_hash_compile_time() {
-        // Valid: exactly 64 ASCII hex digits.
-        let valid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-        assert!(validate_hash(valid).is_ok());
-
-        for len in 0..=128 {
-            let test_str = "a".repeat(len);
-            if len == 64 {
-                assert!(validate_hash(&test_str).is_ok());
-            } else {
-                assert!(validate_hash(&test_str).is_err());
-            }
-        }
-
-        // Invalid hex character at the end: 'g'.
-        let invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
-        assert_eq!(invalid.len(), 64);
-        assert!(validate_hash(invalid).is_err());
-
-        // Invalid ascii character in the middle: 'é'
-        let invalid_ascii = "0123456789abcdef0123456789abcdéf0123456789abcdef0123456789abcde";
-        assert_eq!(invalid_ascii.len(), 64);
-        assert!(validate_hash(invalid_ascii).is_err());
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1370,6 +1370,7 @@ mod test {
     use bitcoin::BlockHash;
     use bitcoin::OutPoint;
     use bitcoin::TxOut;
+    use floresta_common::bhash;
     use rand::Rng;
     use rustreexo::accumulator::proof::Proof;
 

--- a/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainparams.rs
@@ -18,6 +18,8 @@ use bitcoin::p2p::ServiceFlags;
 use bitcoin::params::Params;
 use bitcoin::Block;
 use bitcoin::BlockHash;
+use floresta_common::acchashes;
+use floresta_common::bhash;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 
 use crate::prelude::*;
@@ -99,7 +101,7 @@ impl ChainParams {
                     "00000000000000000000569f4d863c27e667cbee8acc8da195e7e5551658e6e9"
                 ),
                 height: 855571,
-                roots: [
+                roots: acchashes![
                     "4dcc014cc23611dda2dcf0f34a3e62e7d302146df4b0b01ac701d440358c19d6",
                     "988e0a883e4ad0c5559432f4747395115112755ec1138dcdd62e2f5741c31c2c",
                     "49ecba683e12823d44f2ad190120d3028386d8bb7860a3eea62a250a1f293c60",
@@ -118,7 +120,6 @@ impl ChainParams {
                     "67ba89afe6bce9bafbf0b88013e4446c861e6c746e291c3921e0b65c93671ba3",
                     "972ea2c7472c22e4eab49e9c2db5757a048b271b6251883ce89ccfeaa38b47ab",
                 ]
-                .map(|s| s.parse().unwrap())
                 .to_vec(),
                 leaves: 2587882501,
             },

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -494,12 +494,14 @@ impl From<PartialChainStateInner> for PartialChainState {
 
 #[cfg(test)]
 mod tests {
+    use core::str::FromStr;
     use std::collections::HashMap;
 
     use bitcoin::block::Header;
-    use bitcoin::consensus::deserialize;
     use bitcoin::consensus::encode::deserialize_hex;
     use bitcoin::Block;
+    use floresta_common::acchashes;
+    use rustreexo::accumulator::node_hash::BitcoinNodeHash;
     use rustreexo::accumulator::proof::Proof;
     use rustreexo::accumulator::stump::Stump;
 
@@ -556,8 +558,7 @@ mod tests {
             if i > 100 {
                 break;
             }
-            let block: Block = deserialize(&hex::decode(block).unwrap()).unwrap();
-            parsed_blocks.push(block);
+            parsed_blocks.push(parse_block(block));
         }
         let chainstate: PartialChainState = PartialChainStateInner {
             assume_valid: true,
@@ -591,8 +592,7 @@ mod tests {
         let blocks = include_str!("../../testdata/blocks.txt");
         let mut parsed_blocks = vec![];
         for block in blocks.lines() {
-            let block: Block = deserialize(&hex::decode(block).unwrap()).unwrap();
-            parsed_blocks.push(block);
+            parsed_blocks.push(parse_block(block));
         }
         // The file contains 150 blocks, we split them into two chains.
         let (blocks1, blocks2) = parsed_blocks.split_at(101);
@@ -627,12 +627,11 @@ mod tests {
                 .unwrap();
         }
         // The state after 100 blocks, computed ahead of time.
-        let roots = [
+        let roots = acchashes![
             "a2f1e6db842e13c7480c8d80f29ca2db5f9b96e1b428ebfdbd389676d7619081",
             "b21aae30bc74e9aef600a5d507ef27d799b9b6ba08e514656d34d717bdb569d2",
             "bedb648c9a3c5741660f926c1552d83ebb4cb1842cca6855b6d1089bb4951ce1",
         ]
-        .map(|s| s.parse().unwrap())
         .to_vec();
 
         let acc2 = Stump { roots, leaves: 100 };
@@ -666,13 +665,12 @@ mod tests {
                 .unwrap();
         }
 
-        let roots = [
+        let roots = acchashes![
             "e00b4ecc7c30865af0ac3b0c7c1b996015f51d6a6577ee6f52cc04b55933eb91",
             "9bf9659f93e246e0431e228032cd4b3a4d8a13e57f3e08a221e61f3e0bae657f",
             "e329a7ddcc888130bb6e4f82ce9f5cf5a712a7b0ae05a1aaf21b363866a9b05e",
             "1864a4982532447dcb3d9a5d2fea9f8ed4e3b1e759d55b8a427fb599fed0c302",
         ]
-        .map(|s| s.parse().unwrap())
         .to_vec();
 
         let expected_acc: Stump = Stump { leaves: 150, roots };

--- a/crates/floresta-chain/src/pruned_utreexo/udata.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/udata.rs
@@ -547,6 +547,7 @@ mod test {
     use bitcoin::BlockHash;
     use bitcoin::ScriptBuf;
     use bitcoin::Transaction;
+    use floresta_common::bhash;
 
     use super::proof_util::reconstruct_leaf_data;
     use super::CompactLeafData;

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -10,6 +10,8 @@ use miniscript::Descriptor;
 #[cfg(any(feature = "descriptors-std", feature = "descriptors-no-std"))]
 use miniscript::DescriptorPublicKey;
 use sha2::Digest;
+
+pub mod macros;
 pub mod spsc;
 
 use prelude::*;
@@ -147,14 +149,4 @@ pub mod prelude {
     pub use std::sync;
     pub use std::vec;
     pub use std::vec::Vec;
-}
-#[macro_export]
-macro_rules! impl_error_from {
-    ($thing:ty, $from_thing:ty, $field:ident) => {
-        impl From<$from_thing> for $thing {
-            fn from(e: $from_thing) -> Self {
-                <$thing>::$field(e)
-            }
-        }
-    };
 }

--- a/crates/floresta-common/src/macros.rs
+++ b/crates/floresta-common/src/macros.rs
@@ -1,0 +1,94 @@
+#[macro_export]
+macro_rules! impl_error_from {
+    ($thing:ty, $from_thing:ty, $field:ident) => {
+        impl From<$from_thing> for $thing {
+            fn from(e: $from_thing) -> Self {
+                <$thing>::$field(e)
+            }
+        }
+    };
+}
+
+#[macro_export]
+/// Validates a block hash at compile time. Requires `FromStr` and `BlockHash` in scope.
+macro_rules! bhash {
+    ($s:expr) => {{
+        // Catch invalid literals at compile time
+        const _: () = match $crate::macros::validate_hash_compile_time($s) {
+            Ok(()) => (),
+            Err(e) => panic!("{}", e),
+        };
+        BlockHash::from_str($s).expect("Literal should be valid")
+    }};
+}
+
+#[macro_export]
+/// Validates utreexo node hashes at compile time. Requires `FromStr` and `BitcoinNodeHash` in scope.
+///
+/// - Accepts one or more comma-separated hash literal expressions.
+/// - Allows an optional trailing comma.
+macro_rules! acchashes {
+    ( $( $s:expr ),+ $(,)? ) => {
+        [ $( {
+            // Catch invalid literals at compile time
+            const _: () = match $crate::macros::validate_hash_compile_time($s) {
+                Ok(()) => (),
+                Err(e) => panic!("{}", e),
+            };
+            BitcoinNodeHash::from_str($s).expect("Literal should be valid")
+        } ),+ ]
+    };
+}
+
+#[doc(hidden)]
+// This const function is used to validate hash literals at compile time
+pub const fn validate_hash_compile_time(s: &str) -> Result<(), &str> {
+    let bytes = s.as_bytes();
+
+    // Note: An ASCII character is 1 byte, so the expected byte count is 64
+    if bytes.len() != 64 {
+        return Err("Hash literal is not exactly 64 hex digits");
+    }
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if !((b >= b'0' && b <= b'9') || (b >= b'a' && b <= b'f') || (b >= b'A' && b <= b'F')) {
+            return Err("Hash literal contains an invalid ASCII hex digit");
+        }
+        i += 1;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::validate_hash_compile_time as validate_hash;
+
+    #[test]
+    fn test_validate_hash_compile_time() {
+        // Valid: exactly 64 ASCII hex digits.
+        let valid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert!(validate_hash(valid).is_ok());
+
+        for len in 0..=128 {
+            let test_str = "a".repeat(len);
+            if len == 64 {
+                assert!(validate_hash(&test_str).is_ok());
+            } else {
+                assert!(validate_hash(&test_str).is_err());
+            }
+        }
+
+        // Invalid hex character at the end: 'g'.
+        let invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
+        assert_eq!(invalid.len(), 64);
+        assert!(validate_hash(invalid).is_err());
+
+        // Invalid ascii character in the middle: 'é'
+        let invalid_ascii = "0123456789abcdef0123456789abcdéf0123456789abcdef0123456789abcde";
+        assert_eq!(invalid_ascii.len(), 64);
+        assert!(validate_hash(invalid_ascii).is_err());
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/mempool.rs
+++ b/crates/floresta-wire/src/p2p_wire/mempool.rs
@@ -619,6 +619,8 @@ mod tests {
     use floresta_chain::proof_util;
     use floresta_chain::CompactLeafData;
     use floresta_chain::LeafData;
+    use floresta_common::acchashes;
+    use floresta_common::bhash;
     use rand::Rng;
     use rand::SeedableRng;
     use rustreexo::accumulator::node_hash::BitcoinNodeHash;
@@ -705,10 +707,7 @@ mod tests {
 
     #[test]
     fn test_block_proof() {
-        let mut mempool = super::Mempool::new(
-            rustreexo::accumulator::pollard::Pollard::default(),
-            10_000_000,
-        );
+        let mut mempool = Mempool::new(Pollard::default(), 10_000_000);
 
         let coinbase_spk: ScriptBuf = Script::from_bytes(&[0x6a]).into();
 
@@ -819,10 +818,7 @@ mod tests {
 
     #[test]
     fn test_mepool_accept_no_acc() {
-        let mut mempool = super::Mempool::new(
-            rustreexo::accumulator::pollard::Pollard::default(),
-            10_000_000,
-        );
+        let mut mempool = Mempool::new(Pollard::default(), 10_000_000);
 
         let transactions = build_transactions(42, false);
         let len = transactions.len();
@@ -838,10 +834,7 @@ mod tests {
 
     #[test]
     fn test_gbt_with_conflict() {
-        let mut mempool = super::Mempool::new(
-            rustreexo::accumulator::pollard::Pollard::default(),
-            10_000_000,
-        );
+        let mut mempool = Mempool::new(Pollard::default(), 10_000_000);
 
         let transactions = build_transactions(21, true);
 
@@ -900,17 +893,16 @@ mod tests {
         // builds a proof for it, and then consumes the block. After that, we'll have a network at
         // block 270, with the transaction confirmed.
 
-        let roots = [
+        let roots = acchashes![
             "69482b799cf46ed514b01ce0573730a89c537018636b8c52a8864d5968b917f3",
             "53c92fa0792c9af1c19793b1149e7fe209c69b320ea054338f53f8fd8535f2e8",
             "6096c8421c1f86a9caa26e972dccdb964e280164fb060a576d51f5844e259569",
             "fd46029ebb0c19e2d468a9b24d20519c64ccc342e6a32b95c86a57489b6d2504",
         ]
-        .map(|s| s.parse().unwrap())
         .to_vec();
 
         let acc = Pollard::from_roots(roots, 169);
-        let proof_hashes = [
+        let proof_hashes = acchashes![
             "8be90393e71aa65710270b51857b538458dabd7769d801d6bbcbabe32c317251",
             "5ae3964e9cc3c9e188de778c5b5fb19eaa60bce98facf1e9e68b3c1257d08c00",
             "2c8dbc0642bd41cd8625344f99ef6513e5e68c03e184fcd401bddce6eba97674",
@@ -919,12 +911,11 @@ mod tests {
             "15aba691713052033954935777d8089f4ca6b0573c7ad89fe1d0d85bbbe21846",
             "8f22055465f568fd2bf9d19b285fcf2539ffea59a3cb096a3a0645366adea1b0",
         ]
-        .map(|s| s.parse().unwrap())
         .to_vec();
 
         let proof = Proof::new(vec![8], proof_hashes);
-        let del_hashes = ["427aceafd82c11cb53a2b78f408ece6fcacf2a5b9feb5fc45cdcf36627d68d76"]
-            .map(|s| s.parse().unwrap());
+        let del_hashes =
+            acchashes!["427aceafd82c11cb53a2b78f408ece6fcacf2a5b9feb5fc45cdcf36627d68d76"];
 
         let prevout: LeafData = deserialize_hex("0508085c47cc849eb80ea905cc7800a3be674ffc57263cf210c59d8d00000000c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd3704000000001300000000f2052a0100000043410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac").unwrap();
 
@@ -952,10 +943,7 @@ mod tests {
 
         let block = mempool.get_block_template(
             block::Version::ONE,
-            bitcoin::BlockHash::from_str(
-                "000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55",
-            )
-            .unwrap(),
+            bhash!("000000002a22cfee1f2c846adbd12b3e183d4f97683f85dad08a79780a84bd55"),
             1231731025,
             Target::MAX_ATTAINABLE_MAINNET.to_compact_lossy(),
         );
@@ -970,13 +958,9 @@ mod tests {
                 BlockHashProvider {
                     block_hash: [(
                         9,
-                        bitcoin::BlockHash::from_str(
-                            "000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805",
-                        )
-                        .unwrap(),
+                        bhash!("000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805"),
                     )]
-                    .iter()
-                    .cloned()
+                    .into_iter()
                     .collect(),
                 },
             )
@@ -1012,10 +996,7 @@ mod tests {
 
     #[test]
     fn test_gbt() {
-        let mut mempool = super::Mempool::new(
-            rustreexo::accumulator::pollard::Pollard::default(),
-            10_000_000,
-        );
+        let mut mempool = Mempool::new(Pollard::default(), 10_000_000);
 
         let transactions = build_transactions(42, false);
         let len = transactions.len();

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -12,6 +12,7 @@ use bitcoin::hex::FromHex;
 use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
 use floresta_chain::UtreexoBlock;
+use floresta_common::bhash;
 use floresta_common::service_flags;
 use floresta_common::service_flags::UTREEXO;
 use serde::Deserialize;
@@ -270,9 +271,7 @@ pub fn get_essentials() -> Essentials {
     let invalid_block = generate_invalid_block();
 
     // BlockHash of chain_tip: 0000035f0e5513b26bba7cead874fdf06241a934e4bc4cf7a0381c60e4cdd2bb (119)
-    let _tip_hash =
-        BlockHash::from_str("0000035f0e5513b26bba7cead874fdf06241a934e4bc4cf7a0381c60e4cdd2bb")
-            .unwrap();
+    let _tip_hash = bhash!("0000035f0e5513b26bba7cead874fdf06241a934e4bc4cf7a0381c60e4cdd2bb");
 
     Essentials {
         headers,


### PR DESCRIPTION
### Description

Created a new `macros` module at `floresta-common`. Moved here the `bhash` and `impl_error_from` macros.

Then implemented the `nodehash` macro, following a similar approach as `bhash`. We now validate the block hashes and node hashes literals at compile time everywhere.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: `nodehash` macro and common `macros` module

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [x] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.
