### PR TITLE
Optimize `FlatChainStore` and improve tests

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -14,7 +14,7 @@ use spin::RwLock;
 use crate::prelude::*;
 use crate::BlockchainError;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// This enum is used to store a block header in the database.
 /// It contains the header along with metadaba about the validation state of the block, and, if applicable, also its height.
 pub enum DiskBlockHeader {


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Previously we were doing:

```rust
    unsafe fn get_header_by_hash(
        &self,
        hash: BlockHash,
    ) -> Result<Option<DiskBlockHeader>, FlatChainstoreError> {
        let header = self
            .block_index
            .get_index_for_hash(hash, |height| self.get_block_header_by_index(height))?
            .map(|height| self.get_block_header_by_index(height)); // DUPLICATED CALL

        Ok(header.transpose()?.map(|x| x.header))
    }
```

Which we can optimize/simplify by making the `get_index_for_hash` function directly return the header as well, which is free since it's already fetched.

To make this easier I made the `IndexBucket` enum contain the header if occupied (I think this is good as it's data related to the entry we searched for), and named the fields for clarity.

```rust
pub enum IndexBucket {
    Empty { ptr: *mut Index },
    Occupied {
        ptr: *mut Index,
        header: DiskBlockHeader,
    },
}
```

In the `ChainStore::get_block_hash` impl we handle the `NotFound` case. Then I have improved the headers tests by verifying our assumptions are holding.