### PR TITLE
Wire: small fixes and improvements

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node_context.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_context.rs
@@ -74,6 +74,12 @@ pub trait NodeContext {
     /// How long should we wait for a peer to respond our connection request
     const CONNECTION_TIMEOUT: u64 = 30; // 30 seconds
 
+    /// How many blocks we can ask in the same request
+    const BLOCKS_PER_GETDATA: usize = 4;
+
+    /// How many concurrent GETDATA packages we can send at the same time
+    const MAX_CONCURRENT_GETDATA: usize = 2;
+
     fn get_required_services(&self) -> ServiceFlags {
         ServiceFlags::NETWORK
     }

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -40,9 +40,9 @@ use crate::p2p_wire::transport::UtreexoMessage;
 
 /// If we send a ping, and our peer takes more than PING_TIMEOUT to
 /// reply, disconnect.
-const PING_TIMEOUT: u64 = 30;
+const PING_TIMEOUT: u64 = 10 * 60;
 /// If the last message we've got was more than XX, send out a ping
-const SEND_PING_TIMEOUT: u64 = 60;
+const SEND_PING_TIMEOUT: u64 = 2 * 60;
 /// The inv element type for a utreexo block with witness data
 const INV_UTREEXO_BLOCK: u32 = 0x40000002 | (1 << 24);
 

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -135,7 +135,7 @@ pub enum PeerError {
     #[error("Peer sent us too many message in a short period of time")]
     TooManyMessages,
     #[error("Peer timed a ping out")]
-    Timeout,
+    PingTimeout,
     #[error("channel error")]
     Channel,
     #[error("Transport error: {0}")]
@@ -256,7 +256,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
             // If we send a ping and our peer doesn't respond in time, disconnect
             if let Some(when) = self.last_ping {
                 if when.elapsed().as_secs() > PING_TIMEOUT {
-                    return Err(PeerError::Timeout);
+                    return Err(PeerError::PingTimeout);
                 }
             }
 

--- a/crates/floresta-wire/src/p2p_wire/peer.rs
+++ b/crates/floresta-wire/src/p2p_wire/peer.rs
@@ -240,6 +240,7 @@ impl<T: AsyncWrite + Unpin + Send + Sync> Peer<T> {
                             return Err(e);
                         }
                         Some(ReaderMessage::Block(block)) => {
+                            debug!("got a utreexo block from peer {}", self.id);
                             self.send_to_node(PeerMessages::Block(block)).await;
                         }
                         Some(ReaderMessage::Message(msg)) => {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -434,7 +434,7 @@ where
             }
 
             // Check if we haven't missed any block
-            if self.inflight.len() < 10 {
+            if self.inflight.len() < RunningNode::MAX_INFLIGHT_REQUESTS {
                 try_and_log!(self.ask_missed_block().await);
             }
         }

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -405,13 +405,6 @@ where
                     }
 
                     PeerMessages::Disconnected(idx) => {
-                        // check if this peer had inflight block requests, if so, bring our
-                        // `last_block_requested` back
-                        if self.inflight.values().any(|(peer_id, _)| *peer_id == peer) {
-                            self.context.last_block_requested =
-                                self.chain.get_validation_index()?;
-                        }
-
                         try_and_log!(self.handle_disconnection(peer, idx).await);
                     }
 

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -51,7 +51,7 @@ impl NodeContext for SyncNode {
     }
 
     const MAX_OUTGOING_PEERS: usize = 5; // don't need many peers, half the default
-    const TRY_NEW_CONNECTION: u64 = 10; // ten seconds
+    const TRY_NEW_CONNECTION: u64 = 60; // one minute
     const REQUEST_TIMEOUT: u64 = 10 * 60; // 10 minutes
     const MAX_INFLIGHT_REQUESTS: usize = 100; // double the default
 }

--- a/crates/floresta-wire/src/p2p_wire/transport.rs
+++ b/crates/floresta-wire/src/p2p_wire/transport.rs
@@ -147,7 +147,11 @@ async fn try_connection<A: ToSocketAddrs>(
     force_v1: bool,
 ) -> TransportResult {
     let tcp_stream = TcpStream::connect(address).await?;
-    tcp_stream.set_nodelay(true)?;
+    // Data is buffered until there is enough to send out
+    // thus reducing the amount of packages going through
+    // the network.
+    tcp_stream.set_nodelay(false)?;
+
     let peer_addr = match tcp_stream.peer_addr() {
         Ok(addr) => addr.to_string(),
         Err(_) => String::from("unknown peer"),


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Fixes #511

This PR makes some minor changes to make sure our `sync_node` works with slow connections. Our banning logic was too agressive for slow connections, we also may lose some blocks and just get stuck. This gives more margin for those peers, make sure we really don't miss any block and remove one case where we would ask for the same block twice.

This PR also renames `Timeout` to `PingTimeout`, since the only case we use it is if the peer didn't respond a `Ping` in time. I'm also adding a log for utreexo block messages (we had it for all messages but this one).

Finally, I'm using a buffered reader to read from wire, as this tends to perform better when our remote connection is slower (we create one big buffer instead of making tons of small syscalls).