### PR TITLE
CI: Check clippy on all feature combinations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-hack
 
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@nightly
@@ -24,7 +25,8 @@ jobs:
         run: cargo +nightly fmt --all --check
 
       - name: Run cargo clippy
-        run: cargo +nightly clippy --all-targets -- -D warnings
+        run: ./contrib/feature_matrix.sh clippy '-- -D warnings'
+        shell: bash   # Ensure the script runs using bash on all platforms
 
   cross-testing:
     strategy:
@@ -71,7 +73,7 @@ jobs:
 
       # Run the feature testing script
       - name: Run feature tests
-        run: ./contrib/test_features.sh --verbose
+        run: ./contrib/feature_matrix.sh test --verbose
         shell: bash   # Ensure the script runs using bash on all platforms
 
       # Save cache only if the previous steps succeeded and there was not an exact cache key match

--- a/crates/floresta-common/src/lib.rs
+++ b/crates/floresta-common/src/lib.rs
@@ -14,6 +14,7 @@ use sha2::Digest;
 pub mod macros;
 pub mod spsc;
 
+#[cfg(any(feature = "descriptors-std", feature = "descriptors-no-std"))]
 use prelude::*;
 pub use spsc::Channel;
 

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::fmt::Arguments;
 use std::fs::File;
 use std::io::BufReader;
@@ -45,8 +44,6 @@ use log::error;
 use log::info;
 use log::warn;
 use log::Record;
-#[cfg(feature = "metrics")]
-use metrics;
 use rustreexo::accumulator::pollard::Pollard;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
@@ -443,8 +440,7 @@ impl Florestad {
         {
             info!("Starting ZMQ server");
             if let Ok(zserver) = ZMQServer::new(
-                &self
-                    .config
+                self.config
                     .zmq_address
                     .as_ref()
                     .unwrap_or(&"tcp://127.0.0.1:5150".to_string()),
@@ -477,7 +473,7 @@ impl Florestad {
             ));
 
             if self.json_rpc.set(server).is_err() {
-                panic!("We should be the first one setting this");
+                core::panic!("We should be the first one setting this");
             }
         }
 

--- a/justfile
+++ b/justfile
@@ -61,7 +61,9 @@ doc:
 
 # Format code and run configured linters
 lint:
-    cargo +nightly fmt --all && cargo +nightly clippy --all-targets
+    @just fmt
+    cargo +nightly clippy --all-targets --no-default-features
+    cargo +nightly clippy --all-targets --all-features
 
 # Format code
 fmt:
@@ -71,14 +73,22 @@ fmt:
 format:
     cargo +nightly fmt --all --check
 
-# Test all feature combinations for each crate using cargo-hack (arg: optional, e.g., --quiet or --verbose)
+# Test all feature combinations in each crate (arg: optional, e.g., --quiet or --verbose)
 test-features arg="":
     cargo install cargo-hack --locked
-    ./contrib/test_features.sh {{arg}}
+    ./contrib/feature_matrix.sh test {{arg}}
+
+# Run clippy for all feature combinations in each crate (arg: optional, e.g., '-- -D warnings')
+lint-features arg="":
+    cargo install cargo-hack --locked
+    ./contrib/feature_matrix.sh clippy '{{arg}}'
 
 # Remove test-generated data
 clean-data:
     ./contrib/clean_data.sh
 
 # Run all needed checks before contributing code (pre-commit check)
-pcc: lint test-features
+pcc:
+    @just fmt
+    @just lint-features '-- -D warnings'
+    @just test-features


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: clippy checks

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [x] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [x] Other: rust.yml, justfile, contrib

### Description

Renamed `test_features.sh` to `feature_matrix.sh`, which now can execute two actions for all features: clippy or test.

The script can be run as:
`./contrib/feature_matrix.sh {clippy|test} [cargo_arg]`

Similar to the `test-features` just recipe, I have added a `lint-features` one.

### Notes to the reviewers

You can easily verify that this works by adding any unused import that is not compiled by default. Then run `just lint-features '-- -D warnings'` (to trigger an error, which we do in CI)