### PR TITLE
CI: use corpus for fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -84,6 +84,12 @@ jobs:
         if: steps.cache-rust.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz --locked --force
 
+      # Pull corpus data from the floresta-qa-assets repository
+      - name: Pull corpus data
+        run: git clone https://github.com/Davidson-Souza/floresta-qa-assets
+      - name: Copy corpus data
+        run: cp -r floresta-qa-assets/corpus/ fuzz/corpus
+
       # Run fuzzing tests
       - name: Run fuzzing tests
         run: |


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: CI updates

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: CI.

### Description

Closes #415 

The current CI test boostraps the fuzzer every time we run the CI due to it not using any corpus. That reduces the usefulness of running fuzz on CI. Instead of just using the fuzzer like this, we should use some corpus that already have a decent coverage and will stress our code in a satisfactory way.

This commit uses the corpus data provided by the floresta-qa-assets repository. It contains corpus data generated over months of continuous fuzzing.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I'm linking the issue being fixed by this PR (if any)
