### PR TITLE
Fix nix flakes check

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -82,7 +82,7 @@ jobs:
       # Install cargo-fuzz only if not found in cache
       - name: Install cargo-fuzz
         if: steps.cache-rust.outputs.cache-hit != 'true'
-        run: cargo install cargo-fuzz --locked --force
+        run: cargo +nightly install cargo-fuzz --locked --force
 
       # Pull corpus data from the floresta-qa-assets repository
       - name: Pull corpus data

--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -12,6 +12,7 @@
 //! ready-to-use implementation, see the [KvChainStore] struct.
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![allow(clippy::manual_is_multiple_of)]
 
 pub mod pruned_utreexo;
 pub(crate) use floresta_common::prelude;

--- a/crates/floresta-compact-filters/src/lib.rs
+++ b/crates/floresta-compact-filters/src/lib.rs
@@ -9,6 +9,8 @@
 //! This module should receive blocks as we download them, it'll create a filter
 //! for it. Therefore, you can't use this to speedup wallet sync **before** IBD,
 //! since we wouldn't have the filter for all blocks yet.
+#![allow(clippy::manual_is_multiple_of)]
+
 use core::fmt::Debug;
 use std::fmt::Display;
 use std::sync::PoisonError;

--- a/crates/floresta-electrum/src/lib.rs
+++ b/crates/floresta-electrum/src/lib.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+#![allow(clippy::manual_is_multiple_of)]
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: MIT
+#![allow(clippy::manual_is_multiple_of)]
+
 use core::cmp::Ordering;
 use core::fmt::Debug;
 

--- a/flake.lock
+++ b/flake.lock
@@ -157,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744857263,
-        "narHash": "sha256-M4X/CnquHozzgwDk+CbFb8Sb4rSGJttfNOKcpRwziis=",
+        "lastModified": 1751165203,
+        "narHash": "sha256-3QhlpAk2yn+ExwvRLtaixWsVW1q3OX3KXXe0l8VMLl4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9f3d63d569536cd661a4adcf697e32eb08d61e31",
+        "rev": "90f547b90e73d3c6025e66c5b742d6db51c418c3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -69,12 +69,13 @@
                 };
               };
             };
-          # This check runs clippy and rusfmt on all defined files in `fileset`,
+
+          # This check runs clippy and rustfmt on all defined files in `fileset`,
           # the rust files we have in this project
           rust-sanity-check =
             let
               # since the rust code of this project is spread across multiple files,
-              # its better to track them using file sets to avoid useless operations.
+              # it's better to track them using file sets to avoid useless operations.
               fileSet = lib.fileset.unions [
                 ./Cargo.toml
                 ./Cargo.lock
@@ -117,6 +118,7 @@
                 };
               };
             };
+
           # This check runs black on check mode on all defined files in `fileset`,
           # the python files we have in this project
           python-sanity-check =


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [x] Other: flake.nix

### Description

We need to use the latest nightly for `clippy` in flake.nix, such that it recognizes newer lints that we rely on.

In order to use the latest nightly, I updated the flake.lock `rust-overlay` via:

```bash
nix --experimental-features "nix-command flakes" flake update --update-input rust-overlay
```

### Notes to the reviewers

This PR builds on top #541 (for cargo-fuzz install) and #543  (which adds the allow `clippy::manual_is_multiple_of`). These allows were required because the new lint suggests using [a method](https://doc.rust-lang.org/stable/std/primitive.u32.html#method.is_multiple_of) that our MSRV doesn't have.