### PR TITLE
Fix: raise warn instead of error if anchors arent made yet

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -28,8 +28,12 @@ pub enum WireError {
     NoPeersAvailable,
     #[error("Our peer is misbehaving")]
     PeerMisbehaving,
-    #[error("Generic io error")]
+    #[error("Failed to init peers, anchors.json does not exist yet.")]
+    AnchorFileNotFound,
+    #[error("Generic io error: {0}")]
     Io(std::io::Error),
+    #[error("{0}")]
+    Serde(serde_json::Error),
     #[error("We don't have any utreexo peers")]
     NoUtreexoPeersAvailable,
     #[error("We couldn't find a peer to send the request")]
@@ -58,6 +62,12 @@ impl_error_from!(WireError, AddrParseError, InvalidAddress);
 impl From<tokio::sync::mpsc::error::SendError<NodeRequest>> for WireError {
     fn from(error: tokio::sync::mpsc::error::SendError<NodeRequest>) -> Self {
         WireError::ChannelSend(error)
+    }
+}
+
+impl From<serde_json::Error> for WireError {
+    fn from(err: serde_json::Error) -> WireError {
+        WireError::Serde(err)
     }
 }
 

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1343,7 +1343,20 @@ macro_rules! try_and_log {
         let result = $what;
 
         if let Err(error) = result {
-            log::error!("{}:{} - {:?}", line!(), file!(), error);
+            log::error!("{}: {} - {:?}", line!(), file!(), error);
+        }
+    };
+}
+
+/// Run a task and warn any errors that might occur.
+///
+/// try_and_log variant for tasks that can safely fail.
+macro_rules! try_and_warn {
+    ($what:expr) => {
+        let result = $what;
+
+        if let Err(warning) = result {
+            log::warn!("{}: {} - {}", line!(), file!(), warning);
         }
     };
 }
@@ -1365,6 +1378,7 @@ macro_rules! periodic_job {
 
 pub(crate) use periodic_job;
 pub(crate) use try_and_log;
+pub(crate) use try_and_warn;
 
 #[cfg(test)]
 mod tests {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -35,6 +35,7 @@ use super::peer::PeerMessages;
 use crate::address_man::AddressState;
 use crate::node::periodic_job;
 use crate::node::try_and_log;
+use crate::node::try_and_warn;
 use crate::node::ConnectionKind;
 use crate::node::InflightRequests;
 use crate::node::NodeNotification;
@@ -347,7 +348,7 @@ where
     }
 
     pub async fn run(mut self, stop_signal: futures::channel::oneshot::Sender<()>) {
-        try_and_log!(self.init_peers().await);
+        try_and_warn!(self.init_peers().await);
 
         // Use this node state to Initial Block download
         let mut ibd = UtreexoNode {


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

On a clean `datadir` florestad raises an error about `anchors.json` that was actually a expected behavior.

### Notes to the reviewers

fix #438 

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I'm linking the issue being fixed by this PR (if any)
