### PR TITLE
[RPC] Implementation detail for addnode: connect to peer after add it

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -411,10 +411,9 @@ where
         }
     }
 
-    /// Handles addnode add requests, adding a new peer to the node and add a node to the added_node list.
-    /// This means the node is marked as a "manually added node" for future connection attempts does not directly establish a connection to the node.
-    /// Instead, the connection management process will attempt to connect to the manually added nodes in the background
-    pub fn handle_addnode_add_peer(
+    /// Handles addnode-RPC `Add` requests, adding a new peer to the `added_peers` list. This means
+    /// the peer is marked as a "manually added peer". We then try to connect to it, or retry later.
+    pub async fn handle_addnode_add_peer(
         &mut self,
         addr: IpAddr,
         port: u16,
@@ -439,7 +438,11 @@ where
             port,
             transport_protocol,
         });
-        Ok(())
+
+        // Implementation detail for `addnode`: on bitcoin-core, the node doesn't connect immediately
+        // after adding a peer, it just adds it to the `added_peers` list. Here we do almost the same,
+        // but we do an early connection attempt to the peer, so we can start communicating with.
+        self.maybe_open_connection_with_added_peers().await
     }
 
     /// Handles remove node requests, removing a peer from the node.
@@ -556,17 +559,19 @@ where
                     TransportProtocol::V1
                 };
 
-                let node_response =
-                    match self.handle_addnode_add_peer(addr, port, transport_protocol) {
-                        Ok(_) => {
-                            info!("Added peer {addr}:{port}");
-                            NodeResponse::Add(true)
-                        }
-                        Err(err) => {
-                            warn!("{err:?}");
-                            NodeResponse::Add(false)
-                        }
-                    };
+                let node_response = match self
+                    .handle_addnode_add_peer(addr, port, transport_protocol)
+                    .await
+                {
+                    Ok(_) => {
+                        info!("Added peer {addr}:{port}");
+                        NodeResponse::Add(true)
+                    }
+                    Err(err) => {
+                        warn!("{err:?}");
+                        NodeResponse::Add(false)
+                    }
+                };
 
                 let _ = responder.send(node_response);
                 return;
@@ -1420,7 +1425,6 @@ where
                 .await?
             }
         }
-
         Ok(())
     }
 

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -126,6 +126,9 @@ where
     /// If we are missing the speciall peers but have 10 connections, we should disconnect one
     /// random peer and try to connect to a utreexo and a compact filters peer.
     async fn check_connections(&mut self) -> Result<(), WireError> {
+        // retry the added peers connections
+        self.maybe_open_connection_with_added_peers().await?;
+
         // if we have 10 connections, but not a single utreexo or CBF one, disconnect one random
         // peer and create a utreexo and CBS connection
         if !self.has_utreexo_peers() {

--- a/tests/floresta-cli/addnode-test.py
+++ b/tests/floresta-cli/addnode-test.py
@@ -17,7 +17,7 @@ from test_framework.rpc.floresta import REGTEST_RPC_SERVER as floresta_config
 from test_framework.rpc.utreexo import REGTEST_RPC_SERVER as utreexod_config
 
 DATA_DIR = FlorestaTestFramework.get_integration_test_dir()
-TIMEOUT = 25
+TIMEOUT = 5
 
 
 def create_data_dirs(
@@ -122,26 +122,14 @@ class AddnodeTestWrapper:
         # should return a null json object
         test.assertIsNone(result)
 
-        # For now the node will be in awaiting state
-        # and will not be available in `get_peerinfo`
-        # (an empty list). The `addnode` just add the
-        # node to the added_peers list but the connection
-        # and handshake is not established yet (it's managed
-        # in `UtreexoNode::maybe_open_connections` method) that
-        # will be called in subsequent iterations on
-        # `Peer::run_inner_loop` method
+        # Floresta should be able to connect almost immediately
+        # to the utreexod node after adding it.
         peer_info = nodes[0].rpc.get_peerinfo()
-        test.assertEqual(len(peer_info), 0)
-
-        # add some time to guarantee
-        # the handshake establishment
-        time.sleep(TIMEOUT)
+        test.assertEqual(len(peer_info), 1)
 
         # now we expect the node to be in Ready state
         # with some expressive information. The node
         # should be in the `getpeerinfo` list.
-        peer_info = nodes[0].rpc.get_peerinfo()
-        test.assertEqual(len(peer_info), 1)
         test.assertEqual(peer_info[0]["address"], "127.0.0.1:18444")
         test.assertEqual(peer_info[0]["initial_height"], 0)
         test.assertEqual(peer_info[0]["kind"], "regular")
@@ -324,7 +312,7 @@ class AddnodeTestWrapper:
         test.assertIsNone(result)
 
         # add some time to establish the handshake
-        time.sleep(5)
+        time.sleep(TIMEOUT)
 
         # Check if the added node was added
         # to the peers list with the `getpeerinfo` command


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Follow-up of #465

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

* added `maybe_open_connection_with_added_peers` method to `handle_addnode_add_peer`;
* adjusted `TIMEOUT` on addnode tests.

### Notes to the reviewers

Previously the `addnode` command implementation followed the procedure of not connect immediately the added node. This PR implements the possibility of connect immediately after adding the node to the `added_peers` list. 

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above