### PR TITLE
Fix clippy warning for load_descriptor in florestad json_rpc server

### DIFF
--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::slice;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -116,7 +117,8 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     }
 
     fn load_descriptor(&self, descriptor: String) -> Result<bool> {
-        let Ok(mut parsed) = parse_descriptors(&[descriptor.clone()]) else {
+        let desc = slice::from_ref(&descriptor);
+        let Ok(mut parsed) = parse_descriptors(desc) else {
             return Err(Error::InvalidDescriptor);
         };
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: lint.

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

A new clippy warning was raised for `cloned-ref-to-slice`. This commit fixes the warning that raise an error during lint-features just recipe.

### Notes to the reviewers

During a CI job in #465, a new clippy warning was raised, maybe due to `nightly` specs for clippy.

### Author Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
