### PR TITLE
More default features

### DIFF
--- a/crates/floresta-chain/Cargo.toml
+++ b/crates/floresta-chain/Cargo.toml
@@ -43,7 +43,7 @@ zstd = "0.13.3"
 hex = "0.4.3"
 
 [features]
-default = []
+default = ["bitcoinconsensus", "flat-chainstore"]
 bitcoinconsensus = ["bitcoin/bitcoinconsensus", "dep:bitcoinconsensus"]
 metrics = ["dep:metrics"]
 test-utils = ["dep:serde"]

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -58,7 +58,7 @@ flat-chainstore = ["floresta-chain/flat-chainstore"]
 compact-filters = ["dep:floresta-compact-filters"]
 zmq-server = ["dep:zmq"]
 json-rpc = ["dep:axum", "dep:tower-http", "compact-filters"]
-default = ["json-rpc", "flat-chainstore"]
+default = ["json-rpc", "flat-chainstore", "zmq-server"]
 metrics = ["dep:metrics", "floresta-wire/metrics"]
 tokio-console = ["dep:console-subscriber"]
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: Feature change

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Zmq is widely used nowadays by apps that build on top of Bitcoin so adding it as a default feature should make sense.
Also, floresta-chain had a empty default so i took the opportunity to express the standardness of the new db and about bitcoin consensus.

### Notes to the reviewers

May help some linters and IDEs to interact with the project.

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [X] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [X] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
