### PR TITLE
[Rpcsaga] add blockhash to gettxoutproof

### DIFF
--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -11,6 +11,7 @@
 #[cfg(feature = "with-jsonrpc")]
 pub mod jsonrpc_client;
 
+pub mod parsers;
 pub mod rpc;
 pub mod rpc_types;
 

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -56,8 +56,8 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
         Methods::GetTxOut { txid, vout } => {
             serde_json::to_string_pretty(&client.get_tx_out(txid, vout)?)?
         }
-        Methods::GetTxProof { txids, .. } => {
-            serde_json::to_string_pretty(&client.get_tx_proof(txids)?)?
+        Methods::GetTxOutProof { txids, blockhash } => {
+            serde_json::to_string_pretty(&client.get_txout_proof(txids, blockhash))?
         }
         Methods::GetTransaction { txid, .. } => {
             serde_json::to_string_pretty(&client.get_transaction(txid, Some(true))?)?
@@ -144,9 +144,14 @@ pub enum Methods {
     #[command(name = "getblockhash")]
     GetBlockHash { height: u32 },
     /// Returns the proof that one or more transactions were included in a block
-    #[command(name = "gettxproof")]
-    GetTxProof {
-        txids: Txid,
+    #[command(name = "gettxoutproof")]
+    GetTxOutProof {
+        /// The transaction IDs to prove
+        #[arg( required = true, value_parser = floresta_cli::parsers::parse_json_array::<Txid>)]
+        txids: std::vec::Vec<Txid>, // you need to specify the path of Vec https://github.com/clap-rs/clap/discussions/4695
+
+        /// The block in which to look for the transactions
+        #[arg(required = false)]
         blockhash: Option<BlockHash>,
     },
     /// Returns the transaction, assuming it is cached by our watch only wallet

--- a/crates/floresta-cli/src/parsers.rs
+++ b/crates/floresta-cli/src/parsers.rs
@@ -1,0 +1,62 @@
+use std::any::type_name;
+use std::error::Error;
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Debug)]
+/// Collection of errors to deal with parsing.
+pub enum ParseError {
+    /// Returned when the user inserts an broken array
+    InvalidArray,
+
+    /// Returned when the consumer of tries to cast into
+    /// a incompatible type.
+    InvalidTarget(String),
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::InvalidArray => write!(
+                f,
+                "Couldnt parse the inserted as an Array, please refer to the docs"
+            ),
+            ParseError::InvalidTarget(target) => {
+                write!(f, "Could parse itens to {target}")
+            }
+        }
+    }
+}
+
+impl Error for ParseError {}
+
+/// Tries to parse a json array, you can insert a type to be casted on each item.
+///
+/// Example: '["4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b", "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"]'
+/// Tries to parse a JSON array of hash strings into a vector of the target type.
+///
+/// The target type must implement Deserialize and can be converted from a hash string.
+/// By default, it will parse into Hash256, but you can specify any other compatible type.
+///
+/// Example:
+/// ```
+/// # use bitcoin::hashes::sha256;
+/// # use floresta_cli::parsers::parse_json_array;
+/// let hashes: Vec<sha256::Hash> =
+///     parse_json_array(r#"["4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"]"#)
+///         .unwrap();
+/// ```
+pub fn parse_json_array<Target>(s: &str) -> Result<Vec<Target>, ParseError>
+where
+    Target: FromStr,
+{
+    let string_vec: Vec<String> = serde_json::from_str(s).map_err(|_| ParseError::InvalidArray)?;
+
+    string_vec
+        .into_iter()
+        .map(|s| {
+            Target::from_str(&s)
+                .map_err(|_| ParseError::InvalidTarget(type_name::<Target>().to_string()))
+        })
+        .collect()
+}

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -4,6 +4,12 @@ use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Debug, Deserialize, Serialize)]
+/// Return type for the `gettxoutproof` rpc command, the internal is
+/// just the hex representation of the Merkle Block, which was defined
+/// by btc core.
+pub struct GetTxOutProof(pub Vec<u8>);
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GetBlockchainInfoRes {
     /// The best block we know about
     ///

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -457,11 +457,11 @@ impl<Blockchain: BlockchainInterface> ElectrumServer<Blockchain> {
                 let tx_id = get_arg!(request, Txid, 0);
                 let proof = self.address_cache.get_merkle_proof(&tx_id);
                 let height = self.address_cache.get_height(&tx_id);
-                if let Some((proof, position)) = proof {
+                if let Some(proof) = proof {
                     let result = json!({
-                        "merkle": proof,
+                        "merkle": proof.hashes,
                         "block_height": height.unwrap_or(0),
-                        "pos": position
+                        "pos": proof.pos
                     });
                     return json_rpc_res!(request, result);
                 }

--- a/crates/floresta-watch-only/src/merkle.rs
+++ b/crates/floresta-watch-only/src/merkle.rs
@@ -10,9 +10,9 @@ use serde::Deserialize;
 use serde::Serialize;
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MerkleProof {
-    target: Txid,
-    pos: u64,
-    hashes: Vec<sha256d::Hash>,
+    pub target: Txid,
+    pub pos: u64,
+    pub hashes: Vec<sha256d::Hash>,
 }
 impl Default for MerkleProof {
     fn default() -> Self {
@@ -28,10 +28,17 @@ impl MerkleProof {
             pos: 0,
         }
     }
+
+    /// Return the hashes for this proof as a [`Vec<String>`]
+    pub fn to_string_array(&self) -> Vec<String> {
+        self.hashes().iter().map(|hash| hash.to_string()).collect()
+    }
+
     /// Returns the hashes for this proof
     pub fn hashes(&self) -> Vec<sha256d::Hash> {
         self.hashes.clone()
     }
+
     /// Creates a new proof from a list of hashes and a target. Target is a 64 bits
     /// unsigned integer indicating the index of a transaction we with to prove. Note that
     /// this only proves one tx at the time.
@@ -44,6 +51,7 @@ impl MerkleProof {
             hashes: proof,
         }
     }
+
     /// Same as [MerkleProof::from_block_hashes] but you give a block instead of a list of
     /// hashes.
     pub fn from_block(block: &Block, target: u64) -> Self {
@@ -54,7 +62,7 @@ impl MerkleProof {
             .collect();
         Self::from_block_hashes(tx_list, target)
     }
-    #[allow(unused)]
+
     /// Verifies a proof by hashing up all nodes until reach a root, and compare `root` with
     /// computed root.
     pub fn verify(&self, root: sha256d::Hash) -> Result<bool, String> {
@@ -71,15 +79,18 @@ impl MerkleProof {
         }
         Ok(root == computed)
     }
+
     /// Returns the position of a node's parent
     fn get_parent(pos: u64) -> u64 {
         (pos ^ 1) / 2
     }
+
     /// Returns a node's sibling. This is useful because we have to copy a node's sibling
     /// to proof, so we can compute it's parent.
     fn get_sibling(pos: u64) -> u64 {
         pos ^ 1
     }
+
     /// Computes the hash of two node's parent, by taking sha256d(left_child | right_child), where |
     /// means byte-wise concatenation.
     fn parent_hash(left: &[u8], right: &[u8]) -> sha256d::Hash {
@@ -88,6 +99,7 @@ impl MerkleProof {
         engine.input(right);
         sha256d::Hash::from_engine(engine)
     }
+
     /// Iterates over the tree, collecting required nodes for proof, internally we compute
     /// all intermediate nodes, but don't keep them.
     fn transverse(

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -371,10 +371,11 @@ where
         user_req: UserRequest,
         responder: tokio::sync::oneshot::Sender<NodeResponse>,
     ) {
-        debug!("Performing user request {user_req:?}");
         if self.inflight.len() >= RunningNode::MAX_INFLIGHT_REQUESTS {
             return;
         }
+
+        debug!("Performing user request {user_req:?}");
 
         let req = match user_req {
             UserRequest::Block(block) => NodeRequest::GetBlock((vec![block], false)),

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -55,11 +55,7 @@ pretty_assertions = "1"
 experimental-db = ["floresta-chain/experimental-db"]
 compact-filters = ["dep:floresta-compact-filters"]
 zmq-server = ["dep:zmq"]
-json-rpc = [
-    "dep:axum",
-    "dep:tower-http",
-    "compact-filters"
-]
+json-rpc = ["dep:axum", "dep:tower-http", "compact-filters"]
 default = ["json-rpc"]
 metrics = ["dep:metrics", "floresta-wire/metrics"]
 

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -85,6 +85,12 @@ pub struct RpcError {
     pub data: Option<String>,
 }
 
+/// Return type for the `gettxoutproof` rpc command, the internal is
+/// just the hex representation of the Merkle Block, which was defined
+/// by btc core.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetTxOutProof(pub Vec<u8>);
+
 /// A full bitcoin block, returned by get_block
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetBlockResVerbose {
@@ -183,6 +189,7 @@ pub enum Error {
     InvalidVout,
     InvalidHeight,
     InvalidHash,
+    InvalidBlockHash,
     InvalidRequest,
     MethodNotFound,
     Decode(String),
@@ -202,6 +209,7 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Error::InvalidBlockHash => write!(f, "Provided a invalid BlockHash"),
             Error::InvalidRequest => write!(f, "Invalid request"),
             Error::InvalidHeight => write!(f, "Invalid height"),
             Error::InvalidHash =>  write!(f, "Invalid hash"),


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [X] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [X] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [X] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Fix #378

This commit present some changes for gettxoutproof, adding the optional blockhash
input which will make the method interns differ, searching for the transactions
inside the specified block, otherwise, the previous default behavior of getting it
from the wallet cache remains. The method now receives an array of txids instead of
just one.

Also, now named gettxoutproof, was gettxproof.

A unused #[allow(unused)] was also removed from merkle.rs

### Notes to the reviewers

While trying to fork and just complete #379 to accomplish one of [`0.8.0 milestones`](https://github.com/vinteumorg/Floresta/milestone/3) i noticed some opportunities to optimize some decisions and add two new fixes to the #378 issue. (1. and 2.)

Still validating if the changes are effective and are working.
### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
