### PR TITLE
Fix just lint recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,8 +75,26 @@ open-doc:
 # Format code and run configured linters
 lint:
     @just fmt
-    cargo +nightly clippy --all-targets --no-default-features
-    cargo +nightly clippy --all-targets --all-features
+
+    # 1) Run with no features
+    cargo +nightly clippy --workspace --all-targets --no-default-features \
+        --exclude floresta-chain \
+        --exclude florestad
+
+    # 2) Run with all features
+    cargo +nightly clippy --workspace --all-targets --all-features \
+        --exclude floresta-chain \
+        --exclude florestad
+
+    # Run both cases in floresta-chain (one with kv, another with flat)
+    cargo +nightly clippy -p floresta-chain --all-targets --no-default-features --features kv-chainstore
+    cargo +nightly clippy -p floresta-chain --all-targets \
+        --features bitcoinconsensus,metrics,test-utils,flat-chainstore
+
+    # Run both cases in florestad (one with kv, another with flat)
+    cargo +nightly clippy -p florestad --all-targets --no-default-features --features kv-chainstore
+    cargo +nightly clippy -p florestad --all-targets \
+        --features compact-filters,zmq-server,json-rpc,metrics,flat-chainstore
 
 # Format code
 fmt:


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: justfile

### Description

This recipe was previously checking no features and all features, which should cover most cases and is cheap (while we fully enforce clippy on the more expensive `just lint-features` and on CI).

But now the `kv-chainstore` and `flat-chainstore` features are mutually exclusive, so this recipe is broken. I have updated it to properly handle the particular cases of `floresta-chain` and `florestad`. Since cargo doesn't have something like `--all-features-except`, I had to list all the features and exclude one chainstore feature.