### PR TITLE
Create `UtxoData` and check coinbase maturity

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -39,6 +39,7 @@ use super::error::BlockValidationErrors;
 use super::error::BlockchainError;
 use super::BlockchainInterface;
 use super::UpdatableChainstate;
+use crate::pruned_utreexo::utxo_data::UtxoData;
 use crate::UtreexoBlock;
 
 #[doc(hidden)]
@@ -165,7 +166,7 @@ impl PartialChainStateInner {
         &mut self,
         block: &bitcoin::Block,
         proof: rustreexo::accumulator::proof::Proof,
-        inputs: HashMap<bitcoin::OutPoint, bitcoin::TxOut>,
+        inputs: HashMap<bitcoin::OutPoint, UtxoData>,
         del_hashes: Vec<bitcoin::hashes::sha256::Hash>,
     ) -> Result<u32, BlockchainError> {
         let height = self.current_height + 1;
@@ -203,7 +204,7 @@ impl PartialChainStateInner {
         &self,
         block: &bitcoin::Block,
         height: u32,
-        inputs: HashMap<bitcoin::OutPoint, bitcoin::TxOut>,
+        inputs: HashMap<bitcoin::OutPoint, UtxoData>,
     ) -> Result<(), BlockchainError> {
         if !block.check_merkle_root() {
             return Err(BlockValidationErrors::BadMerkleRoot)?;
@@ -300,7 +301,7 @@ impl UpdatableChainstate for PartialChainState {
         &self,
         block: &bitcoin::Block,
         proof: rustreexo::accumulator::proof::Proof,
-        inputs: HashMap<bitcoin::OutPoint, bitcoin::TxOut>,
+        inputs: HashMap<bitcoin::OutPoint, UtxoData>,
         del_hashes: Vec<bitcoin::hashes::sha256::Hash>,
     ) -> Result<u32, BlockchainError> {
         self.inner_mut()
@@ -437,7 +438,7 @@ impl BlockchainInterface for PartialChainState {
         &self,
         _block: &bitcoin::Block,
         _proof: rustreexo::accumulator::proof::Proof,
-        _inputs: HashMap<bitcoin::OutPoint, bitcoin::TxOut>,
+        _inputs: HashMap<bitcoin::OutPoint, UtxoData>,
         _del_hashes: Vec<bitcoin::hashes::sha256::Hash>,
         _acc: Stump,
     ) -> Result<(), Self::Error> {

--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -389,6 +389,7 @@ where
         let (proof, del_hashes, _) = floresta_chain::proof_util::process_proof(
             block.udata.as_ref().unwrap(),
             &block.block.txdata,
+            height,
             |h| self.chain.get_block_hash(h),
         )?;
 
@@ -527,14 +528,15 @@ where
             };
             break block;
         };
+        let fork_height = self.chain.get_block_height(&fork)?.unwrap_or(0);
 
         let (proof, del_hashes, inputs) = floresta_chain::proof_util::process_proof(
             block.udata.as_ref().unwrap(),
             &block.block.txdata,
+            fork_height,
             |h| self.chain.get_block_hash(h),
         )?;
 
-        let fork_height = self.chain.get_block_height(&fork)?.unwrap_or(0);
         let acc = self.find_accumulator_for_block(fork_height, fork).await?;
         let is_valid = self
             .chain

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -722,10 +722,12 @@ where
                 return Ok(());
             };
 
-            let (proof, del_hashes, inputs) =
-                floresta_chain::proof_util::process_proof(udata, &block.block.txdata, |h| {
-                    self.chain.get_block_hash(h)
-                })?;
+            let (proof, del_hashes, inputs) = floresta_chain::proof_util::process_proof(
+                udata,
+                &block.block.txdata,
+                validation_index + 1,
+                |h| self.chain.get_block_hash(h),
+            )?;
 
             if let Err(e) =
                 self.chain

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -245,8 +245,8 @@ where
 
         self.blocks.insert(block.block.block_hash(), (peer, block));
 
-        let next_block = self.chain.get_validation_index()? + 1;
-        let mut next_block = self.chain.get_block_hash(next_block)?;
+        let next_block_height = self.chain.get_validation_index()? + 1;
+        let mut next_block = self.chain.get_block_hash(next_block_height)?;
 
         while let Some((peer, block)) = self.blocks.remove(&next_block) {
             let start = Instant::now();
@@ -271,6 +271,7 @@ where
             let (proof, del_hashes, inputs) = floresta_chain::proof_util::process_proof(
                 &block.udata.unwrap(),
                 &block.block.txdata,
+                next_block_height,
                 |h| self.chain.get_block_hash(h),
             )?;
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Refactor

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: Benches

### Description

I have added the same `UtxoData` struct from PR #300, but with an additional `is_coinbase` flag. We get the flag from the utreexo leaf header code, just like the utxo creation height. The utxo creation unix time is not computed nor used anywhere (covered at #300).

The `Consensus::verify_transaction` now checks the spent coinbase tx outputs maturity. `ChainParams` has a constant for the maturity period but it's always 100 regardless of the network.

### Notes to the reviewers

Most of this diff is refactoring `TxOut` to `UtxoData` in functions. I'm generally not using a `UtxoMap` type alias in order to keep the map types explicit on a first look.

This PR should should make #300 more focused on the timelock checks and unix time computation, and less so on refactors.