### PR TITLE
Fix lint lifetime warnings and docstring tests

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -1070,7 +1070,9 @@ impl FlatChainStore {
 
     #[inline(always)]
     #[doc(hidden)]
-    fn get_cache_mut(&self) -> Result<MutexGuard<CacheType>, PoisonError<MutexGuard<CacheType>>> {
+    fn get_cache_mut(
+        &self,
+    ) -> Result<MutexGuard<'_, CacheType>, PoisonError<MutexGuard<'_, CacheType>>> {
         self.cache.lock()
     }
 }

--- a/crates/floresta-common/src/macros.rs
+++ b/crates/floresta-common/src/macros.rs
@@ -89,7 +89,7 @@ macro_rules! assert_ok {
 /// ```rust,compile_fail
 /// # use floresta_common::assert_err;
 /// // Compile error: `assert_err!` requires a `Result` value
-/// assert_err!(Some(42));
+/// assert_err!(Ok::<u32, &str>Some(42));
 /// ```
 macro_rules! assert_err {
     ($expr:expr $(,)?) => {

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -33,12 +33,12 @@ pub struct MemoryDatabase {
 type Result<T> = floresta_common::prelude::Result<T, MemoryDatabaseError>;
 
 impl MemoryDatabase {
-    fn get_inner(&self) -> Result<sync::RwLockReadGuard<Inner>> {
+    fn get_inner(&self) -> Result<sync::RwLockReadGuard<'_, Inner>> {
         self.inner
             .read()
             .map_err(|_| MemoryDatabaseError::PoisonedLock)
     }
-    fn get_inner_mut(&self) -> Result<sync::RwLockWriteGuard<Inner>> {
+    fn get_inner_mut(&self) -> Result<sync::RwLockWriteGuard<'_, Inner>> {
         self.inner
             .write()
             .map_err(|_| MemoryDatabaseError::PoisonedLock)


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: linting <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [x] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [x] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Fix some lint warnings and docstring tests that appeared on nightly rust version.

### Author Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
