### PR TITLE
Man page cli rendering fix on template.md

### DIFF
--- a/doc/rpc/template.md
+++ b/doc/rpc/template.md
@@ -8,19 +8,22 @@ Brief description of what this RPC does and its primary purpose.
 
 Please, always skip a line to render properly on man-pages.
 
-[ # wrap with `[` and `]` to indicate an array of objects.
+```json5
+// Wrap with `[` and `]` to indicate an array of objects
+[
 
- {
+  {
 
-   json_string: "str", (String, required) Description about the expected json object.
+    "json_string": "str", // (String, required) Description about the expected JSON object.
 
-   numeric_field: n, (numeric, optional) Describes an optional camp of the expected json object.
+    "numeric_field": 123, // (Numeric, optional) Describes an optional field.
 
-   boolean_field: bool, (Boolean, Required) Describes an obligatory boolean.
+    "boolean_field": true // (Boolean, required) Describes an obligatory boolean.
 
- }
+  }
 
 ]
+```
 
 * `param2`  - Description of optional parameter (default: value) (type)
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [X] Other: <!-- Please describe it --> #521 was merged but I forgot to correctly render the json object. Thanks @Davidson-Souza for finding the error quickly.

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description
This PR updates the `template.md` file to use the  ```  operator on the json object.
<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [ ] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
