### PR TITLE
Added modifications on methods find_who_is_lying

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -339,7 +339,15 @@ where
                 // if they disagree on this current block, we need to look in the previous one
                 height -= 1;
             }
+            hash = self.chain.get_block_hash(height)?;
         }
+        hash = self.chain.get_block_hash(height)?;
+
+        let (agreed, _) = self
+            .grab_both_peers_version(peer1, peer2, hash, fork)
+            .await?;
+
+        hash = self.chain.get_block_hash(fork + 1)?;
 
         // now we know where the fork is, we need to check who is lying
         let (Some(peer1_acc), Some(peer2_acc)) = self
@@ -348,10 +356,6 @@ where
         else {
             return Ok(None);
         };
-
-        let (agreed, _) = self
-            .grab_both_peers_version(peer1, peer2, hash, fork)
-            .await?;
 
         let agreed = match agreed {
             Some(acc) => Self::parse_acc(acc)?,
@@ -438,6 +442,13 @@ where
                 } else {
                     invalid_accs.insert(peer[1].1.clone());
                 }
+            } else {
+                // Both peers were lying
+                self.send_to_peer(peer1, NodeRequest::Shutdown).await?;
+                self.send_to_peer(peer2, NodeRequest::Shutdown).await?;
+
+                invalid_accs.insert(peer[0].1.clone());
+                invalid_accs.insert(peer[1].1.clone());
             }
         }
         //filter out the invalid accs


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: Updated logic to get new hash based on height and logic to handle both peers lying. From #180 <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description
The method as is does not update the hash, so this pr modifies to update it and also adds a check for both peers lying.
<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->

### Notes to the reviewers
I opted for using the "?" instead of unwrap, following the discussion on #463 
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower) I did this one
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
