### PR TITLE
Added --gen-selfsigned-cert flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "metrics",
  "miniscript 12.3.0",
  "pretty_assertions",
+ "rcgen",
  "rustreexo",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -192,6 +192,47 @@ This is the default behavior of the `florestad` if no flags are provided. You ca
 
 ```bash
 $ florestad --no-backfill
+
+#### SSL Certificates
+
+By default, `florestad` will run an Electrum server without any encrypted
+communication with clients. But you also can run a TLS enabled electrum
+server. This is particularly important if you want to access the Electrum
+Server from a public untrusted network.
+
+The options below will add encryption and authentication to your service.
+
+```bash
+$ florestad --ssl-key-path=<path to private key> --ssl-cert-path=<path to certificate>
+```
+
+You must use [PKCS#8](https://docs.openssl.org/3.2/man1/openssl-pkcs8/) files,
+either built with a trusted chain or self-signed certificates.
+
+> Be aware that self-signed certificates do not inherently protect against
+man-in-the-middle (MITM) attacks because they
+[lack validation from a trusted Certificate Authority (CA)](https://security.stackexchange.com/questions/264247/man-in-the-middle-attack-only-affects-tls-certs-with-unqualified-subject-names).
+
+If you want to use self-signed certificates (for example, in your local network)
+you can generate them with the `--generate-ssl-certificates` flag. This will
+generate a private key and a certificate in `<data-dir>/ssl` and start a
+TLS server with these keys on `0.0.0.0:50002`.
+
+```bash
+$ florestad --gen-selfsigned-cert
+```
+
+You can also use the `--ssl-electrum-address` flag to specify the
+address and port of the Electrum server. This is useful if you want
+to run the Electrum server on a different machine or if you want to
+use a different port:
+
+```bash
+# Running with given certificates
+$ florestad --ssl-key-path <path> --ssl-cert-path <path> --ssl-electrum-address 51002
+
+# Running with self-signed certificates
+$ florestad --gen-selfsigned-cert --ssl-electrum-address 51002
 ```
 
 ### Compact Filters

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -32,6 +32,7 @@ anyhow = "1.0.40"
 zmq = { version = "0.10.0", optional = true }
 dns-lookup = "2.0.4"
 tower-http = { version = "0.6.2", optional = true, features = ["cors"] }
+rcgen = "0.13.2"
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -164,15 +164,19 @@ pub struct Cli {
     #[arg(long, value_name = "PATH")]
     /// Path to the SSL certificate file (defaults to <data-dir>/ssl/cert.pem).
     ///
-    /// The user should create a PKCS#8 based one with openssl. For example:
+    /// The user should create a PKCS#8 based one with openssl. For example, you
+    /// could create yourself a self-signed certificate with:
     ///
     /// openssl req -x509 -new -key key.pem -out cert.pem -days 365 -subj "/CN=localhost"
+    ///
+    /// alternatively, you can run florestad with --gen-selfsigned-cert
     pub ssl_cert_path: Option<String>,
 
     #[arg(long, value_name = "PATH")]
     /// Path to the SSL private key file (defaults to <data-dir>/ssl/key.pem).
     ///
-    /// The user should create a PKCS#8 based one with openssl. For example:
+    /// The user should create a PKCS#8 based one with openssl. For example, you
+    /// could create yourself a key for a self-signed certificate:
     ///
     /// openssl genpkey -algorithm RSA -out key.pem -pkeyopt rsa_keygen_bits:2048
     pub ssl_key_path: Option<String>,
@@ -180,6 +184,12 @@ pub struct Cli {
     #[arg(long, default_value_t = false)]
     /// Whether to disable SSL
     pub no_ssl: bool,
+
+    #[arg(long, default_value_t = false)]
+    /// Auto generates a ssl certificate in boot phase of florestad.
+    ///
+    /// It may conflict with other ssl related flags, please read the SSL Certificates section in README.md
+    pub gen_selfsigned_cert: bool,
 
     #[arg(long, default_value_t = false)]
     /// Whether to disable fallback to v1 transport if v2 connection fails

--- a/florestad/src/error.rs
+++ b/florestad/src/error.rs
@@ -24,6 +24,10 @@ pub enum Error {
     CouldNotOpenPrivKeyFile(String, std::io::Error),
     CouldNotOpenCertFile(String, std::io::Error),
     CouldNotConfigureTLS(tokio_rustls::rustls::TLSError),
+    CouldNotGenerateKeypair(rcgen::Error),
+    CouldNotGenerateCertParam(rcgen::Error),
+    CouldNotGenerateSelfSignedCert(rcgen::Error),
+    CouldNotWriteFile(String, std::io::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -55,6 +59,18 @@ impl std::fmt::Display for Error {
             }
             Error::CouldNotOpenCertFile(path, err) => {
                 write!(f, "Error while opening PKCS#8 certificate {path}: {err}")
+            }
+            Error::CouldNotGenerateKeypair(err) => {
+                write!(f, "Error while generating PKCS#8 keypair: {err}")
+            }
+            Error::CouldNotGenerateCertParam(err) => {
+                write!(f, "Error while generating certificate param: {}", err)
+            }
+            Error::CouldNotGenerateSelfSignedCert(err) => {
+                write!(f, "Error while generating self-signed certificate: {}", err)
+            }
+            Error::CouldNotWriteFile(path, err) => {
+                write!(f, "Error while creating file {path}: {err}")
             }
         }
     }

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -17,7 +17,6 @@
 #![deny(non_upper_case_globals)]
 
 mod cli;
-
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -56,6 +55,7 @@ fn main() {
         #[cfg(feature = "json-rpc")]
         json_rpc_address: params.rpc_address,
         electrum_address: params.electrum_address,
+        gen_selfsigned_cert: params.gen_selfsigned_cert,
         ssl_electrum_address: params.ssl_electrum_address,
         wallet_descriptor: params.wallet_descriptor,
         filters_start_height: params.filters_start_height,


### PR DESCRIPTION
Fix #423

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

This flag, when passed to florestad, will create a ssl folder in `<data-dir>` and `<data-dir>/ssl/key.pem` and a self-signed `<data-dir>/ssl/cert.pem`. This self-signed certificate can be a option to those users that do not have certificates with a trusted chain. It's import to note that the private-key isn't encrypted.

More specifically, this commit add:

* a flag --gen-selfsigned-cert on CLI;

* some enums elements on error.rs

* a generate_selfsigned_certificate on florestad.rs;

* a new step on florestad::start method before creating the TLS-enabled electrum server.

### Notes to the reviewers

This PR is a followup of #421

### Checklist

- [x] I've signed all my commits
- [x] I ran `just lint`
- [x] I ran `cargo test`
- [x] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
