### PR TITLE
Fix action ip:port address for log RPC info

### DIFF
--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -717,7 +717,10 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
 
         let listener = match tokio::net::TcpListener::bind(address).await {
             Ok(listener) => {
-                info!("RPC server running on: {address}");
+                let local_addr = listener
+                    .local_addr()
+                    .expect("Infallible: listener binding was `Ok`");
+                info!("RPC server running on: {local_addr}");
                 listener
             }
             Err(_) => {


### PR DESCRIPTION


### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

* This commit fixes the correct ip and port information returned from TcpListener made in #531

### Notes to the reviewers

Previously, if we passed `--rpc-address=127.0.0.1:0` it didn't log the port choosen by system. Now this log the correct port.

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
