### PR TITLE
Debug test data with `assert_ok` and `assert_err`

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -1380,6 +1380,7 @@ mod test {
     use bitcoin::BlockHash;
     use bitcoin::Network;
     use bitcoin::OutPoint;
+    use floresta_common::assert_ok;
     use floresta_common::bhash;
     use rand::Rng;
     use rustreexo::accumulator::proof::Proof;
@@ -1564,7 +1565,7 @@ mod test {
         headers.remove(0);
 
         // push_headers
-        assert!(chain.push_headers(headers.clone(), 1).is_ok());
+        assert_ok!(chain.push_headers(headers.clone(), 1));
 
         // get_block_header_by_height
         assert_eq!(chain.get_block_header_by_height(1), headers[0]);

--- a/crates/floresta-chain/src/pruned_utreexo/consensus.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/consensus.rs
@@ -305,6 +305,8 @@ mod tests {
     use bitcoin::TxOut;
     use bitcoin::Txid;
     use bitcoin::Witness;
+    use floresta_common::assert_err;
+    use floresta_common::assert_ok;
 
     use super::*;
 
@@ -402,8 +404,8 @@ mod tests {
         let small_script =
             ScriptBuf::from_hex("76a9149206a30c09cc853bb03bd917a4f9f29b089c1bc788ac").unwrap();
 
-        assert!(Consensus::validate_script_size(&small_script, dummy_txid).is_ok());
-        assert!(Consensus::validate_script_size(&large_script, dummy_txid).is_err());
+        assert_ok!(Consensus::validate_script_size(&small_script, dummy_txid));
+        assert_err!(Consensus::validate_script_size(&large_script, dummy_txid));
     }
 
     #[test]
@@ -411,7 +413,7 @@ mod tests {
         let valid_one = coinbase(true);
         let invalid_one = coinbase(false);
         // The case that should be valid
-        assert!(Consensus::verify_coinbase(&valid_one).is_ok());
+        assert_ok!(Consensus::verify_coinbase(&valid_one));
         // Invalid coinbase script
         assert_eq!(
             Consensus::verify_coinbase(&invalid_one)
@@ -438,7 +440,7 @@ mod tests {
 
             assert_eq!(coinbase_tx.compute_txid().to_string(), expected_coinbase);
             assert_eq!(spending_tx.compute_txid().to_string(), expected_spending);
-            assert!(Consensus::verify_coinbase(coinbase_tx).is_ok());
+            assert_ok!(Consensus::verify_coinbase(coinbase_tx));
 
             let mut utxos = HashMap::new();
             utxos.insert(
@@ -455,7 +457,7 @@ mod tests {
                 Consensus::verify_transaction(spending_tx, &mut utxos, spending_height, true, 0);
 
             if expected_ok {
-                assert!(spend_result.is_ok(), "Expected Ok, found: {spend_result:?}");
+                assert_ok!(spend_result);
             } else {
                 match spend_result.unwrap_err() {
                     BlockchainError::TransactionError(inner) => {

--- a/crates/floresta-electrum/src/electrum_protocol.rs
+++ b/crates/floresta-electrum/src/electrum_protocol.rs
@@ -901,6 +901,7 @@ mod test {
     use floresta_chain::AssumeValidArg;
     use floresta_chain::ChainState;
     use floresta_chain::KvChainStore;
+    use floresta_common::assert_ok;
     use floresta_common::get_spk_hash;
     use floresta_watch_only::kv_database::KvDatabase;
     use floresta_watch_only::merkle::MerkleProof;
@@ -1218,7 +1219,7 @@ mod test {
         let mut batch_req = json!(batch_req).to_string();
         batch_req.push('\n');
 
-        assert!(send_request(batch_req, port).await.is_ok());
+        assert_ok!(send_request(batch_req, port).await);
     }
 
     #[tokio::test]
@@ -1228,7 +1229,8 @@ mod test {
         let method = Value::String("server.banner".to_string());
         let mut request = generate_request(&mut vec![method]).to_string();
         request.push('\n');
-        assert!(send_request(request, port).await.is_ok())
+
+        assert_ok!(send_request(request, port).await);
     }
 
     #[tokio::test]
@@ -1282,9 +1284,9 @@ mod test {
         let mut mempool_req = generate_request(&mut vec![method]).to_string();
         mempool_req.push('\n');
 
-        assert!(send_request(subscribe_req, port).await.is_ok());
+        assert_ok!(send_request(subscribe_req, port).await);
 
-        assert!(send_request(mempool_req, port).await.is_ok());
+        assert_ok!(send_request(mempool_req, port).await);
 
         assert!(send_request(unsubscribe_req, port).await.unwrap()["result"]
             .as_bool()

--- a/crates/floresta-watch-only/src/merkle.rs
+++ b/crates/floresta-watch-only/src/merkle.rs
@@ -230,11 +230,8 @@ mod test {
 
         let proof = MerkleProof::from_block_hashes(hashes, 2);
         let ser_proof = serialize(&proof);
-        let de_proof = deserialize::<MerkleProof>(&ser_proof);
+        let de_proof = deserialize::<MerkleProof>(&ser_proof).unwrap();
 
-        assert!(de_proof.is_ok());
-
-        let de_proof = de_proof.unwrap();
         assert_eq!(de_proof, proof);
         assert!(de_proof.verify(root).unwrap());
     }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -777,6 +777,7 @@ mod test {
     use bitcoin::p2p::ServiceFlags;
     use bitcoin::Network;
     use floresta_chain::get_chain_dns_seeds;
+    use floresta_common::assert_ok;
     use floresta_common::service_flags;
     use rand::Rng;
     use serde::Deserialize;
@@ -892,11 +893,10 @@ mod test {
         assert!(!AddressMan::get_net_seeds(Network::Regtest).is_empty());
         assert!(!AddressMan::get_net_seeds(Network::Testnet).is_empty());
 
-        assert!(AddressMan::get_seeds_from_dns(
+        assert_ok!(AddressMan::get_seeds_from_dns(
             &get_chain_dns_seeds(Network::Signet).unwrap()[0],
             8333
-        )
-        .is_ok());
+        ));
 
         address_man.rearrange_buckets();
     }

--- a/crates/floresta-wire/src/p2p_wire/mempool.rs
+++ b/crates/floresta-wire/src/p2p_wire/mempool.rs
@@ -620,6 +620,7 @@ mod tests {
     use floresta_chain::CompactLeafData;
     use floresta_chain::LeafData;
     use floresta_common::acchashes;
+    use floresta_common::assert_ok;
     use floresta_common::bhash;
     use rand::Rng;
     use rand::SeedableRng;
@@ -798,7 +799,7 @@ mod tests {
             .get_block_proof(&block, hashes)
             .expect("failed to get block proof");
 
-        assert!(mempool.acc.verify(&proof, &target_hashes).is_ok());
+        assert_ok!(mempool.acc.verify(&proof, &target_hashes));
     }
 
     #[test]
@@ -988,7 +989,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert!(mempool.acc.verify(&proof, &del_hashes).is_ok());
+        assert_ok!(mempool.acc.verify(&proof, &del_hashes));
         mempool
             .consume_block(&block, proof, &adds, &target_hashes, 170, true)
             .expect("failed to consume block");


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [x] floresta-common
- [ ] floresta-compact-filters
- [x] floresta-electrum
- [x] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

We have a couple of `assert!(result.is_ok())` and `assert!(result.is_err())` in our tests. These are very readable but whenever they fail they don't debug the `Result` value. We have recently seen this lack of debugging in some electrum tests CI fails:

```
  ---- electrum_protocol::test::test_blockchain_headers stdout ----
  thread 'electrum_protocol::test::test_blockchain_headers' panicked at crates/floresta-electrum/src/electrum_protocol.rs:1221:9:
  assertion failed: send_request(batch_req, port).await.is_ok()
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

We could fix this with `result.unwrap()` or `result.unwrap_err()`, but it worsens readability. I find it nicer to use these new `assert_ok` and `assert_err` macros. Added a few unit and doc tests for them.

### Notes to the reviewers

There's a [clippy lint](https://rust-lang.github.io/rust-clippy/master/#assertions_on_result_states) for this but it's on restriction mode because of the readability loss of using unwraps, which we solve with these macros. But the clippy lint doesn't catch all cases for some reason. I also saw there's an `std::assert_matches` macro but it's unstable.