### PR TITLE
Change create_connection return type on `floresta-wire/src/p2p_wire/node.rs`                

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/error.rs
+++ b/crates/floresta-wire/src/p2p_wire/error.rs
@@ -55,6 +55,8 @@ pub enum WireError {
     Transport(TransportError),
     #[error("Can't send back response for user request")]
     ResponseSendError,
+    #[error("No addresses available")]
+    NoAddressesAvailable,
 }
 
 impl_error_from!(WireError, PeerError, PeerError);

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -139,7 +139,7 @@ where
             }
 
             self.create_connection(ConnectionKind::Regular(UTREEXO.into()))
-                .await;
+                .await?;
         }
 
         if self.block_filters.is_none() {
@@ -157,12 +157,12 @@ where
             }
 
             self.create_connection(ConnectionKind::Regular(ServiceFlags::COMPACT_FILTERS))
-                .await;
+                .await?;
         }
 
         if self.peers.len() < 10 {
             self.create_connection(ConnectionKind::Regular(ServiceFlags::NONE))
-                .await;
+                .await?;
         }
 
         Ok(())
@@ -565,8 +565,7 @@ where
         // update this or we'll get this warning every second after 15 minutes without a block,
         // until we get a new block.
         self.last_tip_update = Instant::now();
-        self.create_connection(ConnectionKind::Extra).await;
-
+        self.create_connection(ConnectionKind::Extra).await?;
         self.send_to_random_peer(
             NodeRequest::GetHeaders(self.chain.get_block_locator().unwrap()),
             ServiceFlags::NONE,

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -165,7 +165,7 @@ where
 
             if assume_stale {
                 self.context.last_block_requested = self.chain.get_validation_index().unwrap();
-                self.create_connection(ConnectionKind::Extra).await;
+                try_and_log!(self.create_connection(ConnectionKind::Extra).await);
                 self.last_tip_update = Instant::now();
                 continue;
             }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: follow-up from #465.

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

* Changed the return type of function signature from `Option<()>` to `Result<(), WireError>`;
* adapted the function calls on node.rs, running_node.rs and sync_node.rs;
* added two new types of errors (`NoAddressAvailable` and `AlreadyConnected`) on `WireError`. enum.

### Notes to the reviewers

While developing #465, it was discussed to change the return type of `create_connection`. This PR follow this discussion.

### Author Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
