### PR TITLE
Bugfix: fix two bugs that may happen after an unclean shutdown

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -53,6 +53,7 @@ pub struct TransactionError {
 #[derive(Clone, Debug, PartialEq)]
 /// Represents errors encountered during block validation.
 pub enum BlockValidationErrors {
+    BlockDoesntExtendTip,
     InvalidCoinbase(String),
     UtxoNotFound(OutPoint),
     ScriptValidationError(String),
@@ -99,6 +100,9 @@ impl Display for TransactionError {
 impl Display for BlockValidationErrors {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            BlockValidationErrors::BlockDoesntExtendTip => {
+                write!(f, "This block doesn't build directly on the tip")
+            }
             BlockValidationErrors::ScriptValidationError(e) => {
                 write!(f, "{e}")
             }

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -179,6 +179,13 @@ where
                 if self.inflight.len() > 10 {
                     continue;
                 }
+
+                // don't ask for blocks if we already have a lot of them in memory.
+                // If we don't limit it, we may end up using all the available memory
+                if self.blocks.len() > 10 {
+                    continue;
+                }
+
                 self.get_blocks_to_download().await;
             }
         }
@@ -318,6 +325,10 @@ where
 
         if self.inflight.len() < 4 {
             if *self.kill_signal.read().await {
+                return Ok(());
+            }
+
+            if self.blocks.len() > 10 {
                 return Ok(());
             }
 

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -264,7 +264,6 @@ where
                         | BlockValidationErrors::FirstTxIsNotCoinbase
                         | BlockValidationErrors::BadCoinbaseOutValue
                         | BlockValidationErrors::EmptyBlock
-                        | BlockValidationErrors::BlockExtendsAnOrphanChain
                         | BlockValidationErrors::BadBip34
                         | BlockValidationErrors::UnspendableUTXO
                         | BlockValidationErrors::CoinbaseNotMatured => {
@@ -272,6 +271,14 @@ where
                             try_and_log!(self.chain.invalidate_block(block.block.block_hash()));
                         }
                         BlockValidationErrors::InvalidProof => {}
+                        BlockValidationErrors::BlockExtendsAnOrphanChain
+                        | BlockValidationErrors::BlockDoesntExtendTip => {
+                            // We've requested and processed a block that's not the next one in our
+                            // chain. Force our last block requested to be the correct block, and
+                            // keep going.
+                            self.context.last_block_requested =
+                                self.chain.get_validation_index()?;
+                        }
                     }
                 }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

If `florestad` has an unclean shutdown, there's a very specific situation where we may have the `SyncNode` not only stuck, but it's memory usage spiraling out of control. I've got an OOM killing because of this bug (see the second commit for more info). This PR fixes both of them.


### Notes to the reviewers

Each bug is clearly explained each commit's message. They are so small that I didn't think we need two PRs for them.