### PR TITLE
Fix non stop florestad process in functional tests

### DIFF
--- a/tests/example/example-test.py
+++ b/tests/example/example-test.py
@@ -44,9 +44,9 @@ After the definition of test within a class, you should call `MyTest().main()` a
 """
 
 import json
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.electrum_client import ElectrumClient
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class ExampleTest(FlorestaTestFramework):
@@ -99,13 +99,20 @@ class ExampleTest(FlorestaTestFramework):
         electrum = ElectrumClient("localhost", 50001)
         rpc_response = json.loads(electrum.get_version())
 
-        # Make assertions
-        assert rpc_response["result"][0] == ExampleTest.expected_version[0]
-        assert rpc_response["result"][1] == ExampleTest.expected_version[1]
-        assert inf_response["height"] == ExampleTest.expected_height
-        assert inf_response["best_block"] == ExampleTest.expected_block
-        assert inf_response["difficulty"] == ExampleTest.expected_difficulty
-        assert inf_response["leaf_count"] == ExampleTest.expected_leaf_count
+        # Make assertions with our framework. Avoid usage of
+        # native `assert` clauses. For more information, see
+        # https://github.com/vinteumorg/Floresta/issues/426
+        self.assertEqual(rpc_response["result"][0], ExampleTest.expected_version[0])
+        self.assertEqual(rpc_response["result"][1], ExampleTest.expected_version[1])
+        self.assertEqual(inf_response["height"], ExampleTest.expected_height)
+        self.assertEqual(inf_response["best_block"], ExampleTest.expected_block)
+        self.assertEqual(inf_response["difficulty"], ExampleTest.expected_difficulty)
+        self.assertEqual(inf_response["leaf_count"], ExampleTest.expected_leaf_count)
+
+        # At the end, you should stop all nodes with the `stop`
+        # method. Alternatively, you can use `stop_node(int) where int`
+        # is the node index
+        self.stop()
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/addnode-test.py
+++ b/tests/floresta-cli/addnode-test.py
@@ -6,8 +6,9 @@ This functional test cli utility to interact with a Floresta node with `addnode`
 
 import os
 import tempfile
-from test_framework.test_framework import FlorestaTestFramework
+
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER, JSONRPCError
+from test_framework.test_framework import FlorestaTestFramework
 
 # Setup a little node with another port
 ANOTHER_REGTEST_RPC_SERVER = {
@@ -87,18 +88,13 @@ class GetAddnodeIDBErrorTest(FlorestaTestFramework):
         self.wait_for_rpc_connection(GetAddnodeIDBErrorTest.nodes[1])
 
         # Test assertions
-        try:
-            node = self.get_node(GetAddnodeIDBErrorTest.nodes[0])
-            success = node.get_addnode(node="0.0.0.0:18443")
-            assert success
-        except JSONRPCError as exc:
-            assert exc.code == -32603
-            assert exc.message == GetAddnodeIDBErrorTest.node_ibd_error
-            assert exc.data is None
-        finally:
-            # stop nodes
-            self.stop_node(GetAddnodeIDBErrorTest.nodes[1])
-            self.stop_node(GetAddnodeIDBErrorTest.nodes[0])
+        node = self.get_node(GetAddnodeIDBErrorTest.nodes[0])
+        result = node.get_addnode(node="0.0.0.0:18443")
+        self.assertTrue(result)
+
+        # stop nodes
+        self.stop_node(GetAddnodeIDBErrorTest.nodes[1])
+        self.stop_node(GetAddnodeIDBErrorTest.nodes[0])
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/getblock-test.py
+++ b/tests/floresta-cli/getblock-test.py
@@ -4,8 +4,8 @@ floresta_cli_getblock.py
 This functional test cli utility to interact with a Floresta node with `getblock`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetBlockTest(FlorestaTestFramework):
@@ -62,24 +62,24 @@ class GetBlockTest(FlorestaTestFramework):
 
         # Test verbose level 1
         response = node.get_block(GetBlockTest.block, 1)
-        assert response["bits"] == GetBlockTest.bits
-        assert response["chainwork"] == GetBlockTest.chainwork
-        assert response["confirmations"] == GetBlockTest.confirmations
-        assert response["difficulty"] == GetBlockTest.difficulty
-        assert response["hash"] == GetBlockTest.hash
-        assert response["height"] == GetBlockTest.height
-        assert response["mediantime"] == GetBlockTest.mediantime
-        assert response["merkleroot"] == GetBlockTest.merkleroot
-        assert response["n_tx"] == GetBlockTest.n_tx
-        assert response["nonce"] == GetBlockTest.nonce
-        assert response["previousblockhash"] == GetBlockTest.prev_blockhash
-        assert response["size"] == GetBlockTest.size
-        assert response["strippedsize"] == GetBlockTest.strippedsize
-        assert response["time"] == GetBlockTest.time
-        assert len(response["tx"]) == len(GetBlockTest.tx)
-        assert response["version"] == GetBlockTest.version
-        assert response["versionHex"] == GetBlockTest.version_hex
-        assert response["weight"] == GetBlockTest.weight
+        self.assertEqual(response["bits"], GetBlockTest.bits)
+        self.assertEqual(response["chainwork"], GetBlockTest.chainwork)
+        self.assertEqual(response["confirmations"], GetBlockTest.confirmations)
+        self.assertEqual(response["difficulty"], GetBlockTest.difficulty)
+        self.assertEqual(response["hash"], GetBlockTest.hash)
+        self.assertEqual(response["height"], GetBlockTest.height)
+        self.assertEqual(response["mediantime"], GetBlockTest.mediantime)
+        self.assertEqual(response["merkleroot"], GetBlockTest.merkleroot)
+        self.assertEqual(response["n_tx"], GetBlockTest.n_tx)
+        self.assertEqual(response["nonce"], GetBlockTest.nonce)
+        self.assertEqual(response["previousblockhash"], GetBlockTest.prev_blockhash)
+        self.assertEqual(response["size"], GetBlockTest.size)
+        self.assertEqual(response["strippedsize"], GetBlockTest.strippedsize)
+        self.assertEqual(response["time"], GetBlockTest.time)
+        self.assertEqual(len(response["tx"]), len(GetBlockTest.tx))
+        self.assertEqual(response["version"], GetBlockTest.version)
+        self.assertEqual(response["versionHex"], GetBlockTest.version_hex)
+        self.assertEqual(response["weight"], GetBlockTest.weight)
 
         # Shutdown node
         self.stop_node(GetBlockTest.nodes[0])

--- a/tests/floresta-cli/getblockchaininfo-test.py
+++ b/tests/floresta-cli/getblockchaininfo-test.py
@@ -4,8 +4,8 @@ floresta_cli_getblockchainfo.py
 This functional test cli utility to interact with a Floresta node with `getblockchaininfo`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetBlockchaininfoTest(FlorestaTestFramework):
@@ -45,17 +45,19 @@ class GetBlockchaininfoTest(FlorestaTestFramework):
         # Test assertions
         node = self.get_node(GetBlockchaininfoTest.nodes[0])
         response = node.get_blockchain_info()
-        assert response["best_block"] == GetBlockchaininfoTest.best_block
-        assert response["difficulty"] == GetBlockchaininfoTest.difficulty
-        assert response["height"] == GetBlockchaininfoTest.height
-        assert response["ibd"] == GetBlockchaininfoTest.ibd
-        assert response["latest_block_time"] == GetBlockchaininfoTest.latest_block_time
-        assert response["latest_work"] == GetBlockchaininfoTest.latest_work
-        assert response["leaf_count"] == GetBlockchaininfoTest.leaf_count
-        assert response["progress"] == GetBlockchaininfoTest.progress
-        assert response["root_count"] == GetBlockchaininfoTest.root_count
-        assert response["root_hashes"] == GetBlockchaininfoTest.root_hashes
-        assert response["validated"] == GetBlockchaininfoTest.validated
+        self.assertEqual(response["best_block"], GetBlockchaininfoTest.best_block)
+        self.assertEqual(response["difficulty"], GetBlockchaininfoTest.difficulty)
+        self.assertEqual(response["height"], GetBlockchaininfoTest.height)
+        self.assertEqual(response["ibd"], GetBlockchaininfoTest.ibd)
+        self.assertEqual(
+            response["latest_block_time"], GetBlockchaininfoTest.latest_block_time
+        )
+        self.assertEqual(response["latest_work"], GetBlockchaininfoTest.latest_work)
+        self.assertEqual(response["leaf_count"], GetBlockchaininfoTest.leaf_count)
+        self.assertEqual(response["progress"], GetBlockchaininfoTest.progress)
+        self.assertEqual(response["root_count"], GetBlockchaininfoTest.root_count)
+        self.assertEqual(response["root_hashes"], GetBlockchaininfoTest.root_hashes)
+        self.assertEqual(response["validated"], GetBlockchaininfoTest.validated)
 
         # Shutdown node
         self.stop_node(GetBlockchaininfoTest.nodes[0])

--- a/tests/floresta-cli/getblockhash-test.py
+++ b/tests/floresta-cli/getblockhash-test.py
@@ -4,8 +4,8 @@ floresta_cli_getblockhash.py
 This functional test cli utility to interact with a Floresta node with `getblockhash`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetBlockhashTest(FlorestaTestFramework):
@@ -35,7 +35,7 @@ class GetBlockhashTest(FlorestaTestFramework):
         # Test assertions
         node = self.get_node(GetBlockhashTest.nodes[0])
         response = node.get_blockhash(0)
-        assert response == GetBlockhashTest.best_block
+        self.assertEqual(response, GetBlockhashTest.best_block)
 
         # Shutdown node
         self.stop_node(GetBlockhashTest.nodes[0])

--- a/tests/floresta-cli/getblockheader-test.py
+++ b/tests/floresta-cli/getblockheader-test.py
@@ -4,8 +4,8 @@ floresta_cli_getblockheader.py
 This functional test cli utility to interact with a Floresta node with `getblockheader`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
@@ -54,12 +54,16 @@ class GetBlockheaderHeightZeroTest(FlorestaTestFramework):
         # Test assertions
         node = self.get_node(GetBlockheaderHeightZeroTest.nodes[0])
         response = node.get_blockheader(GetBlockheaderHeightZeroTest.blockhash)
-        assert response["version"] == GetBlockheaderHeightZeroTest.version
-        assert response["prev_blockhash"] == GetBlockheaderHeightZeroTest.prev_blockhash
-        assert response["merkle_root"] == GetBlockheaderHeightZeroTest.merkle_root
-        assert response["time"] == GetBlockheaderHeightZeroTest.time
-        assert response["bits"] == GetBlockheaderHeightZeroTest.bits
-        assert response["nonce"] == GetBlockheaderHeightZeroTest.nonce
+        self.assertEqual(response["version"], GetBlockheaderHeightZeroTest.version)
+        self.assertEqual(
+            response["prev_blockhash"], GetBlockheaderHeightZeroTest.prev_blockhash
+        )
+        self.assertEqual(
+            response["merkle_root"], GetBlockheaderHeightZeroTest.merkle_root
+        )
+        self.assertEqual(response["time"], GetBlockheaderHeightZeroTest.time)
+        self.assertEqual(response["bits"], GetBlockheaderHeightZeroTest.bits)
+        self.assertEqual(response["nonce"], GetBlockheaderHeightZeroTest.nonce)
 
         # Shutdown node
         self.stop_node(GetBlockheaderHeightZeroTest.nodes[0])

--- a/tests/floresta-cli/getmemoryinfo-test.py
+++ b/tests/floresta-cli/getmemoryinfo-test.py
@@ -8,8 +8,9 @@ import os
 import re
 import sys
 import tempfile
-from test_framework.test_framework import FlorestaTestFramework
+
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetMemoryInfoTest(FlorestaTestFramework):
@@ -50,21 +51,21 @@ class GetMemoryInfoTest(FlorestaTestFramework):
         """
         if sys.platform == "linux":
             result = node.get_memoryinfo("stats")
-            assert "locked" in result
-            assert "chunks_free" in result["locked"]
-            assert "chunks_used" in result["locked"]
-            assert "free" in result["locked"]
-            assert "locked" in result["locked"]
-            assert "total" in result["locked"]
-            assert "used" in result["locked"]
-            assert result["locked"]["chunks_free"] >= 0
-            assert result["locked"]["chunks_used"] >= 0
-            assert result["locked"]["free"] >= 0
-            assert result["locked"]["locked"] >= 0
-            assert result["locked"]["total"] >= 0
-            assert result["locked"]["used"] >= 0
+            self.assertIn("locked", result)
+            self.assertIn("chunks_free", result["locked"])
+            self.assertIn("chunks_used", result["locked"])
+            self.assertIn("free", result["locked"])
+            self.assertIn("locked", result["locked"])
+            self.assertIn("total", result["locked"])
+            self.assertIn("used", result["locked"])
+            self.assertTrue(result["locked"]["chunks_free"] >= 0)
+            self.assertTrue(result["locked"]["chunks_used"] >= 0)
+            self.assertTrue(result["locked"]["free"] >= 0)
+            self.assertTrue(result["locked"]["locked"] >= 0)
+            self.assertTrue(result["locked"]["total"] >= 0)
+            self.assertTrue(result["locked"]["used"] >= 0)
         else:
-            print(
+            self.log(
                 f"Skiping test: 'getmemoryinfo stats' not implemented for '{sys.platform}'"
             )
 
@@ -89,9 +90,9 @@ class GetMemoryInfoTest(FlorestaTestFramework):
                 r"</malloc>"
             )
             result = node.get_memoryinfo("mallocinfo")
-            assert re.fullmatch(pattern, result)
+            self.assertMatch(result, pattern)
         else:
-            print(
+            self.log(
                 f"Skiping test: 'getmemoryinfo malloc' not implemented for '{sys.platform}'"
             )
 

--- a/tests/floresta-cli/getpeerinfo-test.py
+++ b/tests/floresta-cli/getpeerinfo-test.py
@@ -4,8 +4,8 @@ floresta_cli_getpeerinfo.py
 This functional test cli utility to interact with a Floresta node with `getpeerinfo`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER, JSONRPCError
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetPeerInfoTest(FlorestaTestFramework):
@@ -35,15 +35,11 @@ class GetPeerInfoTest(FlorestaTestFramework):
 
         # Test assertions
         node = self.get_node(GetPeerInfoTest.nodes[0])
-        try:
-            node.get_peerinfo()
-        except JSONRPCError as exc:
-            assert exc.code == -32603
-            assert exc.data is None
-            assert exc.message == GetPeerInfoTest.expected_error
-        finally:
-            # Shutdown node
-            self.stop_node(GetPeerInfoTest.nodes[0])
+
+        result = node.get_peerinfo()
+        self.assertIsSome(result)
+        self.assertEqual(len(result), 0)
+        self.stop_node(GetPeerInfoTest.nodes[0])
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/getroots-test.py
+++ b/tests/floresta-cli/getroots-test.py
@@ -4,8 +4,8 @@ floresta_cli_getroots.py
 This functional test cli utility to interact with a Floresta node with `getroots`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetRootsIDBLenZeroTest(FlorestaTestFramework):
@@ -37,7 +37,7 @@ class GetRootsIDBLenZeroTest(FlorestaTestFramework):
         # Test assertions
         node = self.get_node(GetRootsIDBLenZeroTest.nodes[0])
         vec_hashes = node.get_roots()
-        assert len(vec_hashes) == 0
+        self.assertTrue(len(vec_hashes) == 0)
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/getrpcinfo-test.py
+++ b/tests/floresta-cli/getrpcinfo-test.py
@@ -6,8 +6,9 @@ This functional test cli utility to interact with a Floresta node with `getrpcin
 
 import os
 import tempfile
-from test_framework.test_framework import FlorestaTestFramework
+
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class GetRpcInfoTest(FlorestaTestFramework):
@@ -43,15 +44,18 @@ class GetRpcInfoTest(FlorestaTestFramework):
         Test if the 'getrpcinfo' result was built correctly
         """
         result = node.get_rpcinfo()
-        assert "active_commands" in result
-        assert "logpath" in result
-        assert len(result["active_commands"]) == 1
-        assert "duration" in result["active_commands"][0]
-        assert "method" in result["active_commands"][0]
-        assert result["active_commands"][0]["duration"] == 0
-        assert result["active_commands"][0]["method"] == "getrpcinfo"
-        assert result["logpath"] == os.path.normpath(
-            os.path.join(GetRpcInfoTest.data_dir, "regtest", "output.log")
+        self.assertIn("active_commands", result)
+        self.assertIn("logpath", result)
+        self.assertEqual(len(result["active_commands"]), 1)
+        self.assertIn("duration", result["active_commands"][0])
+        self.assertIn("method", result["active_commands"][0])
+        self.assertEqual(result["active_commands"][0]["duration"], 0)
+        self.assertEqual(result["active_commands"][0]["method"], "getrpcinfo")
+        self.assertEqual(
+            result["logpath"],
+            os.path.normpath(
+                os.path.join(GetRpcInfoTest.data_dir, "regtest", "output.log")
+            ),
         )
 
     def run_test(self):

--- a/tests/floresta-cli/stop-test.py
+++ b/tests/floresta-cli/stop-test.py
@@ -4,8 +4,8 @@ floresta_cli_stop.py
 This functional test cli utility to interact with a Floresta node with `stop`
 """
 
-from test_framework.test_framework import FlorestaTestFramework
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class StopTest(FlorestaTestFramework):
@@ -36,7 +36,7 @@ class StopTest(FlorestaTestFramework):
         result = node.stop()
 
         # node should be finished, do not call stop_node
-        assert result
+        self.assertEqual(result, "florestad stopping")
 
 
 if __name__ == "__main__":

--- a/tests/floresta-cli/uptime-test.py
+++ b/tests/floresta-cli/uptime-test.py
@@ -5,10 +5,11 @@ This functional test cli utility to interact with a Floresta node with `uptime`
 """
 
 import os
-import time
 import tempfile
-from test_framework.test_framework import FlorestaTestFramework
+import time
+
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class UptimeTest(FlorestaTestFramework):
@@ -64,7 +65,7 @@ class UptimeTest(FlorestaTestFramework):
         after = time.time()
         elapsed = int(after - before)
 
-        assert uptime == elapsed
+        self.assertEqual(uptime, elapsed)
 
         # Stop node
         self.stop_node(UptimeTest.nodes[0])

--- a/tests/florestad/restart-test.py
+++ b/tests/florestad/restart-test.py
@@ -6,12 +6,13 @@ A simple test that restart a Floresta node and a related data directory.
 The directories used between each power-on/power-off must not be corrupted.
 """
 
-import time
-import os
 import filecmp
+import os
 import tempfile
-from test_framework.test_framework import FlorestaTestFramework
+import time
+
 from test_framework.floresta_rpc import REGTEST_RPC_SERVER
+from test_framework.test_framework import FlorestaTestFramework
 
 
 class TestRestart(FlorestaTestFramework):
@@ -65,7 +66,9 @@ class TestRestart(FlorestaTestFramework):
         self.stop_node(TestRestart.indexes[1])
 
         # check for any corruption
-        assert filecmp.dircmp(TestRestart.data_dirs[0], TestRestart.data_dirs[1])
+        # if any files are different, we will get a list of them
+        result = filecmp.dircmp(TestRestart.data_dirs[0], TestRestart.data_dirs[1])
+        self.assertEqual(len(result.diff_files), 0)
 
 
 if __name__ == "__main__":

--- a/tests/florestad/ssl-fail-test.py
+++ b/tests/florestad/ssl-fail-test.py
@@ -38,11 +38,10 @@ class TestSslFailInitialization(FlorestaTestFramework):
 
         # now try create a connection with an electrum client at default port
         # it must fail, since the TLS port isnt opened
-        try:
+        with self.assertRaises(ConnectionRefusedError) as exc:
             TestSslFailInitialization.electrum = ElectrumClient("0.0.0.0", 50002)
 
-        except ConnectionRefusedError as exc:
-            assert exc.errno == errno.ECONNREFUSED
+        self.assertEqual(exc.exception.errno, errno.ECONNREFUSED)
 
         # Shutdown node
         self.stop_node(TestSslFailInitialization.nodes[0])

--- a/tests/florestad/ssl-test.py
+++ b/tests/florestad/ssl-test.py
@@ -39,9 +39,9 @@ class TestSslInitialization(FlorestaTestFramework):
 
         # request something to TLS port
         result = TestSslInitialization.electrum.ping()
-        self.log(result)
 
-        assert result is not None
+        # if pinged, we should get a response `""`
+        self.assertEqual(result, "")
 
         # Shutdown node
         self.stop_node(TestSslInitialization.nodes[0])

--- a/tests/test_framework/floresta_rpc.py
+++ b/tests/test_framework/floresta_rpc.py
@@ -14,6 +14,8 @@ The list below describe the python method and the related JSONRPC call:
 - get_roots: `getroots`;
 """
 
+import json
+
 # commented unused modules since maybe they can be useful
 # import os
 # import shutil
@@ -22,9 +24,10 @@ The list below describe the python method and the related JSONRPC call:
 # import traceback
 import re
 import time
-import json
 from subprocess import Popen
-from requests import post, exceptions
+from typing import Any
+
+from requests import exceptions, post
 
 REGTEST_RPC_SERVER = {
     "host": "127.0.0.1",
@@ -165,7 +168,7 @@ class FlorestaRPC:
         else:
             raise RuntimeError("Cannot wait for null process")
 
-    def perform_request(self, method, params=None) -> dict:
+    def perform_request(self, method, params=None) -> Any:
         """
         Perform an JsonRPC request to the floresta node.
         """

--- a/tests/test_framework/test_framework.py
+++ b/tests/test_framework/test_framework.py
@@ -4,22 +4,22 @@ test_framework.py
 Adapted from
 https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/test_framework.py
 
-BitcoinCore functional tests define a metaclass that checks if some important methods are defined
-or not defined.
-
-Floresta functional tests will follow this since it is a good practice for a framework.
-
-The difference is that our node will run withing a `cargo run` subprocess, defined at
-`add_node_settings`.
+BitcoinCore functional tests define a metaclass that checks if some important
+methods are defined or not defined. Floresta functional tests will follow this
+since it is a good practice for a framework. The difference is that our node
+will run withing a `cargo run` subprocess, defined at `add_node_settings`.
 """
 
 import os
+import re
 import subprocess
-from test_framework.floresta_rpc import FlorestaRPC
+from typing import Any, List, Pattern
+
 from test_framework.crypto.pkcs8 import (
     create_pkcs8_private_key,
     create_pkcs8_self_signed_certificate,
 )
+from test_framework.floresta_rpc import FlorestaRPC
 
 VALID_FLORESTAD_EXTRA_ARGS = [
     "-c",
@@ -76,15 +76,73 @@ class FlorestaTestMetaClass(type):
         return super().__new__(mcs, clsname, bases, dct)
 
 
+# pylint: disable=too-many-public-methods
 class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
     """
-    Base class for a floresta test script.
+    Base class for a floresta test script. Individual floresta
+    test scripts should:
 
-    Individual floresta test scripts should subclass this class and override the:
+    - subclass FlorestaTestFramework;
+    - not override the __init__() method;
+    - not override the main() method;
+    - implement set_test_params();
+    - implement run_test();
 
-    - set_test_params(); and
-    - run_test() methods.
+    The `set_test_params` method is called before the test starts
+    and aims to configure nodes, florestad params, what should be
+    considered as expected result, and what you think should be defined.
+    It is a good practice to set the number of nodes and their
+    configuration in this method with `self.add_node_settings`.
+
+    The `run_test` method is the test itself, where a (or more) node(s)
+    are started, and the test is executed. This is where you start a node
+    with `run_node` and wait for it to be ready with `wait_for_rpc_connection`.
+    It is also where you should do the assertions (`self.assertIsNone`,
+    `self.assertIsSome`, `self.assertEqual`, `self.assertIn`,
+    `self.assertMatch`, `self.assertTrue`, `self.assertRaises`)
+    as well stop nodes when done (`self.stop_node` for stop one node
+    or `self.stop` to stop all nodes).
+
+    In both mthods, you can use `self.log` to log messages.
+
+    At the end of file, you should execute `MyTest().main()` method.
+
+    For more details, see the tests/example/example-test.py and/or
+    tests/test_framework/test_framework.py.
     """
+
+    class _AssertRaisesContext:
+        """
+        Context manager for testing that an exception is raised.
+
+        This keeps the assertRaises functionality neatly contained within our test framework
+        """
+
+        def __init__(self, test_framework, expected_exception):
+            """Initialize the context manager with the expected exception type."""
+            self.test_framework = test_framework
+            self.expected_exception = expected_exception
+            self.exception = None
+
+        def __enter__(self):
+            """Enter the context manager."""
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            """Exit the context manager and check if the expected exception was raised."""
+            if exc_type is None:
+                self.test_framework.stop_all_nodes()
+                trace = traceback.format_exc()
+                message = f"{self.expected_exception} was not raised"
+                raise AssertionError(f"{message}: {trace}")
+
+            if not issubclass(exc_type, self.expected_exception):
+                trace = traceback.format_exc()
+                message = f"Expected {self.expected_exception} but got {exc_type}"
+                raise AssertionError(f"{message}: {trace}")
+
+            self.exception = exc_value
+            return True
 
     def __init__(self):
         """
@@ -95,7 +153,7 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
         self._tests = []
         self._nodes = []
 
-    def log(self, msg: str) -> str:
+    def log(self, msg: str):
         """Log a message with the class caller"""
         print(f"[{self.__class__.__name__} INFO] {msg}")
 
@@ -128,18 +186,14 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
         Get path for florestad used in integration tests, generally set on
         $FLORESTA_TEMP_DIR/binaries
         """
+        if os.getenv("FLORESTA_TEMP_DIR") is None:
+            raise RuntimeError(
+                "FLORESTA_TEMP_DIR not set. "
+                + " Please set it to the path of the integration test directory."
+            )
         return os.path.normpath(
-            os.path.join(os.environ.get("FLORESTA_TEMP_DIR"), "binaries")
+            os.path.join(os.getenv("FLORESTA_TEMP_DIR"), "binaries")
         )
-
-    @staticmethod
-    def get_target_release_dir():
-        """ "
-        Get path for built florestad, generally on
-        ./target/release/florestad
-        """
-        dirname = os.path.dirname(__file__)
-        return os.path.normpath(os.path.join(dirname, "..", "..", "target", "release"))
 
     def create_ssl_keys(self) -> tuple[str, str]:
         """
@@ -147,18 +201,14 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
         These keys are intended to be used with florestad's --ssl-key-path and --ssl-cert-path
         options.
         """
-        # Check if we're in CI or not
-        if "/tmp/floresta-integration-tests" in os.getenv("PATH"):
-            ssl_path = os.path.normpath(
-                os.path.abspath(
-                    os.path.join(self.get_integration_test_dir(), "..", "..", "ssl")
-                )
-            )
-        else:
-            home = os.path.expanduser("~")  # Fixed: '~user' -> '~' for current user
-            ssl_path = os.path.normpath(
-                os.path.abspath(os.path.join(home, ".floresta", "ssl"))
-            )
+        # If we're in CI, we need to use the
+        # path to the integration test dir
+        # tempfile will be used to get the proper
+        # temp dir for the OS
+        ssl_rel_path = os.path.join(
+            FlorestaTestFramework.get_integration_test_dir(), "..", "..", "ssl"
+        )
+        ssl_path = os.path.normpath(os.path.abspath(ssl_rel_path))
 
         # Create the folder if not exists
         os.makedirs(ssl_path, exist_ok=True)
@@ -179,32 +229,29 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
         self, chain: str, extra_args: list[str], rpcserver: dict, ssl: bool = False
     ) -> int:
         """
-        Add a node settings to be run. Use this on set_test_params method many times you want.
-
-        extra_args should be a list of string in the --key=value strings
-        (see florestad --help for a list of available commands)
+        Add a node settings to be run. Use this on set_test_params method
+        many times you want. Extra_args should be a list of string in the
+        --key=value strings (see florestad --help for a list of available
+        commands)
         """
         # PR #331 introduced a preparatory environment at
         # /tmp/floresta-integration-tests.$(git rev-parse HEAD).
-        tmpdir = FlorestaTestFramework.get_integration_test_dir()
-        targetdir = FlorestaTestFramework.get_target_release_dir()
-
         # So, check for it first before define the florestad path.
-        if os.path.exists(tmpdir):
-            florestad = os.path.normpath(os.path.join(tmpdir, "florestad"))
+        if os.getenv("FLORESTA_TEMP_DIR") is not None:
+            targetdir = FlorestaTestFramework.get_integration_test_dir()
 
-        # If not exists, define the one at ./target/release.
-        elif os.path.exists(targetdir):
-            florestad = os.path.normpath(os.path.join(targetdir, "florestad"))
-
-        # In case any test florestad is found, raise an exception
         else:
             raise RuntimeError(
-                f"Not found 'florestad' in '{tmpdir}' or '{targetdir}'. "
-                "Run 'tests/prepare.sh' or 'cargo build --release'."
+                "FLORESTA_TEMP_DIR not set. "
+                + " Please set it to the path of the integration test directory."
             )
 
-        print(f"Using {florestad}")
+        florestad = os.path.join(targetdir, "florestad")
+
+        # In case any florestad is found, raise an exception
+        if not os.path.exists(florestad):
+            raise RuntimeError(f"Not found any 'florestad' in '{targetdir}'")
+
         setting = {
             "chain": chain,
             "config": [florestad, "--network", chain],
@@ -258,7 +305,8 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
 
         if node["chain"] == "regtest":
             # pylint: disable=consider-using-with
-            # add text=True to treat all outputs as texts (jsons or python stack traces)
+            # add text=True to treat all outputs as texts
+            # (jsons or python stack traces)
             cmd = " ".join(node["config"])
             self.log(f"Running '{cmd}'")
             process_node = subprocess.Popen(node["config"], text=True)
@@ -296,3 +344,80 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
         """
         for i in range(len(self._nodes)):
             self.stop_node(i)
+
+    # pylint: disable=invalid-name
+    def assertTrue(self, condition: bool):
+        """
+        Assert if the condition is True, otherwise
+        all nodes will be stopped and an AssertionError will
+        be raised
+        """
+        if not condition:
+            self.stop()
+            raise AssertionError(f"Actual: {condition}\nExpected: True")
+
+    # pylint: disable=invalid-name
+    def assertIsNone(self, thing: Any):
+        """
+        Assert if the condition is None, otherwise
+        all nodes will be stopped and an AssertionError will
+        be raised
+        """
+        if thing is not None:
+            self.stop()
+            raise AssertionError(f"Actual: {thing}\nExpected: None")
+
+    # pylint: disable=invalid-name
+    def assertIsSome(self, thing: Any):
+        """
+        Assert if the condition is not None, otherwise
+        all nodes will be stopped and an AssertionError will
+        be raised
+        """
+        if thing is None:
+            self.stop()
+            raise AssertionError(f"Actual: {thing}\nExpected: not None")
+
+    # pylint: disable=invalid-name
+    def assertEqual(self, condition: Any, expected: Any):
+        """
+        Assert if the condition is True, otherwise
+        all nodes will be stopped and an AssertionError will
+        be raised
+        """
+
+        if not condition == expected:
+            self.stop()
+            raise AssertionError(f"Actual: {condition}\nExpected: {expected}")
+
+    # pylint: disable=invalid-name
+    def assertIn(self, element: Any, listany: List[Any]):
+        """
+        Assert if the element is in listany , otherwise
+        all nodes will be stopped and an AssertionError will
+        be raised
+        """
+
+        if element not in listany:
+            self.stop()
+            raise AssertionError(
+                f"Actual: {element} not in {listany}\nExpected: {element} in {listany}"
+            )
+
+    # pylint: disable=invalid-name
+    def assertMatch(self, actual: Any, pattern: Pattern):
+        """
+        Assert if the element fully matches a pattern, otherwise
+        all nodes will be stopped and an AssertionError will
+        be raised
+        """
+
+        if not re.fullmatch(pattern, actual):
+            self.stop()
+            raise AssertionError(
+                f"Actual: {actual} !~ {pattern} \nExpected: {actual} ~ {set}"
+            )
+
+    def assertRaises(self, expected_exception):
+        """Assert that the expected exception is raised."""
+        return self._AssertRaisesContext(self, expected_exception)


### PR DESCRIPTION
Fix #426 

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: functional tests

### Description

Added a pipeline for assertions, where a failure of a condition start a node's shutdown procedure. The pipeline can be used with these methods:

* assertTrue for boolean condition;

* assertEqual for expected general condition;

* assertIn for expected item in a list;

* assertMatch for expected strings in a given regex pattern;

* assertRaises for expected exceptions.

The pipeline was applied in these suites:

* Added assertion pipeline to example suite;

* Added assertion pipeline to floresta-cli suite;

* Added assertion pipeline to florestad suite.

### Notes to the reviewers

This PR depends on #431 to work without false positives.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Checklist

- [x] I've signed all my commits
- [x] I ran `just lint`
- [x] I ran `cargo test`
- [x] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
