### PR TITLE
Lint `fuzz` and `metrics`

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -82,7 +82,7 @@ jobs:
       # Install cargo-fuzz only if not found in cache
       - name: Install cargo-fuzz
         if: steps.cache-rust.outputs.cache-hit != 'true'
-        run: cargo install cargo-fuzz --locked --force
+        run: cargo +nightly install cargo-fuzz --locked --force
 
       # Pull corpus data from the floresta-qa-assets repository
       - name: Pull corpus data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
     "crates/floresta-wire",
 ]
 
-default-members = [ 
+default-members = [
     "florestad",
     "crates/floresta",
     "crates/floresta-chain",
@@ -25,4 +25,3 @@ default-members = [
     "crates/floresta-watch-only",
     "crates/floresta-wire",
 ]
-

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -9,7 +9,8 @@ just bench
 Under the hood this runs:
 
 ```bash
-cargo bench --features test-utils,experimental-db
+cargo bench -p floresta-chain --no-default-features --features test-utils,kv-chainstore
+cargo bench -p floresta-chain --no-default-features --features test-utils,flat-chainstore
 ```
 
 By default, benchmarks that are resource-intensive are excluded to allow for quicker testing. If you'd like to include all benchmarks, use the following command:
@@ -19,7 +20,8 @@ By default, benchmarks that are resource-intensive are excluded to allow for qui
 EXPENSIVE_BENCHES=1 just bench
 
 # or, without Just:
-EXPENSIVE_BENCHES=1 cargo bench --features test-utils,experimental-db
+EXPENSIVE_BENCHES=1 cargo bench -p floresta-chain --no-default-features --features test-utils,kv-chainstore
+EXPENSIVE_BENCHES=1 cargo bench -p floresta-chain --no-default-features --features test-utils,flat-chainstore
 ```
 
 > **Note**: Running with `EXPENSIVE_BENCHES=1` enables the full benchmark suite, which will take several minutes to complete.

--- a/justfile
+++ b/justfile
@@ -61,8 +61,8 @@ test-functional:
 
 # Run the benchmarks
 bench:
-    cargo bench --package floresta-chain --no-default-features --features test-utils,kv-chainstore
-    cargo bench --package floresta-chain --no-default-features --features test-utils,flat-chainstore
+    cargo bench -p floresta-chain --no-default-features --features test-utils,kv-chainstore
+    cargo bench -p floresta-chain --no-default-features --features test-utils,flat-chainstore
 
 # Generate documentation for all crates
 doc:
@@ -96,7 +96,7 @@ lint:
     cargo +nightly clippy -p florestad --all-targets \
         --features compact-filters,zmq-server,json-rpc,metrics,flat-chainstore
 
-    # lint the functional tests
+    # Lint the functional tests
     @just test-functional-uv-fmt
 
 # Format code

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,4 +10,3 @@ sysinfo = "0.33"
 axum = "0.7"
 prometheus-client = "0.22.3"
 tokio = { version = "1", features = ["full"] }
-


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: contrib dir

### Description

I added these two packages to the crate list in `feature_matrix` so that we lint them (and test them if in the future we add tests).

The `just lint` recipe already checks them since it is run with the `--workspace` flag (and `just fmt` uses the `--all` flag). This change is to enforce clippy at CI.

I updated the benchmarking docs, and also fixed [an issue](https://github.com/JoseSK999/Floresta/actions/runs/15909410255/job/44872820406#step:8:39) with the `cargo-fuzz` installation.