### PR TITLE
floresta-chain: fix a test feature problem

### DIFF
--- a/crates/floresta-electrum/Cargo.toml
+++ b/crates/floresta-electrum/Cargo.toml
@@ -35,4 +35,4 @@ thiserror = "1.0"
 rand = "0.8.5"
 rcgen = "0.13"
 zstd = "0.13.3"
-floresta-chain = { path = "../floresta-chain", features = ["kv-chainstore"] }
+floresta-chain = { path = "../floresta-chain", features = ["flat-chainstore"] }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [X] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

If we ran `cargo test` without any features, it might turn both
chainstores on, which causes trouble with our tests, since we have
tests with both chinstore, just overloading the setup functions
at compilation time. Without this change, we get a name clash on
default `cargo run`

It doesn't change anything for the `contrib/test_matrix` script, which
defines features in separate.