### PR TITLE
functional-tests: allow using different versions of utreexod

### DIFF
--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -45,7 +45,7 @@ Using these scripts, you have a few options for running the tests and verifying 
 
 2) (Recommended): Use the helper scripts — [prepare.sh](https://github.com/vinteumorg/Floresta/blob/master/tests/prepare.sh) and [run.sh](https://github.com/vinteumorg/Floresta/blob/master/tests/run.sh) — to automatically build and run the tests.
 
-3) With installed binaries: If you’ve already installed the binaries system-wide, you can simply run the tests directly.
+3) With installed binaries: If you've already installed the binaries system-wide, you can simply run the tests directly.
 
 ### Running Functional Tests
 

--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -47,6 +47,13 @@ Using these scripts, you have a few options for running the tests and verifying 
 
 3) With installed binaries: If you've already installed the binaries system-wide, you can simply run the tests directly.
 
+By default, the tool will build `utreexod` on its latest commit on `main` branch. If you want to build a specific commit, you can set the `UTREEXO_REVISION` environment variable before running the script. It may be a tag or a commit hash. For example:
+
+```bash
+export UTREEXO_REVISION=0.1.0
+./tests/prepare.sh
+```
+
 ### Running Functional Tests
 
 Additional functional tests are available (minimum python version: 3.12).

--- a/tests/floresta-cli/addnode-test.py
+++ b/tests/floresta-cli/addnode-test.py
@@ -31,21 +31,22 @@ class GetAddnodeIDBErrorTest(FlorestaTestFramework):
     data_dirs = [
         os.path.normpath(
             os.path.join(
-                tempfile.gettempdir(),
-                "floresta-func-tests",
+                FlorestaTestFramework.get_integration_test_dir(),
+                "data",
                 "florestacli-addnode-test",
                 "node-0",
             )
         ),
         os.path.normpath(
             os.path.join(
-                tempfile.gettempdir(),
-                "floresta-func-tests",
+                FlorestaTestFramework.get_integration_test_dir(),
+                "data",
                 "floresta-cli-addnode-test",
                 "node-1",
             )
         ),
     ]
+
     electrum_addrs = ["0.0.0.0:50001", "0.0.0.0:50002"]
     rpc_addrs = ["0.0.0.0:18442", "0.0.0.0:18443"]
     node_ibd_error = "Node is in initial block download, wait until it's finished"

--- a/tests/floresta-cli/getmemoryinfo-test.py
+++ b/tests/floresta-cli/getmemoryinfo-test.py
@@ -24,8 +24,8 @@ class GetMemoryInfoTest(FlorestaTestFramework):
     # pylint: disable=duplicate-code
     data_dir = os.path.normpath(
         os.path.join(
-            tempfile.gettempdir(),
-            "floresta-func-tests",
+            FlorestaTestFramework.get_integration_test_dir(),
+            "data",
             "florestacli-getmemoryinfo-test",
             "node-0",
         )

--- a/tests/floresta-cli/getrpcinfo-test.py
+++ b/tests/floresta-cli/getrpcinfo-test.py
@@ -19,8 +19,8 @@ class GetRpcInfoTest(FlorestaTestFramework):
     nodes = [-1]
     data_dir = os.path.normpath(
         os.path.join(
-            tempfile.gettempdir(),
-            "floresta-func-tests",
+            FlorestaTestFramework.get_integration_test_dir(),
+            "data",
             "florestacli-getrpcinfo-test",
             "node-0",
         )

--- a/tests/floresta-cli/uptime-test.py
+++ b/tests/floresta-cli/uptime-test.py
@@ -24,8 +24,8 @@ class UptimeTest(FlorestaTestFramework):
     # pylint: disable=duplicate-code
     data_dir = os.path.normpath(
         os.path.join(
-            tempfile.gettempdir(),
-            "floresta-func-tests",
+            FlorestaTestFramework.get_integration_test_dir(),
+            "data",
             "florestacli-uptime-test",
             "node-0",
         )

--- a/tests/florestad/restart-test.py
+++ b/tests/florestad/restart-test.py
@@ -25,12 +25,18 @@ class TestRestart(FlorestaTestFramework):
     data_dirs = [
         os.path.normpath(
             os.path.join(
-                tempfile.gettempdir(), "floresta-func-tests", "restart", "node-0"
+                FlorestaTestFramework.get_integration_test_dir(),
+                "data",
+                "restart",
+                "node-0",
             )
         ),
         os.path.normpath(
             os.path.join(
-                tempfile.gettempdir(), "floresta-func-tests", "restart", "node-1"
+                FlorestaTestFramework.get_integration_test_dir(),
+                "data",
+                "restart",
+                "node-1",
             )
         ),
     ]

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -61,6 +61,18 @@ build_utreexod() {
 	git clone https://github.com/utreexo/utreexod
 
 	cd utreexod
+	
+	# check if UTREEXO_REVISION is set, if so checkout to it
+	if [ -n "$UTREEXO_REVISION" ]; then
+		# Check if the revision exists as a tag only
+		if git --no-pager tag -l | grep "$UTREEXO_REVISION"; then
+			git checkout "tags/v$UTREEXO_REVISION"
+		else
+			echo "utreexod 'v$UTREEXO_REVISION' is not a valid tag in this repository."
+			exit 1
+		fi
+	fi
+
 	go build -o $FLORESTA_TEMP_DIR/binaries/. .
 	rm -rf $FLORESTA_TEMP_DIR/binaries/build
 }
@@ -96,3 +108,4 @@ fi
 
 echo "All done!"
 exit 0
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,8 +18,19 @@ if [[ -z "$FLORESTA_TEMP_DIR" ]]; then
     # This helps us to keep track of the actual version being tested without conflicting with any already installed binaries.
     HEAD_COMMIT_HASH=$(git rev-parse HEAD)
 
+    # This helps us to keep track of the actual version being tested without conflicting with any already installed binaries.
+    GIT_DESCRIBE=$(git describe --tags --always)
+
     # Since its deterministic how we make the setup, we already know where to search for the binaries to be testing.
-    export FLORESTA_TEMP_DIR="/tmp/floresta-functional-tests.${HEAD_COMMIT_HASH}"
+    export FLORESTA_TEMP_DIR="/tmp/floresta-func-tests.${GIT_DESCRIBE}"
 
 fi
+
 uv run ./tests/run_tests.py
+
+# Clean up the data dir if we succeeded and --preserve-data-dir was not passed
+if [ $? -eq 0 ] && [ "$1" != "--preserve-data-dir" ];
+then
+    echo "Tests passed, cleaning up the data dir at $FLORESTA_TEMP_DIR"
+    rm -rf $FLORESTA_TEMP_DIR/data $FLORESTA_TEMP_DIR/logs
+fi

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -7,7 +7,6 @@ can run it with `python` if you installed the packages properly, in a isolated o
 environment (althought we recommend the isolated environment).
 
 All tests will run as a spwaned subprocess and what happens will be logged to a temporary directory
-(we defined, in linux, /tmp/floresta-func-tests/<test_name>):
 
 ```bash
 # The default way to run all tests
@@ -32,10 +31,13 @@ import os
 import subprocess
 import time
 import argparse
-import tempfile
 
 
-BASE_DIR = os.path.normpath(os.path.join(tempfile.gettempdir(), "floresta-func-tests"))
+from test_framework.test_framework import FlorestaTestFramework
+
+BASE_DIR = os.path.normpath(
+    os.path.join(FlorestaTestFramework.get_integration_test_dir(), "logs")
+)
 INFO_EMOJI = "ℹ️"
 SUCCESS_EMOJI = "✅"
 FAILURE_EMOJI = "❌"


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [X] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: tests.

### Description

Right now the functional tests uses `~/.floresta` as datadir and builds utreexod on $PWD. That kills the insulation idea behind the tempdir we are using. This commit fixes this by building utreexod inside the tempdir/build and using tempdir/data as datadir

Then, I've implemented a logic to allow using any version of `utreexod`. In the future, we can run `floresta` against different versions of `utreexod` and `bitcoind`.
  
### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
