### PR TITLE
[RPC] Fix getrpcinfo to return the duration compliant with core

### DIFF
--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -253,6 +253,17 @@ pub enum Methods {
     GetMemoryInfo { mode: Option<String> },
 
     /// Returns information about the RPC server
+    ///
+    /// Result: {                  (json object)
+    ///   "active_commands" : [    (json array) All active commands
+    ///     {                      (json object) Information about an active command
+    ///       "method" : "str",    (string) The name of the RPC command
+    ///       "duration" : n       (numeric) The running time in microseconds
+    ///     },
+    ///     ...
+    ///   ],
+    ///   "logpath" : "str"        (string) The complete file path to the output log
+    /// }
     #[command(name = "getrpcinfo")]
     GetRpcInfo,
 

--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -64,7 +64,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
             .values()
             .map(|req| ActiveCommand {
                 method: req.method.clone(),
-                duration: req.when.elapsed().as_secs(),
+                duration: req.when.elapsed().as_micros() as u64,
             })
             .collect();
 

--- a/tests/floresta-cli/addnode-test.py
+++ b/tests/floresta-cli/addnode-test.py
@@ -8,7 +8,6 @@ in context of the v1/v2 transport protocol.
 (see more at https://bitcoincore.org/en/doc/29.0.0/rpc/network/addnode/)
 """
 
-import os
 import re
 import time
 
@@ -21,25 +20,6 @@ TIMEOUT = 15
 PING_TIMEOUT = 40
 
 
-def create_data_dirs(
-    base_name: str, nodes: int, v2transport: bool = False
-) -> list[str]:
-    """
-    Create the data directories for the two nodes
-    to be used in the test.
-    """
-    transport = "v2" if v2transport else "v1"
-    dir_name = f"{base_name}-{transport}-transport"
-
-    paths = []
-    for i in range(nodes):
-        p = os.path.join(str(DATA_DIR), "data", dir_name, f"node-{i}")
-        os.makedirs(p, exist_ok=True)
-        paths.append(p)
-
-    return paths
-
-
 def run_test(name: str, v2transport: bool = False):
 
     class _AddnodeTest(FlorestaTestFramework):
@@ -47,9 +27,9 @@ def run_test(name: str, v2transport: bool = False):
         def set_test_params(self):
             self.log(f"**************** Running {name} test")
             self.nodes = [-1, -1]
-            self.data_dirs = create_data_dirs(
-                self.__class__.__name__, 2, v2transport=v2transport
-            )
+
+            # Create data directories for the nodes
+            self.data_dirs = _AddnodeTest.create_data_dirs(DATA_DIR, name, 2)
             self.v2transport = v2transport
             AddnodeTestWrapper.set_test_params(self)
 

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -230,6 +230,19 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
             )
         return os.getenv("FLORESTA_TEMP_DIR")
 
+    @staticmethod
+    def create_data_dirs(data_dir: str, base_name: str, nodes: int) -> list[str]:
+        """
+        Create the data directories for any nodes to be used in the test.
+        """
+        paths = []
+        for i in range(nodes):
+            p = os.path.join(data_dir, "data", base_name, f"node-{i}")
+            os.makedirs(p, exist_ok=True)
+            paths.append(p)
+
+        return paths
+
     def create_ssl_keys(self) -> tuple[str, str]:
         """
         Create a PKCS#8 formatted private key and a self-signed certificate.

--- a/tests/test_framework/rpc/bitcoin.py
+++ b/tests/test_framework/rpc/bitcoin.py
@@ -46,3 +46,10 @@ class BitcoinRPC(BaseRPC):
         Perform the `ping` RPC that checks if our peers are alive.
         """
         self.perform_request("ping")
+
+    def get_rpcinfo(self):
+        """
+        Returns stats about our RPC server performing
+        `perform_request('getrpcinfo')`
+        """
+        return self.perform_request("getrpcinfo")


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [x] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Fix #516

### Notes to the reviewers

* changes the `get_rpc_info` method to return the
`req.when.elapsed().as_micros() as u64` instead
`req.when.elapsed().as_secs()`;
* added docstring documentation compliant with core for `getrpcinfo` in
`floresta-cli`;
* added `getrpcinfo` method in
`tests/test_framework/rpc/bitcoin.py::BitcoinRPC`;
* added a bitcoind node in
`tests/test_framework/floresta-cli/getrpcinfo-test.py`.


### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above
