### PR TITLE
chain: fix a CI break with linting

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -462,7 +462,7 @@ mod tests {
                         let txid = || spending_tx.compute_txid();
                         assert_eq!(inner, tx_err!(txid, CoinbaseNotMatured));
                     }
-                    e => panic!("Expected a TransactionError, but got: {:?}", e),
+                    e => panic!("Expected a TransactionError, but got: {e:?}"),
                 }
             }
         }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->.

### Description
#457 introduced a change that broke a new lint for string interpolation. For some reason, it didn't break on the PR itself, but did break after merge. This commit fixes it and should get CI green again.

### Checklist

- [X] I've signed all my commits
- [X] I ran `just lint`
- [X] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I'm linking the issue being fixed by this PR (if any)
