### PR TITLE
remove core2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,15 +689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,7 +1044,6 @@ name = "floresta-common"
 version = "0.3.0"
 dependencies = [
  "bitcoin 0.32.6",
- "core2",
  "hashbrown",
  "miniscript 12.3.2",
  "sha2",

--- a/crates/floresta-common/Cargo.toml
+++ b/crates/floresta-common/Cargo.toml
@@ -17,7 +17,6 @@ spin = "0.9.8"
 
 # No-std specific dependencies
 hashbrown = { version = "0.15.2" }
-core2 = { version = "0.4.0", default-features = false }
 
 # Optional as descriptors feature
 miniscript = { version = "12", default-features = false, optional = true }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: removing unused dependency

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [X] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

`core2` was made unused by #487, but it's still mentioned is floresta-common. This commit removes it