### PR TITLE
Add missing `checkTransaction` rules

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/error.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/error.rs
@@ -60,7 +60,9 @@ pub enum BlockValidationErrors {
     InvalidCoinbase(String),
     UtxoNotFound(OutPoint),
     ScriptValidationError(String),
-    InvalidOutput,
+    NullPrevOut,
+    EmptyInputs,
+    EmptyOutputs,
     ScriptError,
     BlockTooBig,
     TooManyCoins,
@@ -113,8 +115,17 @@ impl Display for BlockValidationErrors {
             BlockValidationErrors::UtxoNotFound(outpoint) => {
                 write!(f, "Utxo referenced by {outpoint:?} not found")
             }
-            BlockValidationErrors::InvalidOutput => {
-                write!(f, "Invalid output, verify spending values")
+            BlockValidationErrors::NullPrevOut => {
+                write!(
+                    f,
+                    "This transaction has a null PrevOut but it's not coinbase"
+                )
+            }
+            BlockValidationErrors::EmptyInputs => {
+                write!(f, "This transaction has no inputs")
+            }
+            BlockValidationErrors::EmptyOutputs => {
+                write!(f, "This transaction has no outputs")
             }
             BlockValidationErrors::BlockTooBig => write!(f, "Block too big"),
             BlockValidationErrors::InvalidCoinbase(e) => {

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -647,7 +647,9 @@ where
                         BlockValidationErrors::InvalidCoinbase(_)
                         | BlockValidationErrors::UtxoNotFound(_)
                         | BlockValidationErrors::ScriptValidationError(_)
-                        | BlockValidationErrors::InvalidOutput
+                        | BlockValidationErrors::NullPrevOut
+                        | BlockValidationErrors::EmptyInputs
+                        | BlockValidationErrors::EmptyOutputs
                         | BlockValidationErrors::ScriptError
                         | BlockValidationErrors::BlockTooBig
                         | BlockValidationErrors::NotEnoughPow

--- a/crates/floresta-wire/src/p2p_wire/sync_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/sync_node.rs
@@ -299,7 +299,9 @@ where
                         BlockValidationErrors::InvalidCoinbase(_)
                         | BlockValidationErrors::UtxoNotFound(_)
                         | BlockValidationErrors::ScriptValidationError(_)
-                        | BlockValidationErrors::InvalidOutput
+                        | BlockValidationErrors::NullPrevOut
+                        | BlockValidationErrors::EmptyInputs
+                        | BlockValidationErrors::EmptyOutputs
                         | BlockValidationErrors::ScriptError
                         | BlockValidationErrors::BlockTooBig
                         | BlockValidationErrors::NotEnoughPow


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

When trying to reuse the Bitcoin Core tests, one of the problems I found is that we don't implement three basic checks that are performed in Core's checkTransaction (from the consensus directory): https://github.com/bitcoin/bitcoin/blob/master/src/consensus/tx_check.cpp

Transactions must have:

- At least 1 input
- At least 1 output

```c++
    // Basic checks that don't depend on any context
    if (tx.vin.empty())
        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vin-empty");
    if (tx.vout.empty())
        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-empty");
```

- And no null PrevOut if not coinbase

```c++
    if (tx.IsCoinBase())
    {
        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
            return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-cb-length");
    }
    else
    {
        for (const auto& txin : tx.vin)
            if (txin.prevout.IsNull())
                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-prevout-null");
    }
```

Added these three error variants, and removed the `InvalidOutput` one which wasn't used.

### Notes to the reviewers

I have checked this against the first 400,000 blocks and it works as expected. These error paths will be tested when we vendor the Bitcoin Core test vectors.