### PR TITLE
Fix rust lint warnings

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1536,7 +1536,7 @@ mod test {
             if let Ok(DiskBlockHeader::HeadersOnly(..)) = chain.get_disk_block_header(&accepted) {
                 continue;
             }
-            panic!("Block {} is not in the store", i);
+            panic!("Block {i} is not in the store");
         }
     }
 

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -460,7 +460,7 @@ mod tests {
         // order <spending_tx>:<prevout>.
 
         let Some((spending, prevout)) = case.split_once(':') else {
-            panic!("Invalid case: {}", case);
+            panic!("Invalid case: {case}");
         };
 
         let spending_tx: Transaction = deserialize_hex(spending).unwrap();
@@ -582,7 +582,7 @@ mod tests {
             BlockchainError::TransactionError(inner) => {
                 assert_eq!(inner, tx_err!(|| spending_tx.compute_txid(), ScriptError));
             }
-            e => panic!("Expected a TransactionError, but got: {:?}", e),
+            e => panic!("Expected a TransactionError, but got: {e:?}"),
         }
     }
 }

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -93,17 +93,17 @@ impl Display for BlockValidationErrors {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             BlockValidationErrors::ScriptValidationError(e) => {
-                write!(f, "{}", e)
+                write!(f, "{e}")
             }
             BlockValidationErrors::UtxoNotFound(outpoint) => {
-                write!(f, "Utxo referenced by {:?} not found", outpoint)
+                write!(f, "Utxo referenced by {outpoint:?} not found")
             }
             BlockValidationErrors::InvalidOutput => {
                 write!(f, "Invalid output, verify spending values")
             }
             BlockValidationErrors::BlockTooBig => write!(f, "Block too big"),
             BlockValidationErrors::InvalidCoinbase(e) => {
-                write!(f, "Invalid coinbase: {:?}", e)
+                write!(f, "Invalid coinbase: {e:?}")
             }
             BlockValidationErrors::TooManyCoins => write!(f, "Moving more coins that exists"),
             BlockValidationErrors::ScriptError => {
@@ -160,7 +160,7 @@ impl_error_from!(BlockchainError, script::Error, ScriptValidationFailed);
 
 impl Display for BlockchainError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -93,13 +93,13 @@ mod tests {
         let fld = Command::new(&florestad_path)
             .args(["-n", "regtest"])
             .args(["--data-dir", &dirname])
-            .args(["--rpc-address", &format!("127.0.0.1:{}", port)])
+            .args(["--rpc-address", &format!("127.0.0.1:{port}")])
             .args(["--electrum-address", "127.0.0.1:0"])
             .args(["--ssl-electrum-address", "127.0.0.1:0"])
             .stdout(Stdio::null())
             .stderr(Stdio::inherit())
             .spawn()
-            .unwrap_or_else(|e| panic!("Couldn't launch florestad at {}: {}", florestad_path, e));
+            .unwrap_or_else(|e| panic!("Couldn't launch florestad at {florestad_path}: {e}"));
 
         let client = Client::new(format!("http://127.0.0.1:{port}"));
 

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     let res = do_request(&cli, client)?;
 
     // Print the result to the console
-    println!("{}", res);
+    println!("{res}");
 
     // Return Ok to indicate the program ran successfully
     anyhow::Ok(())

--- a/crates/floresta-compact-filters/src/flat_filters_store.rs
+++ b/crates/floresta-compact-filters/src/flat_filters_store.rs
@@ -232,6 +232,6 @@ mod tests {
 
         assert_eq!(iter.next(), None);
         remove_file(path).expect("could not remove file after test");
-        remove_file(format!("{}-index", path)).expect("could not remove index after test");
+        remove_file(format!("{path}-index")).expect("could not remove index after test");
     }
 }

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -993,7 +993,7 @@ mod test {
     }
 
     async fn send_request(request: String, port: u16) -> Result<Value, io::Error> {
-        let address = format!("localhost:{}", port);
+        let address = format!("localhost:{port}");
         let mut stream = TcpStream::connect(address).await?;
 
         stream.write_all(request.as_bytes()).await?;
@@ -1014,7 +1014,7 @@ mod test {
                 Ok(response)
             }
             Ok(Err(e)) => {
-                eprintln!("Error reading from socket: {}", e);
+                eprintln!("Error reading from socket: {e}");
                 Err(e)
             }
             Err(_) => Err(io::Error::new(io::ErrorKind::TimedOut, "Timeout occurred")),

--- a/crates/floresta-watch-only/src/kv_database.rs
+++ b/crates/floresta-watch-only/src/kv_database.rs
@@ -39,10 +39,10 @@ impl_error_from!(KvDatabaseError, Error, DeserializeError);
 impl Display for KvDatabaseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            KvDatabaseError::KvError(e) => write!(f, "KvError: {}", e),
-            KvDatabaseError::SerdeJsonError(e) => write!(f, "SerdeJsonError: {}", e),
+            KvDatabaseError::KvError(e) => write!(f, "KvError: {e}"),
+            KvDatabaseError::SerdeJsonError(e) => write!(f, "SerdeJsonError: {e}"),
             KvDatabaseError::WalletNotInitialized => write!(f, "WalletNotInitialized"),
-            KvDatabaseError::DeserializeError(e) => write!(f, "DeserializeError: {}", e),
+            KvDatabaseError::DeserializeError(e) => write!(f, "DeserializeError: {e}"),
             KvDatabaseError::TransactionNotFound => write!(f, "TransactionNotFound"),
         }
     }

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -47,7 +47,7 @@ impl<DatabaseError: fmt::Debug> Display for WatchOnlyError<DatabaseError> {
                 write!(f, "Transaction not found")
             }
             WatchOnlyError::DatabaseError(e) => {
-                write!(f, "Database error: {:?}", e)
+                write!(f, "Database error: {e:?}")
             }
         }
     }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -273,7 +273,7 @@ impl AddressMan {
     ) -> Result<Vec<LocalAddress>, dns_lookup::LookupError> {
         let mut addresses = Vec::new();
         for ip in dns_lookup::lookup_host(address)? {
-            if let Ok(ip) = LocalAddress::try_from(format!("{}:{}", ip, default_port).as_str()) {
+            if let Ok(ip) = LocalAddress::try_from(format!("{ip}:{default_port}").as_str()) {
                 addresses.push(ip);
             }
         }

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1353,9 +1353,9 @@ mod tests {
         let result =
             UtreexoNode::<PartialChainState, RunningNode>::resolve_connect_host(address, port);
         if should_succeed {
-            assert!(result.is_ok(), "Failed: {}", description);
+            assert!(result.is_ok(), "Failed: {description}");
         } else {
-            assert!(result.is_err(), "Unexpected success: {}", description);
+            assert!(result.is_err(), "Unexpected success: {description}");
         }
     }
 

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -105,5 +105,5 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Block: {:?}", block);
+    println!("Block: {block:?}");
 }

--- a/crates/floresta/examples/watch-only.rs
+++ b/crates/floresta/examples/watch-only.rs
@@ -75,11 +75,11 @@ fn main() {
 
     // We can now print the information we fetched.
     println!("************** Wallet Summary *****************\n");
-    println!("Descriptor: {}\n", descriptor);
-    println!("Address #1 hash: {}\n", hash);
-    println!("History: {:#?}\n", history);
-    println!("Balance: {:?}\n", balance);
-    println!("UTXOs: {:#?}", utxos);
+    println!("Descriptor: {descriptor}\n");
+    println!("Address #1 hash: {hash}\n");
+    println!("History: {history:#?}\n");
+    println!("Balance: {balance:?}\n");
+    println!("UTXOs: {utxos:#?}");
 }
 
 const BLOCKS: [&str; 11] = [

--- a/florestad/build.rs
+++ b/florestad/build.rs
@@ -17,8 +17,8 @@ fn main() {
         .expect("Failed to run rustc --version. Is rustc installed?");
 
     let long_version = format!("version {version} compiled for {arch}-{os}-{runtime} with {rustc}");
-    println!("cargo:rustc-env=LONG_VERSION={}", long_version);
-    println!("cargo:rustc-env=GIT_DESCRIBE={}", version);
+    println!("cargo:rustc-env=LONG_VERSION={long_version}");
+    println!("cargo:rustc-env=GIT_DESCRIBE={version}");
 
     // re-run if either the build script or the git HEAD changes
     println!("cargo:rerun-if-changed=../.git/HEAD");

--- a/florestad/src/error.rs
+++ b/florestad/src/error.rs
@@ -39,9 +39,9 @@ impl std::fmt::Display for Error {
             Error::Rustreexo(err) => write!(f, "Rustreexo error: {err}"),
             Error::Io(err) => write!(f, "Io error {err}"),
             Error::ScriptValidation(err) => write!(f, "Error during script evaluation: {err}"),
-            Error::Blockchain(err) => write!(f, "Error with our blockchain backend: {:?}", err),
+            Error::Blockchain(err) => write!(f, "Error with our blockchain backend: {err:?}"),
             Error::SerdeJson(err) => write!(f, "Error serializing object {err}"),
-            Error::WalletInput(err) => write!(f, "Error while parsing user input {:?}", err),
+            Error::WalletInput(err) => write!(f, "Error while parsing user input {err:?}"),
             Error::TomlParsing(err) => write!(f, "Error deserializing toml file {err}"),
             Error::AddressParsing(err) => write!(f, "Invalid address {err}"),
             Error::Miniscript(err) => write!(f, "Miniscript error: {err}"),
@@ -64,10 +64,10 @@ impl std::fmt::Display for Error {
                 write!(f, "Error while generating PKCS#8 keypair: {err}")
             }
             Error::CouldNotGenerateCertParam(err) => {
-                write!(f, "Error while generating certificate param: {}", err)
+                write!(f, "Error while generating certificate param: {err}")
             }
             Error::CouldNotGenerateSelfSignedCert(err) => {
-                write!(f, "Error while generating self-signed certificate: {}", err)
+                write!(f, "Error while generating self-signed certificate: {err}")
             }
             Error::CouldNotWriteFile(path, err) => {
                 write!(f, "Error while creating file {path}: {err}")

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -666,7 +666,7 @@ impl Florestad {
         let file_dispatcher = fern::Dispatch::new()
             .format(formatter(false))
             .level(log::LevelFilter::Info)
-            .chain(fern::log_file(format!("{}/output.log", data_dir))?);
+            .chain(fern::log_file(format!("{data_dir}/output.log"))?);
 
         if log_file {
             dispatchers = dispatchers.chain(file_dispatcher);

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -208,14 +208,14 @@ impl Display for Error {
             Error::InvalidHex =>  write!(f, "Invalid hex"),
             Error::InvalidVout =>  write!(f, "Invalid vout"),
             Error::MethodNotFound =>  write!(f, "Method not found"),
-            Error::Decode(e) =>  write!(f, "error decoding request: {}", e),
+            Error::Decode(e) =>  write!(f, "error decoding request: {e}"),
             Error::TxNotFound =>  write!(f, "Transaction not found"),
             Error::InvalidDescriptor =>  write!(f, "Invalid descriptor"),
             Error::BlockNotFound =>  write!(f, "Block not found"),
             Error::Chain => write!(f, "Chain error"),
             Error::InvalidPort => write!(f, "Invalid port"),
             Error::InvalidAddress => write!(f, "Invalid address"),
-            Error::Node(e) => write!(f, "Node error: {}", e),
+            Error::Node(e) => write!(f, "Node error: {e}"),
             Error::NoBlockFilters => write!(f, "You don't have block filters enabled, please start florestad with --cfilters to run this RPC"),
             Error::InvalidNetwork => write!(f, "Invalid network"),
             Error::InInitialBlockDownload => write!(f, "Node is in initial block download, wait until it's finished"),
@@ -225,8 +225,8 @@ impl Display for Error {
             Error::MissingReq => write!(f, "Missing request field"),
             Error::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
             Error::InvalidMemInfoMode => write!(f, "Invalid meminfo mode, should be stats or mallocinfo"),
-            Error::Wallet(e) => write!(f, "Wallet error: {}", e),
-            Error::Filters(e) => write!(f, "Error with filters: {}", e),
+            Error::Wallet(e) => write!(f, "Wallet error: {e}"),
+            Error::Filters(e) => write!(f, "Error with filters: {e}"),
         }
     }
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Lint.

### Which crates are being modified?

- [x] floresta-chain
- [x] floresta-cli
- [ ] floresta-common
- [x] floresta-compact-filters
- [x] floresta-electrum
- [x] floresta-watch-only
- [x] floresta-wire
- [x] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->.

### Description

Fix #458

### Notes to the reviewers

Rust nightly added a new linting that warns interpolation styles. This was noted when trying to run CI on #452 .

### Checklist

- [x] I've signed all my commits
- [x] I ran `just lint`
- [x] I ran `cargo test`
- [x] I've checked the integration tests
- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I'm linking the issue being fixed by this PR (if any)
