### PR TITLE
Use FlatChainStore in tests and benches

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Run benchmarks
       - name: Run cargo bench
-        run: cargo bench --features test-utils
+        run: cargo bench --features test-utils,experimental-db
 
       # Save cache only if the previous steps succeeded and there was not an exact cache key match
       # This happens everytime we modify any `cargo.lock` or `cargo.toml`, or each two weeks (caching recent changes)

--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -52,4 +52,4 @@ experimental-db = ["dep:memmap2", "dep:lru"]
 [[bench]]
 name = "chain_state_bench"
 harness = false
-required-features = ["test-utils"]
+required-features = ["test-utils", "experimental-db"]

--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -19,6 +19,8 @@ pub use pruned_utreexo::chain_state::*;
 pub use pruned_utreexo::chainparams::*;
 pub use pruned_utreexo::chainstore::*;
 pub use pruned_utreexo::error::*;
+#[cfg(feature = "experimental-db")]
+pub use pruned_utreexo::flat_chain_store::*;
 pub use pruned_utreexo::udata::*;
 pub use pruned_utreexo::ChainBackend;
 pub use pruned_utreexo::Notification;

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -9,7 +9,7 @@ just bench
 Under the hood this runs:
 
 ```bash
-cargo bench --features test-utils
+cargo bench --features test-utils,experimental-db
 ```
 
 By default, benchmarks that are resource-intensive are excluded to allow for quicker testing. If you'd like to include all benchmarks, use the following command:
@@ -19,7 +19,7 @@ By default, benchmarks that are resource-intensive are excluded to allow for qui
 EXPENSIVE_BENCHES=1 just bench
 
 # or, without Just:
-EXPENSIVE_BENCHES=1 cargo bench --features test-utils
+EXPENSIVE_BENCHES=1 cargo bench --features test-utils,experimental-db
 ```
 
 > **Note**: Running with `EXPENSIVE_BENCHES=1` enables the full benchmark suite, which will take several minutes to complete.

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -15,16 +15,16 @@ pub use bitcoin::Network;
 use fern::colors::Color;
 use fern::colors::ColoredLevelConfig;
 use fern::FormatCallback;
-#[cfg(feature = "experimental-db")]
-use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStore as ChainStore;
-#[cfg(feature = "experimental-db")]
-use floresta_chain::pruned_utreexo::flat_chain_store::FlatChainStoreConfig;
 #[cfg(feature = "zmq-server")]
 use floresta_chain::pruned_utreexo::BlockchainInterface;
 pub use floresta_chain::AssumeUtreexoValue;
 use floresta_chain::AssumeValidArg;
 use floresta_chain::BlockchainError;
 use floresta_chain::ChainState;
+#[cfg(feature = "experimental-db")]
+use floresta_chain::FlatChainStore as ChainStore;
+#[cfg(feature = "experimental-db")]
+use floresta_chain::FlatChainStoreConfig;
 #[cfg(not(feature = "experimental-db"))]
 use floresta_chain::KvChainStore as ChainStore;
 #[cfg(feature = "compact-filters")]

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ test-functional:
 
 # Run the benchmarks
 bench:
-    cargo bench --features test-utils
+    cargo bench --features test-utils,experimental-db
 
 # Generate documentation for all crates
 doc:


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [x] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

In _chain_state.rs_ tests we now conditionally compile the `ChainState<FlatChainStore>`.

I am also re-exporting the flat store module conditionally at the root of floresta-chain. In this module I have removed a couple of `pub` keywords and some unused `Index` methods. We now check that the index is only 31 bits before creation, which avoids misusing `update_block_index` with a very big height.

Then at the benchmarks we also bench using the flat store version. Updated docs, recipe and workflow to compile benches with `experimental-db`.