### PR TITLE
[RPC] Change the stop return value to be compliant wit Bitcoin Core 

### DIFF
--- a/crates/floresta-cli/src/lib.rs
+++ b/crates/floresta-cli/src/lib.rs
@@ -141,7 +141,7 @@ mod tests {
         let (mut _proc, client) = start_florestad();
 
         let stop = client.stop().expect("rpc not working");
-        assert_eq!(stop.as_str(), "florestad stopping");
+        assert_eq!(stop.as_str(), "Floresta stopping");
     }
 
     #[test]

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -208,7 +208,10 @@ pub enum Methods {
     #[command(name = "gettxout")]
     GetTxOut { txid: Txid, vout: u32 },
 
-    /// Stops the node
+    /// Request a graceful shutdown of Floresta.
+    ///
+    /// Result:
+    /// "str"    (string) A string with the content 'Floresta stopping'
     #[command(name = "stop")]
     Stop,
 

--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -83,7 +83,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     pub(super) async fn stop(&self) -> Result<&str, Error> {
         *self.kill_signal.write().await = true;
 
-        Ok("florestad stopping")
+        Ok("Floresta stopping")
     }
 
     // uptime

--- a/tests/floresta-cli/stop-test.py
+++ b/tests/floresta-cli/stop-test.py
@@ -4,8 +4,10 @@ floresta_cli_stop.py
 This functional test cli utility to interact with a Floresta node with `stop`
 """
 
+import re
 from test_framework import FlorestaTestFramework
-from test_framework.rpc.floresta import REGTEST_RPC_SERVER
+from test_framework.rpc.floresta import REGTEST_RPC_SERVER as florestad_rpc
+from test_framework.rpc.bitcoin import REGTEST_RPC_SERVER as bitcoin_rpc
 
 
 class StopTest(FlorestaTestFramework):
@@ -13,36 +15,48 @@ class StopTest(FlorestaTestFramework):
     Test `stop` command with a fresh node and its initial state.
     """
 
-    nodes = [-1]
+    nodes = [-1, -1]
 
     def set_test_params(self):
         """
         Setup a single node
         """
-        StopTest.nodes[0] = self.add_node(extra_args=[], rpcserver=REGTEST_RPC_SERVER)
+        StopTest.nodes[0] = self.add_node(
+            variant="florestad", extra_args=[], rpcserver=florestad_rpc
+        )
+        StopTest.nodes[1] = self.add_node(
+            variant="bitcoind", extra_args=[], rpcserver=bitcoin_rpc
+        )
 
     def run_test(self):
         """
-        Run JSONRPC server and get some data about blockchain with only regtest genesis block
+        Run JSONRPC stop command on both flrestad and bitcoin core nodes and
+        check if floresta and bitcoin core nodes are stopped correctly and if
+        the floresta's stop message is compliant with bitcoin core's stop message.
         """
-        # Start node and wait for it to be ready
-        # This is important to ensure that the node
-        # is fully initialized before we attempt to stop it.
-        # This is already made in the `run_node` method
-        # but let's wait a bit more to be sure
         self.run_node(StopTest.nodes[0])
-        node = self.get_node(StopTest.nodes[0])
-        node.rpc.wait_for_connections(opened=True)
+        self.run_node(StopTest.nodes[1])
+
+        floresta = self.get_node(StopTest.nodes[0])
+        bitcoin = self.get_node(StopTest.nodes[1])
 
         # Generally, the self.stop_node() method
         # do all the work for us, but in this case
         # we're testing the method rpc.stop(), so
         # re-do all the steps  to ensure that it
         # was successful and the ports are closed
-        result = node.rpc.stop()
-        self.assertEqual(result, "florestad stopping")
-        node.rpc.wait_for_connections(opened=False)
-        node.daemon.process.wait()
+        result_floresta = floresta.rpc.stop()
+        result_bitcoin = bitcoin.rpc.stop()
+
+        # Check if the messages are correct
+        for res in [result_floresta, result_bitcoin]:
+            self.assertIsSome(res)
+            self.assertIn("stopping", res)
+            self.assertMatch(res, re.compile(r"^(Floresta|Bitcoin Core) stopping$"))
+
+        # Check that the node is stopped
+        floresta.rpc.wait_for_connections(opened=False)
+        bitcoin.rpc.wait_for_connections(opened=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: adjust rpc `stop` return message.

### Which crates are being modified?

- [ ] floresta-chain
- [x] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

* change return string "florestad stopping" to "Floresta stopping";
* added a docstring for `stop` rpc command compliant with core;
* include bitcoin core to stop test.

### Notes to the reviewers

The [Bitcoin Core `stop` rpc command](https://bitcoincore.org/en/doc/29.0.0/rpc/control/stop/) return the message `'Bitcoin Core stopping'` and our `stop` message retuns a little different message (`'florestad stopping'`).

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
