### PR TITLE
fuzz: add target for addrman

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -9,3 +9,4 @@ You can replace `local_address_str` with the name of any other target you want t
 Available fuzz targets:
 - `local_address_str`
 - `utreexo_block_des`
+- `addrman`

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,10 @@ path = "fuzz_targets/utreexo_block_des.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "addrman"
+path = "fuzz_targets/addrman.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/addrman.rs
+++ b/fuzz/fuzz_targets/addrman.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use bitcoin::consensus::encode;
+use bitcoin::p2p::address::AddrV2Message;
+use bitcoin::p2p::ServiceFlags;
+use floresta_wire::address_man::AddressMan;
+use floresta_wire::address_man::LocalAddress;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut address_man = AddressMan::default();
+    let addrv2_msg_vec = encode::deserialize::<Vec<AddrV2Message>>(data);
+    match addrv2_msg_vec {
+        Err(_) => {}
+        Ok(addrv2_vec) => {
+            let mut local_addresses = Vec::<LocalAddress>::new();
+            for addrv2 in addrv2_vec {
+                let local_address = LocalAddress::from(addrv2);
+                local_addresses.push(local_address);
+            }
+            address_man.push_addresses(&local_addresses);
+        }
+    }
+    address_man.get_addresses_to_send();
+    let available_flags = [
+        ServiceFlags::NETWORK,
+        ServiceFlags::GETUTXO,
+        ServiceFlags::BLOOM,
+        ServiceFlags::WITNESS,
+        ServiceFlags::COMPACT_FILTERS,
+        ServiceFlags::NETWORK_LIMITED,
+        ServiceFlags::P2P_V2,
+    ];
+    for flag in available_flags {
+        address_man.get_address_to_connect(flag, false);
+    }
+    address_man.rearrange_buckets();
+});


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [X] Test
- [ ] Other: <!-- Please describe it -->

### Description

This PR adds a fuzz target to cover address manager stuff. It creates a vector of `addrv2` messages that it uses to extract addresses, convert to local addresses and then push to the addrman. Therefore, it explores other functions like `get_addresses_to_send`, `get_address_to_connect` and `rearrange_buckets`.

