### PR TITLE
Remove unused `florestad` and `wire` features

### DIFF
--- a/crates/floresta-wire/Cargo.toml
+++ b/crates/floresta-wire/Cargo.toml
@@ -40,5 +40,4 @@ hex = "0.4.3"
 
 [features]
 default = []
-pruned_utreexo_chainstate = []
 metrics = ["dep:metrics"]

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -55,13 +55,12 @@ pretty_assertions = "1"
 experimental-db = ["floresta-chain/experimental-db"]
 compact-filters = ["dep:floresta-compact-filters"]
 zmq-server = ["dep:zmq"]
-experimental-p2p = []
 json-rpc = [
     "dep:axum",
     "dep:tower-http",
     "compact-filters"
 ]
-default = ["experimental-p2p", "json-rpc"]
+default = ["json-rpc"]
 metrics = ["dep:metrics", "floresta-wire/metrics"]
 
 [build-dependencies]


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Remove features

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

The last usage of the `florestad/experimental-p2p` feature was removed at #209. It is not used anywhere now.

Also we have a `floresta-wire/pruned_utreexo_chainstate` feature which is not used either. I guess we could reintroduce it if in the future we have a non pruned chain (but maybe it is not needed since we work with trait bounds).

### Notes to the reviewers

Our CI will also be faster after this, since the feature matrix grows exponentially with each feature.