### PR TITLE
cli: rename rescan to rescanblockchain

### DIFF
--- a/crates/floresta-cli/README.md
+++ b/crates/floresta-cli/README.md
@@ -13,7 +13,7 @@ Available commands:
  - [gettxout](#gettxout)
  - [gettxproof](#gettxproof)
  - [gettransaction](#gettransaction)
- - [rescan](#rescan)
+ - [rescanblockchain](#rescanblockchain)
  - [sendrawtransaction](#sendrawtransaction)
  - [getblockheader](#getblockheader)
  - [loaddescriptor](#loaddescriptor)
@@ -120,49 +120,51 @@ Returns a transaction data, given its id. The transaction itself doesn't have to
 `vin`: A vector of inputs
 
   `script_sig`: The script signature for this input
-  
+
   `asm`: The disassembled script signature
-    
+
   `hex`: Raw hex-encoded script signature
-  
+
   `sequence`: The nSequence value for this input
-  
+
   `txid`: The id of the transaction containing the output we are spending
-  
+
   `vout`: The index of the output we are spending
-  
+
   `witness`: A vector of witness data
 
 `vout`: A vector of outputs
 
   `n`: The index of this output
-  
+
   `script_pub_key`: The script pubkey for this output
-  
+
   `address`: The address this output pays to, if it's a standard output
-    
+
   `asm`: The disassembled script pubkey
-    
+
   `hex`: Raw hex-encoded script pubkey
-    
+
   `req_sigs`: The amount of signatures required to spend this output (Deprecated)
-    
+
   `type`: The type of this output (e.g pubkeyhash, scripthash, etc)
-    
+
   `value`: The amount of satoshis in this output
 
 `vsize`: The size of this transaction, in virtual bytes
 
 `weight`: The weight of this transaction
 
-## rescan
+## rescanblockchain
 
 Tells our node to rescan blocks. This rpc will only work if the node is not in IBD and it was started with the `--cfilters` flag.
 This will rescan for all scripts in our internal wallet within the range of blocks you've downloaded filters for (which can be set
 with the `--filters-start-height` flag). If we don't see any error in early stages, the rescan will continue in the background, and
 you'll get a `true` as a response. Once the process is finished, you'll see a log message in the node's log saying that the rescan is done.
 
-**Args**: None
+**Args**:
+
+`start_height`: The height of the block we should start rescanning from. If not provided, it will default to rescan from the genesis block.
 
 **Return**
 

--- a/crates/floresta-cli/src/main.rs
+++ b/crates/floresta-cli/src/main.rs
@@ -64,7 +64,7 @@ fn do_request(cmd: &Cli, client: Client) -> anyhow::Result<String> {
             serde_json::to_string_pretty(&client.get_transaction(txid, Some(true))?)?
         }
         Methods::RescanBlockchain { start_height } => {
-            serde_json::to_string_pretty(&client.rescan(start_height)?)?
+            serde_json::to_string_pretty(&client.rescanblockchain(start_height)?)?
         }
         Methods::SendRawTransaction { tx } => {
             serde_json::to_string_pretty(&client.send_raw_transaction(tx)?)?
@@ -172,7 +172,7 @@ pub enum Methods {
     GetTransaction { txid: Txid, verbose: Option<bool> },
 
     /// Ask the node to rescan the blockchain for transactions
-    #[command(name = "rescan")]
+    #[command(name = "rescanblockchain")]
     RescanBlockchain { start_height: u32 },
 
     /// Submits a raw transaction to the network

--- a/crates/floresta-cli/src/rpc.rs
+++ b/crates/floresta-cli/src/rpc.rs
@@ -64,7 +64,7 @@ pub trait FlorestaRPC {
     /// filters, we'll need to download the entire blockchain again, which will take a while.
     /// The rescan parameter is the height at which to start the rescan, and should be at least
     /// as old as the oldest transaction this descriptor could have been used in.
-    fn rescan(&self, rescan: u32) -> Result<bool>;
+    fn rescanblockchain(&self, start_height: u32) -> Result<bool>;
     /// Returns the current height of the blockchain
     fn get_block_count(&self) -> Result<u32>;
     /// Sends a hex-encoded transaction to the network
@@ -189,8 +189,11 @@ impl<T: JsonRPCClient> FlorestaRPC for T {
         self.call("stop", &[])
     }
 
-    fn rescan(&self, rescan: u32) -> Result<bool> {
-        self.call("rescan", &[Value::Number(Number::from(rescan))])
+    fn rescanblockchain(&self, start_height: u32) -> Result<bool> {
+        self.call(
+            "rescanblockchain",
+            &[Value::Number(Number::from(start_height))],
+        )
     }
 
     fn get_roots(&self) -> Result<Vec<String>> {


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [X] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Fixes #554

This is the name used in Bitcoin Core. We've renamed the server implementation (due to #453), but didn't change the CLI implementation.