### PR TITLE
Small refactors to remove unwraps

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -203,9 +203,9 @@ impl ChainStore for KvChainStore<'_> {
 
     /// Loads the best chain data from the metadata bucket.
     fn load_height(&self) -> Result<Option<BestChain>, Self::Error> {
-        let height = self.meta.get(&"height")?;
-        if let Some(height) = height {
-            return Ok(Some(deserialize(&height).unwrap()));
+        if let Some(b) = self.meta.get(&"height")? {
+            let height = deserialize(&b).expect("infallible: came from `serialize(height)`");
+            return Ok(Some(height));
         }
 
         Ok(None)


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Refactor

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Relates to #463. A couple of replacements of `unwrap` for `expect` with proper messages.

In partial_chain.rs `get_validation_flags` now takes the hash directly from the caller, avoiding the `unwrap` (exactly as we do for `get_validation_flags` [in chain_state.rs](https://github.com/vinteumorg/Floresta/blob/master/crates/floresta-chain/src/pruned_utreexo/chain_state.rs#L167)).

In `get_leaf_hashes` (udata.rs) we instead take the TxOut directly. We also avoid computing the txid twice by passing it.

### Notes to the reviewers

The only remaining `unwraps` in `floresta-chain` are in `chain_state.rs`. We can then remove them (with a bit of error handling) and enforce they are not re-introduced.
