### PR TITLE
[Fix] Created `just open-doc` command

### DIFF
--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ test-functional-prepare arg="":
 test-functional-run arg="":
     bash tests/run.sh {{arg}}
 
-# format and lint functional tests 
+# format and lint functional tests
 test-functional-uv-fmt:
     uv run black --check --verbose ./tests
     uv run pylint --verbose ./tests
@@ -65,8 +65,7 @@ bench:
 
 # Generate documentation for all crates
 doc:
-    @just test-doc
-    cargo +nightly doc --no-deps
+    cargo +nightly doc --workspace --no-deps
 
 # Format code and run configured linters
 lint:

--- a/justfile
+++ b/justfile
@@ -67,6 +67,10 @@ bench:
 doc:
     cargo +nightly doc --workspace --no-deps
 
+# Generate and open documentation for all crates
+open-doc:
+    cargo +nightly doc --workspace --no-deps --open
+
 # Format code and run configured linters
 lint:
     @just fmt


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: Updates `just doc` and creates `just open-doc`  <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: No crate is being modified. `justfile` is. <!-- Please describe it -->

### Description

When running regular `cargo doc --no-deps --open` it might not link correctly the crates or intra-links and there are known problems in rustc 1.74.1 doc generator as it cannot solve naming conflicts between libs and binaries with similar names so thir PR aims at using `nightly`.

The `just` already had a command called `just doc` to generate docs but it did not open and it also ran `just test-doc` as well. 

The purpose of this PR is twofold: simplify the `just doc` to literally just create the documentation and to add a new just recipe called `just open-doc` where it will generate docs for all crates on workspace and open it.

This PR is an improvement suggested for #376 (it was not there originally but will help its development).

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->

### Notes to the reviewers

I added the flag `--workspace` as well to make sure all crates were being correctly linked. I was facing issues on correct linkage of crates without the flag. 

Before testing the just recipe, please remember to run 

`rm -rf target/doc`

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above
