### PR TITLE
Handle ChainStateBuilder errors, avoid unwraps

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -15,6 +15,8 @@ use bitcoin::Txid;
 use floresta_common::impl_error_from;
 
 use crate::prelude::*;
+use crate::pruned_utreexo::chain_state_builder::BlockchainBuilderError;
+
 pub trait DatabaseError: Debug + Send + Sync + 'static {}
 #[derive(Debug)]
 /// This is the highest level error type in floresta-chain, returned by the [crate::ChainState] methods.
@@ -144,6 +146,12 @@ impl Display for BlockValidationErrors {
 impl<T: DatabaseError> From<T> for BlockchainError {
     fn from(value: T) -> Self {
         BlockchainError::Database(Box::new(value))
+    }
+}
+
+impl<T: DatabaseError> From<T> for BlockchainBuilderError {
+    fn from(value: T) -> Self {
+        BlockchainBuilderError::Database(Box::new(value))
     }
 }
 

--- a/crates/floresta/examples/chainstate-builder.rs
+++ b/crates/floresta/examples/chainstate-builder.rs
@@ -6,12 +6,11 @@
 //! block, or that doesn't validate all signatures. All customizations are done through the
 //! ChainStateBuilder struct. This example shows how to use it.
 use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::hashes::Hash;
-use bitcoin::BlockHash;
 use floresta::chain::ChainState;
 use floresta::chain::KvChainStore;
 use floresta::chain::Network;
 use floresta_chain::pruned_utreexo::chain_state_builder::ChainStateBuilder;
+use floresta_chain::AssumeValidArg;
 use floresta_chain::ChainParams;
 use rustreexo::accumulator::stump::Stump;
 
@@ -19,6 +18,10 @@ const DATA_DIR: &str = "./tmp-db";
 
 #[tokio::main]
 async fn main() {
+    let network = Network::Bitcoin;
+    let params = ChainParams::from(network);
+    let genesis = genesis_block(&params);
+
     // Create a new chain state, which will store the accumulator and the headers chain.
     // It will be stored in the DATA_DIR directory. With this chain state, we don't keep
     // the block data after we validated it. This saves a lot of space, but it means that
@@ -43,12 +46,9 @@ async fn main() {
     // to validate the blockchain. If you set the chain height, you should update
     // the accumulator to the state of the blockchain at that height too.
     let _chain: ChainState<KvChainStore> = ChainStateBuilder::new()
-        .with_assume_valid(BlockHash::all_zeros())
-        .with_chain_params(ChainParams::from(Network::Bitcoin))
-        .with_tip(
-            (genesis_block(bitcoin::Network::Bitcoin).block_hash(), 0),
-            genesis_block(bitcoin::Network::Bitcoin).header,
-        )
+        .with_assume_valid(AssumeValidArg::Disabled, network)
+        .with_chain_params(params)
+        .with_tip((genesis.block_hash(), 0), genesis.header)
         .assume_utreexo(Stump::new())
         .with_chainstore(chain_store)
         .build()


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Error handling

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Relates to #463. This is a first step on hardening error handling.

Previously we were using `unwrap` for things like chainstore operations and `Option` values unwrapping in the `ChainStateBuilder` methods.

I have replaced all unwraps in the file with proper error handling. Added the new `IncompleteTip` and `Database` error variants. Polished a bit the comments.

Also instead of implementing `From` ChainStateBuilder for Chainstate I implement `TryFrom` (it's fallible, failing if the chainstore and chain params are not set).