### PR TITLE
fix(wire): don't error if we don't have any utreexo peers to save

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -28,13 +28,13 @@ pub enum WireError {
     NoPeersAvailable,
     #[error("Our peer is misbehaving")]
     PeerMisbehaving,
-    #[error("Failed to init peers, anchors.json does not exist yet.")]
+    #[error("Failed to init Utreexo peers: anchors.json does not exist yet")]
     AnchorFileNotFound,
     #[error("Generic io error: {0}")]
     Io(std::io::Error),
     #[error("{0}")]
     Serde(serde_json::Error),
-    #[error("We don't have any utreexo peers")]
+    #[error("Failed to save Utreexo peers: no peers to save to anchors.json")]
     NoUtreexoPeersAvailable,
     #[error("We couldn't find a peer to send the request")]
     NoPeerToSendRequest,

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -942,7 +942,7 @@ where
         for peer in self.peer_ids.iter() {
             try_and_log!(self.send_to_peer(*peer, NodeRequest::Shutdown).await);
         }
-        try_and_log!(self.save_utreexo_peers());
+        try_and_warn!(self.save_utreexo_peers());
         try_and_log!(self.save_peers());
         try_and_log!(self.chain.flush());
     }
@@ -1028,10 +1028,10 @@ where
         let peers: &Vec<u32> = self
             .peer_by_service
             .get(&service_flags::UTREEXO.into())
-            .ok_or(WireError::NoPeersAvailable)?;
+            .ok_or(WireError::NoUtreexoPeersAvailable)?;
         let peers_usize: Vec<usize> = peers.iter().map(|&peer| peer as usize).collect();
         if peers_usize.is_empty() {
-            warn!("No connected utreexo peers to save to disk");
+            warn!("No connected Utreexo peers to save to disk");
             return Ok(());
         }
         info!("Saving utreexo peers to disk");
@@ -1318,7 +1318,7 @@ macro_rules! try_and_warn {
         let result = $what;
 
         if let Err(warning) = result {
-            log::warn!("{}: {} - {}", line!(), file!(), warning);
+            log::warn!("{}", warning);
         }
     };
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

This PR builds on #439 to also removes the warning when trying to persist Utreexo peers. Now the `NoUtreexoPeersAvailable` variant is used instead.

I took the liberty of modifying the  `try_and_warn!` macro and the error strings, as I think the output looks cleaner now.

```
$ florestad
[2025-04-11 18:36:02 WARN florestad::florestad] Could not read config file, ignoring it
[2025-04-11 18:36:02 INFO florestad::florestad] Wallet setup completed!
[2025-04-11 18:36:02 INFO florestad::florestad] Loading blockchain database
[2025-04-11 18:36:02 INFO florestad::florestad] Loaded compact filters store at height: 0
[2025-04-11 18:36:02 INFO florestad::florestad] Starting server
[2025-04-11 18:36:02 WARN florestad::florestad] Failed to load SSL certificates: Error while opening PKCS#8 certificate /home/schwab/.floresta/ssl/cert.pem: No such file or directory (os error 2)
[2025-04-11 18:36:02 INFO florestad::florestad] Server running on: 0.0.0.0:50001
[2025-04-11 18:36:02 INFO floresta_wire::p2p_wire::address_man] Starting peer discovery via DNS seeds
[2025-04-11 18:36:02 INFO floresta_wire::p2p_wire::address_man] Got 25 peers from seed.calvinkim.info
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 46 peers from seed.bitcoin.luisschwab.com
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 25 peers from seed.bitcoin.sipa.be
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 42 peers from dnsseed.bluematt.me
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 48 peers from seed.bitcoinstats.com
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 46 peers from seed.btc.petertodd.org
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 46 peers from seed.bitcoin.sprovoost.nl
[2025-04-11 18:36:04 INFO floresta_wire::p2p_wire::address_man] Got 50 peers from dnsseed.emzy.de
^C[2025-04-11 18:36:06 INFO floresta_wire::p2p_wire::address_man] Got 42 peers from seed.bitcoin.wiz.biz
[2025-04-11 18:36:06 INFO floresta_wire::p2p_wire::address_man] Got 370 peers from 9 DNS seeds
[2025-04-11 18:36:06 WARN floresta_wire::p2p_wire::running_node] Failed to init utreexo peers: anchors.json does not exist yet
[2025-04-11 18:36:06 INFO floresta_wire::p2p_wire::chain_selector] Starting IBD, selecting the best chain
[2025-04-11 18:36:07 INFO florestad] Shutting down florestad
[2025-04-11 18:36:07 INFO floresta_wire::p2p_wire::node] Shutting down node
[2025-04-11 18:36:07 WARN floresta_wire::p2p_wire::node] Failed to save utreexo peers: no peers to save to anchors.json
```

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
