### PR TITLE
Simplify flat store, create `get_header_by_height`

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chainstore.rs
@@ -244,8 +244,8 @@ impl ChainStore for KvChainStore<'_> {
         Ok(())
     }
 
-    /// Gets the block header using the provided block hash. If it is on cache, it returns it directly, otherwise
-    /// it fetches it from the database.
+    /// Gets the block header using the provided block hash. If it is on cache, it returns it
+    /// directly, otherwise it fetches it from the database.
     fn get_header(&self, block_hash: &BlockHash) -> Result<Option<DiskBlockHeader>, Self::Error> {
         match self.headers_cache.read().get(block_hash) {
             Some(header) => Ok(Some(*header)),
@@ -256,6 +256,16 @@ impl ChainStore for KvChainStore<'_> {
                     .get(&block_hash)?
                     .and_then(|b| deserialize(&b).ok()))
             }
+        }
+    }
+
+    // Fetches the block header using the provided height. If it is on cache, it returns it
+    // directly, otherwise it fetches it from the database.
+    fn get_header_by_height(&self, height: u32) -> Result<Option<DiskBlockHeader>, Self::Error> {
+        let hash = self.get_block_hash(height)?;
+        match hash {
+            Some(hash) => self.get_header(&hash),
+            None => Ok(None),
         }
     }
 

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -203,6 +203,9 @@ pub trait ChainStore {
     /// the data we save.
     fn get_header(&self, block_hash: &BlockHash) -> Result<Option<DiskBlockHeader>, Self::Error>;
 
+    /// Get a block header by its height in our database.
+    fn get_header_by_height(&self, height: u32) -> Result<Option<DiskBlockHeader>, Self::Error>;
+
     /// Saves a block header to our database. See [DiskBlockHeader] for more info about
     /// the data we save.
     fn save_header(&mut self, header: &DiskBlockHeader) -> Result<(), Self::Error>;


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

I have added a new required method to `ChainStore` that allows fetching the header directly from the height, which is supported out of the box with `FlatChainStore`.

I also made the flat store `Index` impl be under its own module, enforcing we always use the API. Then I refactored `get_block_header_by_index` into the inner `get_disk_header`, which is more concise. This also ensures our heights are checked to be 31-bits.

EDIT: `save_roots_for_block` now returns error if we don't have the respective header, which makes the behavior more consistent. (same for the load function)