### PR TITLE
flat-chain-store: Detect file corruption and reindex if needed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,6 +980,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "spin",
+ "xxhash-rust",
  "zstd",
 ]
 
@@ -3139,6 +3140,12 @@ checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.9.0",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -32,6 +32,7 @@ metrics = { path = "../../metrics", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 memmap2 = { version = "0.9.5", optional = true }
 lru = { version = "0.12.5", optional = true }
+xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -199,9 +199,17 @@ impl<'a> KvChainStore<'a> {
 
 impl ChainStore for KvChainStore<'_> {
     type Error = kv::Error;
+
     /// Loads the utreexo roots from the metadata bucket.
     fn load_roots(&self) -> Result<Option<Vec<u8>>, Self::Error> {
         self.meta.get(&"roots")
+    }
+
+    /// For this [ChainStore], since [sled] already checks integrity implicitly, this is a no-op.
+    ///
+    /// [sled]: https://docs.rs/sled/latest/sled/enum.Error.html#variant.Corruption
+    fn check_integrity(&self) -> Result<(), Self::Error> {
+        Ok(())
     }
 
     /// Saves the current utreexo roots to the metadata bucket.

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -184,26 +184,41 @@ pub trait ChainStore {
     type Error: DatabaseError;
     /// Saves the current state of our accumulator.
     fn save_roots(&self, roots: Vec<u8>) -> Result<(), Self::Error>;
+
     /// Loads the state of our accumulator.
     fn load_roots(&self) -> Result<Option<Vec<u8>>, Self::Error>;
+
     /// Loads the blockchain height
     fn load_height(&self) -> Result<Option<BestChain>, Self::Error>;
+
     /// Saves the blockchain height.
     fn save_height(&self, height: &BestChain) -> Result<(), Self::Error>;
+
     /// Get a block header from our database. See [DiskBlockHeader] for more info about
     /// the data we save.
     fn get_header(&self, block_hash: &BlockHash) -> Result<Option<DiskBlockHeader>, Self::Error>;
+
     /// Saves a block header to our database. See [DiskBlockHeader] for more info about
     /// the data we save.
     fn save_header(&self, header: &DiskBlockHeader) -> Result<(), Self::Error>;
+
     /// Returns the block hash for a given height.
     fn get_block_hash(&self, height: u32) -> Result<Option<BlockHash>, Self::Error>;
+
     /// Flushes write buffers to disk, this is called periodically by the [ChainState](crate::ChainState),
     /// so in case of a crash, we don't lose too much data. If the database doesn't support
     /// write buffers, this method can be a no-op.
     fn flush(&self) -> Result<(), Self::Error>;
+
     /// Associates a block hash with a given height, so we can retrieve it later.
     fn update_block_index(&self, height: u32, hash: BlockHash) -> Result<(), Self::Error>;
+
+    /// Checks if our database didn't get corrupted, and if it has, it returns
+    /// an error.
+    ///
+    /// If you're using a database that already checks for integrity by itself,
+    /// this can safely be a no-op.
+    fn check_integrity(&self) -> Result<(), Self::Error>;
 }
 
 #[derive(Debug, Clone)]

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -811,6 +811,7 @@ impl Florestad {
         assume_valid: Option<bitcoin::BlockHash>,
     ) -> ChainState<ChainStore> {
         let db = Self::load_chain_store(data_dir.clone());
+
         let assume_valid =
             assume_valid.map_or(AssumeValidArg::Hardcoded, AssumeValidArg::UserInput);
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [X] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

This commit adds a simple, XOR-based check for integrity for the
flat_chain_store. If we find it to be corrupted, we reindex to find how
much of it is lost, and try to continue from there.

There's no error-correction logic in this commit, because this tends to
bring complexity and require more space. Since modern file-systems are
so good at keeping things from corrupting, I don't think there's that
much need to make our own error correction code here.

### Notes to the reviewers

Depends on #251
