### PR TITLE
chain: handle accumulator reorg

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -38,6 +38,7 @@ pub enum BlockchainError {
     ScriptValidationFailed(script::Error),
     Io(ioError),
     UnsupportedNetwork(Network),
+    BadValidationIndex,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -183,11 +183,15 @@ pub trait UpdatableChainstate {
 pub trait ChainStore {
     type Error: DatabaseError;
 
-    /// Saves the current state of our accumulator.
-    fn save_roots(&mut self, roots: Vec<u8>) -> Result<(), Self::Error>;
+    /// Saves the accumulator state for a given block height.
+    fn save_roots_for_block(&mut self, roots: Vec<u8>, height: u32) -> Result<(), Self::Error>;
 
-    /// Loads the state of our accumulator.
-    fn load_roots(&self) -> Result<Option<Vec<u8>>, Self::Error>;
+    /// Loads the state of our accumulator for a given block height.
+    ///
+    /// This is the state of the resulting accumulator after we process the block at `height`. If you
+    /// need the accumulator used to validate a block at height `n`, you should get the accumulator
+    /// from block `n - 1`.
+    fn load_roots_for_block(&mut self, height: u32) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Loads the blockchain height
     fn load_height(&self) -> Result<Option<BestChain>, Self::Error>;

--- a/tests/florestad/reorg-chain.py
+++ b/tests/florestad/reorg-chain.py
@@ -1,0 +1,93 @@
+"""
+Chain reorg test
+
+This test will spawn a florestad and a utreexod, we will use utreexod to mine some blocks.
+Then we will invalidate one of those blocks, and mine an alternative chain. This should
+make florestad switch to the new chain. We then compare the two node's main chain and
+accumulator to make sure they are the same.
+"""
+
+from test_framework import FlorestaRPC, UtreexoRPC, FlorestaTestFramework
+from test_framework.rpc.floresta import REGTEST_RPC_SERVER as florestad_rpc
+from test_framework.rpc.utreexo import REGTEST_RPC_SERVER as utreexod_rpc
+
+import time
+
+
+class ChainReorgTest(FlorestaTestFramework):
+    index = [-1, -1]
+    expected_chain = "regtest"
+
+    def set_test_params(self):
+        ChainReorgTest.index[0] = self.add_node(
+            variant="florestad", rpcserver=florestad_rpc
+        )
+
+        # since utreexod and bitcoind
+        # uses the same RPC server, we need to
+        # select a different port for utreexod
+        utreexod_rpc["ports"]["server"] = 18446
+        utreexod_rpc["ports"]["rpc"] = 18447
+        ChainReorgTest.index[1] = self.add_node(
+            variant="utreexod",
+            rpcserver=utreexod_rpc,
+            extra_args=[
+                "--listen=127.0.0.1:18446",
+                "--rpclisten=127.0.0.1:18447",
+                "--miningaddr=bcrt1q4gfcga7jfjmm02zpvrh4ttc5k7lmnq2re52z2y",
+                "--utreexoproofindex",
+                "--prune=0",
+            ],
+        )
+
+    def run_test(self):
+        # Start the nodes
+        self.run_node(ChainReorgTest.index[0])
+        self.run_node(ChainReorgTest.index[1])
+
+        utreexod: UtreexoRPC = self.get_node(ChainReorgTest.index[1]).rpc
+
+        # Mine some blocks with utreexod
+        self.log("Mining blocks with utreexod...")
+        utreexod.generate(10)
+
+        # Connect floresta to utreexod
+        florestad: FlorestaRPC = self.get_node(ChainReorgTest.index[0]).rpc
+        florestad.addnode(
+            f"{utreexod_rpc["host"]}:{utreexod_rpc["ports"]["server"]}", "onetry"
+        )
+
+        time.sleep(20)
+
+        # Check that floresta has the same chain as utreexod
+        floresta_chain = florestad.get_blockchain_info()
+        utreexo_chain = utreexod.get_blockchain_info()
+
+        self.assertEqual(floresta_chain["height"], utreexo_chain["blocks"])
+
+        hash = utreexod.get_blockhash(5)
+        self.log(f"Block hash at height 5: {hash}")
+        utreexod.invalidate_block(hash)
+
+        # Mine an alternative chain with 20 blocks
+        self.log("Mining alternative chain with utreexod...")
+        utreexod.generate(20)
+
+        # Wait for the nodes to sync
+        time.sleep(10)
+
+        # Check that floresta has switched to the new chain
+        floresta_chain = florestad.get_blockchain_info()
+        utreexo_chain = utreexod.get_blockchain_info()
+        self.assertEqual(floresta_chain["height"], utreexo_chain["blocks"])
+
+        # Compare the accumulator roots for each node
+        floresta_roots = florestad.get_roots()
+        utreexo_roots = utreexod.get_utreexo_roots(utreexo_chain["bestblockhash"])
+        self.assertEqual(floresta_roots, utreexo_roots["roots"])
+
+        self.stop()
+
+
+if __name__ == "__main__":
+    ChainReorgTest().main()

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -20,6 +20,11 @@ FLORESTA_PROJ_DIR=$(git rev-parse --show-toplevel)
 # This helps us to keep track of the actual version being tested without conflicting with any already installed binaries.
 GIT_DESCRIBE=$(git describe --tags --always)
 
+# Floresta can't talk the new, experimental p2p messages for utreexo. This is the last version of utreexod that
+# implements the old p2p messages, and is used for testing by default. It can be overridden by setting the
+# UTREEXO_REVISION environment variable.
+export DEFAULT_UTREEXO_REV="0.4.1"
+
 export FLORESTA_TEMP_DIR="/tmp/floresta-func-tests.${GIT_DESCRIBE}"
 
 # Dont use mktemp so we can have deterministic results for each version of floresta.

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -268,15 +268,14 @@ class BaseRPC(metaclass=BaseRpcMetaClass):
             raise HTTPError
 
         result = response.json()
-
         # Error could be None or a str
         # If in the future this change,
         # cast the resulted error to str
         if "error" in result and result["error"] is not None:
             raise JSONRPCError(
+                data=result["error"] if isinstance(result["error"], str) else None,
                 rpc_id=result["id"],
                 code=result["error"]["code"],
-                data=result["error"]["data"],
                 message=result["error"]["message"],
             )
 

--- a/tests/test_framework/rpc/utreexo.py
+++ b/tests/test_framework/rpc/utreexo.py
@@ -41,20 +41,23 @@ class UtreexoRPC(BaseRPC):
         """
         return self.perform_request("getnewaddress", [])
 
-    def generate_blocks(self, blocks: int, addr: str = ""):
+    def generate(self, blocks: int):
         """
-        Perform the `generatetoaddress` RPC command to utreexod.
+        Perform the `generate` RPC command to utreexod.
         """
-        if addr == "" or addr is None:
-            raise ValueError("Address is required")
+        return self.perform_request("generate", [blocks])
 
-        self.perform_request("generatetoaddress", [blocks, addr])
+    def get_utreexo_roots(self, block_hash: str):
+        """
+        Perform the `getutreexoroots` RPC command to utreexod
+        """
+        return self.perform_request("getutreexoroots", [block_hash])
 
     def send_to_address(self, address: str, amount: float):
         """
         Perform the `sendtoaddress` RPC command to utreexod
         """
-        self.perform_request("sendtoaddress", [address, amount])
+        return self.perform_request("sendtoaddress", [address, amount])
 
     def get_balance(self):
         """
@@ -67,6 +70,20 @@ class UtreexoRPC(BaseRPC):
         Perform the `getpeerinfo` RPC command to utreexod
         """
         return self.perform_request("getpeerinfo", [])
+
+    def invalidate_block(self, blockhash: str):
+        """
+        Invalidate a block by its hash performing
+        `perform_request('invalidateblock', params=[<str>])`
+        """
+        return self.perform_request("invalidateblock", params=[blockhash])
+
+    def get_blockhash(self, height: int) -> str:
+        """
+        Get the blockhash associated with a given height performing
+        `perform_request('getblockhash', params=[<int>])`
+        """
+        return self.perform_request("getblockhash", [height])
 
     def addnode(
         self, node: str, command: str, v2transport: bool = False, rpcquirk: bool = False


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Right now, if we ever encounter ourselves in a reorg of the chain, we will get into a corrupted state, because we won't update our accumulator for the no most-work-chain. Therefore, causing us to get stuck.

This commit adds logic to save an retrieve accumulators from different heights, allowing a full reorg of our chain.