### PR TITLE
Benchmark checksums and chainstore creation

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -188,7 +188,7 @@ struct FileChecksum(u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// The current checksum of our database
-struct DbCheckSum {
+pub struct DbCheckSum {
     /// The checksum of the headers file
     headers_checksum: FileChecksum,
 
@@ -780,8 +780,8 @@ impl FlatChainStore {
         Ok(())
     }
 
-    /// Computes a checksum for our database
-    fn compute_checksum(&self) -> DbCheckSum {
+    /// Computes the XXH3-64 checksum for our database
+    pub fn compute_checksum(&self) -> DbCheckSum {
         // a function that computes the xxHash of a memory map
         let checksum_fn = |mmap: &MmapMut| {
             let mmap_as_slice = mmap.iter().as_slice();


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

We have found that the checksum method reads all the virtual data. It may be useful to benchmark it, which helps evaluating future changes. Also the initialization time for each chainstore.

`DbCheckSum` and the method will now be public, although it seems harmless as the inner fields are private (i.e., the only way to produce a `DbCheckSum` is via the method).