### PR TITLE
just: don't call black in `check` mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,7 +50,7 @@ test-functional-run arg="":
 
 # format and lint functional tests
 test-functional-uv-fmt:
-    uv run black --check --verbose ./tests
+    uv run black --verbose ./tests
     uv run pylint --verbose ./tests
 
 # Run all required stuff to functional tests
@@ -96,6 +96,9 @@ lint:
     cargo +nightly clippy -p florestad --all-targets \
         --features compact-filters,zmq-server,json-rpc,metrics,flat-chainstore
 
+    # lint the functional tests
+    @just test-functional-uv-fmt
+
 # Format code
 fmt:
     cargo +nightly fmt --all
@@ -123,4 +126,5 @@ clean-data:
 pcc:
     @just lint-features '-- -D warnings'
     @just test-features
+    @test-functional-uv-fmt
     @just test-functional


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: `justfile`

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: justfile

### Description

The `lint*` receipts are meant to fix you code, not check whether it's well formatted. However, black (the python linter) is called with `--check`, which only yells at you if there's something wrong.

This commit fixes this by removing this paramenter. I'm also adding the python lint to other receipts like `pcc` and `lint`.