### PR TITLE
wire: prefer v2 connections for non-utreexo peers

### DIFF
--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -225,7 +225,7 @@ pub enum Methods {
     ///     - 'onetry' to try a connection to the node once.
     ///
     /// 3. v2transport (boolean, optional, default=false):
-    ///     - Attempt to connect using BIP324 v2 transport protocol (ignored for 'remove' command)
+    ///     - Only tries to connect with this address using BIP0324 P2P V2 protocol (ignored for 'remove' command)
     ///
     /// Result: json null
     ///

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -104,6 +104,8 @@ pub trait FlorestaRPC {
     /// Tells florestad to connect with a peer
     ///
     /// You can use this to connect with a given node, providing it's IP address and port.
+    /// If the `v2transport` option is set, we won't retry connecting using the old, unencrypted
+    /// P2P protocol.
     fn add_node(&self, node: String, command: AddNodeCommand, v2transport: bool) -> Result<Value>;
     /// Finds an specific utxo in the chain
     ///

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -218,7 +218,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
         self.state = State::SentVersion(Instant::now());
         loop {
             futures::select! {
-                request = tokio::time::timeout(Duration::from_secs(10), self.node_requests.recv()).fuse() => {
+                request = tokio::time::timeout(Duration::from_secs(2), self.node_requests.recv()).fuse() => {
                     match request {
                         Ok(None) => {
                             return Err(PeerError::Channel);

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -153,8 +153,12 @@ pub struct Cli {
     pub gen_selfsigned_cert: bool,
 
     #[arg(long, default_value_t = false)]
-    /// Whether to disable fallback to v1 transport if v2 connection fails
-    pub no_v1_fallback: bool,
+    /// Whether we should try to connect with peers using the old, unencrypted V1 P2P protocol,
+    /// if we can't make a V2 connection.
+    ///
+    /// Note that for utreexod, we will still use V1, because it doesn't have V2 yet.
+    /// (TODO: Update when they implement this)
+    pub allow_v1_fallback: bool,
 
     #[cfg(unix)]
     #[arg(long, default_value = "false")]

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
         ssl_cert_path: params.ssl_cert_path,
         ssl_key_path: params.ssl_key_path,
         no_ssl: params.no_ssl,
-        allow_v1_fallback: !params.no_v1_fallback,
+        allow_v1_fallback: params.allow_v1_fallback,
         backfill: !params.no_backfill,
     };
 

--- a/tests/test_framework/rpc/bitcoin.py
+++ b/tests/test_framework/rpc/bitcoin.py
@@ -40,3 +40,9 @@ class BitcoinRPC(BaseRPC):
         Get the peer information by performing `perform_request('getpeerinfo')`
         """
         return self.perform_request("getpeerinfo")
+
+    def ping(self) -> None:
+        """
+        Perform the `ping` RPC that checks if our peers are alive.
+        """
+        self.perform_request("ping")


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [X] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Closes #416

We already have a good quorum of people running nodes that support v2, we can prefer v2 connections over v1 at this point safely. The only exception for now is `utreexod`, that still doesn't have v2, but we need to connect with them do download proofs.

~This commit adds a logic that turns the v1 fallback off for all non-utreexo peers~
This commit adds a logic that turns the v1 fallback off for all non-utreexo peers, unless the `allow-v1-fallback` CLI option was set to true. We also deny fallback for the `addnode` rpc, iff the `v2transport` option was set.