### PR TITLE
florestad: fix `--connect`

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -1539,10 +1539,12 @@ where
             ));
         }
 
-        // We allow V1 fallback only if the cli option was set, or if we are connecting to a
-        // utreexo peer, since utreexod doesn't support V2 yet.
-        let allow_v1 =
-            self.config.allow_v1_fallback || kind == ConnectionKind::Regular(UTREEXO.into());
+        // We allow V1 fallback only if the cli option was set, it's a --connect peer
+        // or if we are connecting to a utreexo peer, since utreexod doesn't support V2 yet.
+        let is_fixed = self.fixed_peer.is_some();
+        let allow_v1 = self.config.allow_v1_fallback
+            || kind == ConnectionKind::Regular(UTREEXO.into())
+            || is_fixed;
 
         self.open_connection(kind, peer_id, address, allow_v1)
             .await?;

--- a/tests/florestad/connect-test.py
+++ b/tests/florestad/connect-test.py
@@ -1,0 +1,56 @@
+"""
+Test the --connect cli option of florestad
+
+This test will start a utreexod, then start a florestad node with
+the --connect option pointing to the utreexod node. Then check if
+the utreexod node is connected to the florestad node.
+"""
+
+from test_framework import UtreexoRPC, FlorestaTestFramework
+from test_framework.rpc.floresta import REGTEST_RPC_SERVER as florestad_rpc
+from test_framework.rpc.utreexo import REGTEST_RPC_SERVER as utreexod_rpc
+
+import time
+
+SLEEP_TIME = 10
+
+
+class CliConnectTest(FlorestaTestFramework):
+    nodes = [-1, -1]
+
+    def set_test_params(self):
+        to_connect = f"{utreexod_rpc['host']}:{utreexod_rpc['ports']['server']}"
+        CliConnectTest.nodes[0] = self.add_node(
+            variant="florestad",
+            rpcserver=florestad_rpc,
+            extra_args=[
+                f"--connect={to_connect}",
+            ],
+        )
+
+        CliConnectTest.nodes[1] = self.add_node(
+            variant="utreexod",
+            rpcserver=utreexod_rpc,
+        )
+
+    def run_test(self):
+        # Start the nodes
+        self.log("=== Starting nodes")
+        self.run_node(CliConnectTest.nodes[0])
+        self.run_node(CliConnectTest.nodes[1])
+
+        time.sleep(SLEEP_TIME)  # Give some time for the nodes to start
+
+        # Check whether the utreexod is connected to florestad
+        self.log("=== Checking connection")
+        utreexod: UtreexoRPC = self.get_node(CliConnectTest.nodes[1]).rpc
+        res = utreexod.get_peerinfo()
+        self.assertEqual(len(res), 1)
+
+        # Stop the nodes
+        self.log("=== Stopping nodes")
+        self.stop()
+
+
+if __name__ == "__main__":
+    CliConnectTest().main()


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: functional tests

### Description

After https://github.com/vinteumorg/Floresta/pull/501, using --connect with a node that doesn't support V2 would
make the node never make any connections. But --connect should be
allowed to make V1 connections, as it's the only peer allowed to connect
with.

I'm also adding a functional test to make sure it won't happen again.
