### PR TITLE
Rename `florestad/src/json_rpc/res.rs::Error`

### DIFF
--- a/florestad/src/json_rpc/control.rs
+++ b/florestad/src/json_rpc/control.rs
@@ -1,12 +1,12 @@
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::res::Error;
+use super::res::JsonRpcError;
 use super::server::RpcChain;
 use super::server::RpcImpl;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
-    pub(super) fn get_memory_info(&self, mode: &str) -> Result<GetMemInfoRes, Error> {
+    pub(super) fn get_memory_info(&self, mode: &str) -> Result<GetMemInfoRes, JsonRpcError> {
         #[cfg(target_env = "gnu")]
         match mode {
             // only available for glibc
@@ -44,7 +44,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 Ok(GetMemInfoRes::MallocInfo(info_str))
             }
 
-            _ => Err(Error::InvalidMemInfoMode),
+            _ => Err(JsonRpcError::InvalidMemInfoMode),
         }
 
         #[cfg(not(target_env = "gnu"))]
@@ -52,11 +52,11 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         match mode {
             "stats" => Ok(GetMemInfoRes::Stats(GetMemInfoStats::default())),
             "mallocinfo" => Ok(GetMemInfoRes::MallocInfo(String::new())),
-            _ => Err(Error::InvalidMemInfoMode),
+            _ => Err(JsonRpcError::InvalidMemInfoMode),
         }
     }
 
-    pub(super) async fn get_rpc_info(&self) -> Result<GetRpcInfoRes, Error> {
+    pub(super) async fn get_rpc_info(&self) -> Result<GetRpcInfoRes, JsonRpcError> {
         let active_commands = self
             .inflight
             .read()
@@ -80,7 +80,7 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     // logging
 
     // stop
-    pub(super) async fn stop(&self) -> Result<&str, Error> {
+    pub(super) async fn stop(&self) -> Result<&str, JsonRpcError> {
         *self.kill_signal.write().await = true;
 
         Ok("Floresta stopping")

--- a/florestad/src/json_rpc/network.rs
+++ b/florestad/src/json_rpc/network.rs
@@ -1,14 +1,14 @@
 //! This module holds all RPC server side methods for interacting with our node's network stack.
 
-use super::res::Error as RpcError;
+use super::res::JsonRpcError;
 use super::server::RpcChain;
 use super::server::RpcImpl;
 
 impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
-    pub(crate) async fn ping(&self) -> Result<bool, RpcError> {
+    pub(crate) async fn ping(&self) -> Result<bool, JsonRpcError> {
         self.node
             .ping()
             .await
-            .map_err(|e| RpcError::Node(e.to_string()))
+            .map_err(|e| JsonRpcError::Node(e.to_string()))
     }
 }

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -96,21 +96,27 @@ pub struct GetTxOutProof(pub Vec<u8>);
 pub struct GetBlockResVerbose {
     /// This block's hash.
     pub hash: String,
+
     /// How many blocks have been added to the chain, after this one have been found. This is
     /// inclusive, so it starts with one when this block is the latest. If another one is found,
     /// then it increments to 2 and so on...
     pub confirmations: u32,
+
     /// The size of this block, without the witness
     pub strippedsize: usize,
+
     /// This block's size, with the witness
     pub size: usize,
+
     /// This block's weight.
     ///
     /// Data inside a segwit block is counted differently, 'base data' has a weight of 4, while
     /// witness only counts 1. This is (3 * base_size) + size
     pub weight: usize,
+
     /// How many blocks there are before this block
     pub height: u32,
+
     /// This block's version field
     ///
     /// Currently, blocks have version 2 (see BIP34), but it may also flip some of the LSB for
@@ -119,9 +125,11 @@ pub struct GetBlockResVerbose {
     /// version & ~(1 << 24).
     /// This is encoded as a number, see `version_hex` for a hex-encoded version
     pub version: i32,
+
     #[serde(rename = "versionHex")]
     /// Same as `version` by hex-encoded
     pub version_hex: String,
+
     /// This block's merkle root
     ///
     /// A Merkle Tree is a binary tree where every leaf is some data, and the branches are pairwise
@@ -129,8 +137,10 @@ pub struct GetBlockResVerbose {
     /// set. This merkle tree commits to the txid of all transactions in a block, and is used by
     /// some light clients to determine whether a transaction is in a given block
     pub merkleroot: String,
+
     /// A list of hex-encoded transaction id for the tx's in this block
     pub tx: Vec<String>,
+
     /// The timestamp committed to in this block's header
     ///
     /// Since there's no central clock that can tell time precisely in Bitcoin, this value is
@@ -139,22 +149,26 @@ pub struct GetBlockResVerbose {
     /// block `n - 1`.
     /// If you need it to be monotonical, see `mediantime` instead
     pub time: u32,
+
     /// The meadian of the last 11 blocktimes.
     ///
     /// This is a monotonically increasing number that bounds how old a block can be. Blocks may
     /// not have a timestamp less than the current `mediantime`. This is also used in relative
     /// timelocks.
     pub mediantime: u32,
+
     /// The nonce used to mine this block.
     ///
     /// Blocks are mined by increasing this value until you find a hash that is less than a network
     /// defined target. This number has no meaning in itself and is just a random u32.
     pub nonce: u32,
+
     /// Bits is a compact representation for the target.
     ///
     /// This is a exponential format (with well-define rounding) used by openssl that Satoshi
     /// decided to make consensus critical :/
     pub bits: String,
+
     /// The difficulty is derived from the current target and is defined as how many hashes, on
     /// average, one has to make before finding a valid block
     ///
@@ -163,85 +177,141 @@ pub struct GetBlockResVerbose {
     /// difficulty you have to multiply this by the min_diff.
     /// For mainnet, mindiff is 2 ^ 32
     pub difficulty: u128,
+
     /// Commullative work in this network
     ///
     /// This is a estimate of how many hashes the network has ever made to produce this chain
     pub chainwork: String,
+
     /// How many transactions in this block
     pub n_tx: usize,
+
     /// The hash of the block coming before this one
     pub previousblockhash: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The hash of the block coming after this one, if any
     pub nextblockhash: Option<String>,
 }
 
 #[derive(Debug)]
-pub enum Error {
+pub enum JsonRpcError {
+    /// The request is missing some params field, which is required for most RPC calls
     MissingParams,
+
+    /// The request is missing a request field, which is required for most RPC calls
     MissingReq,
+
+    /// Verbosity level is not 0 or 1
     InvalidVerbosityLevel,
+
+    /// The requested transaction is not found in the blockchain
     TxNotFound,
+
+    /// The provided script is invalid, e.g., if it is not a valid P2PKH or P2SH script
     InvalidScript,
+
+    /// The provided descriptor is invalid, e.g., if it does not match the expected format
     InvalidDescriptor,
+
+    /// The requested block is not found in the blockchain
     BlockNotFound,
+
+    /// There is an error with the chain, e.g., if the chain is not synced or when the chain is not valid
     Chain,
+
+    /// The provided vout is invalid, e.g., if it is not a valid output
     InvalidVout,
+
+    /// The provided height is invalid, e.g., if it is negative or too high
     InvalidHeight,
+
+    /// The provided hash is invalid, e.g., if it is not a valid SHA256 hash
     InvalidHash,
+
+    /// The provided block hash is invalid, e.g., if it is not a valid SHA256 hash
     InvalidBlockHash,
+
+    /// The request is invalid, e.g., some parameters use an incorrect type
     InvalidRequest,
+
+    /// The requested method is not found, e.g., if the method is not implemented or when the method is not available
     MethodNotFound,
+
+    /// This error is returned when there is an error decoding the request, e.g., if the request is not valid JSON
     Decode(String),
+
+    /// The provided port is invalid, e.g., when it is not a valid port number (0-65535)
     InvalidPort,
+
+    /// The provided address is invalid, e.g., when it is not a valid IP address or hostname
     InvalidAddress,
+
+    /// This error is returned when there is an error with the node, e.g., if the node is not connected or when the node is not responding
     Node(String),
+
+    /// This error is returned when the node does not have block filters enabled, which is required for some RPC calls
     NoBlockFilters,
+
+    /// The provided network is invalid, e.g., when it is not a valid Bitcoin network (mainnet, testnet3, testnet4, regtest)
     InvalidNetwork,
+
+    /// This error is returned when a hex value is invalid
     InvalidHex,
+
+    /// This error is returned when the node is in initial block download, which means it is still syncing the blockchain
     InInitialBlockDownload,
+
+    /// This error is returned when there is an error encoding the response, e.g., if the response is not valid JSON
     Encode,
+
     InvalidMemInfoMode,
+
+    /// This error is returned when there is an error with the wallet, e.g., if the wallet is not loaded or when the wallet is not available
     Wallet(String),
+
+    /// This error is returned when there is an error with block filters, e.g., if the filters are not available or when there is an issue with the filter data
     Filters(String),
+
+    /// This error is returned when the addnode command is invalid, e.g., if the command is not recognized or when the parameters are incorrect
     InvalidAddnodeCommand,
 }
 
-impl Display for Error {
+impl Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::InvalidBlockHash => write!(f, "Provided a invalid BlockHash"),
-            Error::InvalidRequest => write!(f, "Invalid request"),
-            Error::InvalidHeight => write!(f, "Invalid height"),
-            Error::InvalidHash =>  write!(f, "Invalid hash"),
-            Error::InvalidHex =>  write!(f, "Invalid hex"),
-            Error::InvalidVout =>  write!(f, "Invalid vout"),
-            Error::MethodNotFound =>  write!(f, "Method not found"),
-            Error::Decode(e) =>  write!(f, "error decoding request: {e}"),
-            Error::TxNotFound =>  write!(f, "Transaction not found"),
-            Error::InvalidDescriptor =>  write!(f, "Invalid descriptor"),
-            Error::BlockNotFound =>  write!(f, "Block not found"),
-            Error::Chain => write!(f, "Chain error"),
-            Error::InvalidPort => write!(f, "Invalid port"),
-            Error::InvalidAddress => write!(f, "Invalid address"),
-            Error::Node(e) => write!(f, "Node error: {e}"),
-            Error::NoBlockFilters => write!(f, "You don't have block filters enabled, please start florestad with --cfilters to run this RPC"),
-            Error::InvalidNetwork => write!(f, "Invalid network"),
-            Error::InInitialBlockDownload => write!(f, "Node is in initial block download, wait until it's finished"),
-            Error::Encode => write!(f, "Error encoding response"),
-            Error::InvalidScript => write!(f, "Invalid script"),
-            Error::MissingParams => write!(f, "Missing params field"),
-            Error::MissingReq => write!(f, "Missing request field"),
-            Error::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
-            Error::InvalidMemInfoMode => write!(f, "Invalid meminfo mode, should be stats or mallocinfo"),
-            Error::Wallet(e) => write!(f, "Wallet error: {e}"),
-            Error::Filters(e) => write!(f, "Error with filters: {e}"),
-            Error::InvalidAddnodeCommand => write!(f, "Invalid addnode command"),
+            JsonRpcError::InvalidBlockHash => write!(f, "Provided a invalid BlockHash"),
+            JsonRpcError::InvalidRequest => write!(f, "Invalid request"),
+            JsonRpcError::InvalidHeight => write!(f, "Invalid height"),
+            JsonRpcError::InvalidHash =>  write!(f, "Invalid hash"),
+            JsonRpcError::InvalidHex =>  write!(f, "Invalid hex"),
+            JsonRpcError::InvalidVout =>  write!(f, "Invalid vout"),
+            JsonRpcError::MethodNotFound =>  write!(f, "Method not found"),
+            JsonRpcError::Decode(e) =>  write!(f, "error decoding request: {e}"),
+            JsonRpcError::TxNotFound =>  write!(f, "Transaction not found"),
+            JsonRpcError::InvalidDescriptor =>  write!(f, "Invalid descriptor"),
+            JsonRpcError::BlockNotFound =>  write!(f, "Block not found"),
+            JsonRpcError::Chain => write!(f, "Chain error"),
+            JsonRpcError::InvalidPort => write!(f, "Invalid port"),
+            JsonRpcError::InvalidAddress => write!(f, "Invalid address"),
+            JsonRpcError::Node(e) => write!(f, "Node error: {e}"),
+            JsonRpcError::NoBlockFilters => write!(f, "You don't have block filters enabled, please start florestad with --cfilters to run this RPC"),
+            JsonRpcError::InvalidNetwork => write!(f, "Invalid network"),
+            JsonRpcError::InInitialBlockDownload => write!(f, "Node is in initial block download, wait until it's finished"),
+            JsonRpcError::Encode => write!(f, "Error encoding response"),
+            JsonRpcError::InvalidScript => write!(f, "Invalid script"),
+            JsonRpcError::MissingParams => write!(f, "Missing params field"),
+            JsonRpcError::MissingReq => write!(f, "Missing request field"),
+            JsonRpcError::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
+            JsonRpcError::InvalidMemInfoMode => write!(f, "Invalid meminfo mode, should be stats or mallocinfo"),
+            JsonRpcError::Wallet(e) => write!(f, "Wallet error: {e}"),
+            JsonRpcError::Filters(e) => write!(f, "Error with filters: {e}"),
+            JsonRpcError::InvalidAddnodeCommand => write!(f, "Invalid addnode command"),
         }
     }
 }
 
-impl IntoResponse for Error {
+impl IntoResponse for JsonRpcError {
     fn into_response(self) -> axum::http::Response<axum::body::Body> {
         let body = serde_json::json!({
             "error": self.to_string(),


### PR DESCRIPTION


### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: follow-up #86

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

* Rename `Error` to `JsonRpcError`;
* Derive JsonRpcError from `thiserror::Error`;
* Change calls of `Error` on `blockchain.rs`, `control.rs`, `network.rs` and `res.rs` to calls of `JsonRpcError`.

### Notes to the reviewers

Following the issue #86 and as discussed in meetings with @Davidson-Souza and @lucad70, this PR aim to standardize errors with JSONRPC calls with the `thiserror` crate.

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above