### PR TITLE
[FIX] prepare.sh now override pre-built binaires

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,4 +1,4 @@
-# runs our functinal tests from tests/
+name: Functional Tests
 
 on:
   push:

--- a/doc/running-tests.md
+++ b/doc/running-tests.md
@@ -12,8 +12,7 @@ cargo build
 
 The functional tests also need some dependencies, we use python for writing them and `uv` to manage its dependencies.
 
-Our tests also needs the `Utreexod` and `florestad` binaries to match some functionalities and we have some helper scripts to avoid conflicts, which happens a lot while developing but can help one that have one of them installed in the system.
-
+Our tests also needs `utreexod` and `florestad` to test some functionalities. We offer a helper script to assist in this process and guarantee isolation and reproducibility. Since `go` is a requirement to build utreexod, make sure you have `go` available on your system.
 See [Setting Functional Tests Binaries](#setting-functional-tests-binaries) for more instructions.
 
 ## Testing Options


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: functional test/ prepare script

### Description

Add:
	A name for the CI functional workflow
	new check_installed function
	build flag to force florestad building
fix:
	the florestad symlink now its directly from the actual dir, as a absolute path. cargo
build will update the linked binary too.
	echoing the directory at the end so one just see the dir if the
script ran fine

### Notes to the reviewers

try to fix https://github.com/vinteumorg/Floresta/pull/461#discussion_r2066316318

### Checklist

- [X] I've signed all my commits
- [] I ran `just lint`
- [] I ran `cargo test`
- [X] I've checked the integration tests
- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I'm linking the issue being fixed by this PR (if any)
