### PR TITLE
Deny unwraps in `floresta-chain`, handle errors

### DIFF
--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -11,6 +11,7 @@
 //! underlying database. See the ChainStore trait for more information. For a
 //! ready-to-use implementation, see the [KvChainStore] struct.
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
 
 pub mod pruned_utreexo;
 pub(crate) use floresta_common::prelude;

--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -24,6 +24,7 @@ pub trait DatabaseError: Debug + Send + Sync + 'static {}
 /// It represents errors encountered during blockchain validation.
 pub enum BlockchainError {
     BlockNotPresent,
+    OrphanOrInvalidBlock,
     Parsing(String),
     BlockValidation(BlockValidationErrors),
     TransactionError(TransactionError),


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Error handling

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Relates to #463

We deny the `clippy::unwrap_used` for non test code, so no unwraps can be reintroduced. Then we use expects if it's infallible and no `Result` is returned. If it's infallible but we can return it's clearer to use `?`.

`verify_script` is refactored to return `Result` with chainstore errors, but other return-database-error refactors are `TODO`.

Finally we were returning `BlockNotPresent` errors in cases where the block is actually present but it's `Orphan` or `InvalidChain`. Created a new error variant for these two cases. It's also used in places where we were using `disk_header.height().unwrap()`.