### PR TITLE
Improve `find_who_is_lying` and `find_accumulator_for_block` 

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -115,6 +115,19 @@ pub enum FindAccResult {
     KeepLooking(Vec<(PeerId, Vec<u8>)>),
 }
 
+/// Helper enum to express the different possibilities under `find_who_is_lying`
+pub enum LyingPeer {
+    OnePeer(PeerId),
+
+    BothPeers(PeerId, PeerId),
+
+    UnresponsivePeer(PeerId),
+
+    BothUnresponsivePeers(PeerId, PeerId),
+
+    None,
+}
+
 impl NodeContext for ChainSelector {
     const REQUEST_TIMEOUT: u64 = 60; // Ban peers stalling our IBD
     const TRY_NEW_CONNECTION: u64 = 10; // Try creating connections more aggressively
@@ -248,7 +261,7 @@ where
         &mut self,
         peer1: PeerId,
         peer2: PeerId,
-    ) -> Result<Option<PeerId>, WireError> {
+    ) -> Result<LyingPeer, WireError> {
         let (mut height, mut hash) = self.chain.get_best_block()?;
         let mut prev_height = 0;
         // we first norrow down the possible fork point to a couple of blocks, looking
@@ -259,11 +272,12 @@ where
                 .grab_both_peers_version(peer1, peer2, hash, height)
                 .await?;
 
+            // if a peer is unresponsive, we opt for an early return
             let (peer1_acc, peer2_acc) = match (peer1_acc, peer2_acc) {
                 (Some(acc1), Some(acc2)) => (acc1, acc2),
-                (None, Some(_)) => return Ok(Some(peer2)),
-                (Some(_), None) => return Ok(Some(peer1)),
-                (None, None) => return Ok(None),
+                (None, Some(_)) => return Ok(LyingPeer::UnresponsivePeer(peer1)),
+                (Some(_), None) => return Ok(LyingPeer::UnresponsivePeer(peer2)),
+                (None, None) => return Ok(LyingPeer::BothUnresponsivePeers(peer1, peer2)),
             };
 
             // if we have different states, we need to keep looking until we find the
@@ -353,27 +367,35 @@ where
             (Some(acc1), Some(_acc2)) => Self::parse_acc(acc1)?,
             (Some(acc1), None) => Self::parse_acc(acc1)?,
             (None, Some(acc2)) => Self::parse_acc(acc2)?,
-            (None, None) => return Ok(None),
+            (None, None) => return Ok(LyingPeer::BothUnresponsivePeers(peer1, peer2)),
         };
 
         hash = self.chain.get_block_hash(fork + 1)?;
 
         // now we know where the fork is, we need to check who is lying
-        let (Some(peer1_acc), Some(peer2_acc)) = self
+        let (peer1_acc, peer2_acc) = self
             .grab_both_peers_version(peer1, peer2, hash, fork + 1)
-            .await?
-        else {
-            return Ok(None);
+            .await?;
+
+        // if a peer is unresponsive, we opt for an early return
+        let (peer1_acc, peer2_acc) = match (peer1_acc, peer2_acc) {
+            (Some(acc1), Some(acc2)) => (acc1, acc2),
+            (None, Some(_)) => return Ok(LyingPeer::UnresponsivePeer(peer1)),
+            (Some(_), None) => return Ok(LyingPeer::UnresponsivePeer(peer2)),
+            (None, None) => return Ok(LyingPeer::BothUnresponsivePeers(peer1, peer2)),
         };
 
         let block = self.chain.get_block_hash(fork + 1).unwrap();
         self.send_to_peer(peer1, NodeRequest::GetBlock((vec![block], true)))
             .await?;
 
+        self.send_to_peer(peer2, NodeRequest::GetBlock((vec![block], true)))
+            .await?;
+
         let NodeNotification::FromPeer(_, PeerMessages::Block(block)) =
             self.node_rx.recv().await.unwrap()
         else {
-            return Ok(None);
+            return Ok(LyingPeer::BothUnresponsivePeers(peer1, peer2));
         };
 
         let acc1 = self.update_acc(agreed, block, fork + 1)?;
@@ -381,14 +403,14 @@ where
         let peer2_acc = Self::parse_acc(peer2_acc)?;
 
         if peer1_acc != acc1 && peer2_acc != acc1 {
-            return Ok(None);
+            return Ok(LyingPeer::BothPeers(peer1, peer2));
         }
 
         if peer1_acc != acc1 {
-            return Ok(Some(peer1));
+            return Ok(LyingPeer::OnePeer(peer1));
         }
 
-        Ok(Some(peer2))
+        Ok(LyingPeer::OnePeer(peer2))
     }
 
     /// Updates a Stump, with the data from a Utreexo block
@@ -438,21 +460,31 @@ where
             }
             let (peer1, peer2) = (peer[0].0, peer[1].0);
 
-            if let Some(liar) = self.find_who_is_lying(peer1, peer2).await? {
-                // if we found a liar, we need to ban them
-                self.send_to_peer(liar, NodeRequest::Shutdown).await?;
-                if liar == peer1 {
+            let liar_state = self.find_who_is_lying(peer1, peer2).await?;
+
+            match liar_state {
+                LyingPeer::OnePeer(liar) => {
+                    self.send_to_peer(liar, NodeRequest::Shutdown).await?;
+                    if liar == peer1 {
+                        invalid_accs.insert(peer[0].1.clone());
+                    } else {
+                        invalid_accs.insert(peer[1].1.clone());
+                    }
+                }
+                LyingPeer::UnresponsivePeer(dead_peer) => {
+                    self.send_to_peer(dead_peer, NodeRequest::Shutdown).await?;
+                }
+                LyingPeer::BothUnresponsivePeers(peer1, peer2) => {
+                    self.send_to_peer(peer1, NodeRequest::Shutdown).await?;
+                    self.send_to_peer(peer2, NodeRequest::Shutdown).await?;
+                }
+                LyingPeer::BothPeers(peer1, peer2) => {
+                    self.send_to_peer(peer1, NodeRequest::Shutdown).await?;
+                    self.send_to_peer(peer2, NodeRequest::Shutdown).await?;
                     invalid_accs.insert(peer[0].1.clone());
-                } else {
                     invalid_accs.insert(peer[1].1.clone());
                 }
-            } else {
-                // Both peers were lying
-                self.send_to_peer(peer1, NodeRequest::Shutdown).await?;
-                self.send_to_peer(peer2, NodeRequest::Shutdown).await?;
-
-                invalid_accs.insert(peer[0].1.clone());
-                invalid_accs.insert(peer[1].1.clone());
+                LyingPeer::None => continue,
             }
         }
         //filter out the invalid accs

--- a/crates/floresta-wire/src/p2p_wire/tests/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/chain_selector.rs
@@ -1,0 +1,144 @@
+#[cfg(test)]
+mod tests_utils {
+
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bitcoin::Network;
+    use floresta_chain::pruned_utreexo::UpdatableChainstate;
+    use floresta_chain::AssumeValidArg;
+    use floresta_chain::FlatChainStore;
+    use floresta_chain::FlatChainStoreConfig;
+    use rustreexo::accumulator::pollard::Pollard;
+    use tokio::sync::Mutex;
+    use tokio::sync::RwLock;
+    use tokio::time::timeout;
+
+    use crate::address_man::AddressMan;
+    use crate::node::UtreexoNode;
+    use crate::p2p_wire::mempool::Mempool;
+    use crate::p2p_wire::sync_node::SyncNode;
+    use crate::p2p_wire::tests::utils::create_peer;
+    use crate::p2p_wire::tests::utils::get_node_config;
+    use crate::p2p_wire::tests::utils::get_test_headers;
+    use crate::p2p_wire::tests::utils::BlockDataMap;
+    use crate::p2p_wire::tests::utils::BlockHashMap;
+    use crate::p2p_wire::tests::utils::HeaderList;
+    use floresta_chain::ChainState;
+    pub const NUM_BLOCKS: usize = 120;
+
+    type PeerData = (HeaderList, BlockHashMap, BlockDataMap);
+
+    pub async fn setup_node(
+        peers: Vec<PeerData>,
+        pow_fraud_proofs: bool,
+        network: Network,
+    ) -> Arc<floresta_chain::pruned_utreexo::chain_state::ChainState<FlatChainStore>> {
+        let datadir = format!("./tmp-db/{}.chain_selector", rand::random::<u32>());
+        let config = FlatChainStoreConfig::new(datadir.clone());
+
+        let chainstore = FlatChainStore::new(config).unwrap();
+        let mempool = Arc::new(Mutex::new(Mempool::new(Pollard::default(), 1000)));
+        let chain = ChainState::new(chainstore, network, AssumeValidArg::Disabled);
+        let chain = Arc::new(chain);
+
+        let mut headers = get_test_headers();
+        headers.remove(0);
+        headers.truncate(119);
+        for header in headers {
+            chain.accept_header(header).unwrap();
+        }
+
+        let config = get_node_config(datadir, network, pow_fraud_proofs);
+        let kill_signal = Arc::new(RwLock::new(false));
+        let mut node = UtreexoNode::<Arc<ChainState<FlatChainStore>>, SyncNode>::new(
+            config,
+            chain.clone(),
+            mempool,
+            None,
+            kill_signal.clone(),
+            AddressMan::default(),
+        )
+        .unwrap();
+
+        for (i, peer) in peers.into_iter().enumerate() {
+            let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+            let peer = create_peer(
+                peer.0,
+                peer.1,
+                peer.2,
+                node.node_tx.clone(),
+                sender.clone(),
+                receiver,
+                i as u32,
+            );
+            let _peer = peer.clone();
+
+            node.peers.insert(i as u32, peer);
+        }
+
+        timeout(Duration::from_secs(100), node.run(|_| {}))
+            .await
+            .unwrap();
+
+        chain
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::Network;
+    use floresta_chain::pruned_utreexo::BlockchainInterface;
+    use floresta_chain::pruned_utreexo::UpdatableChainstate;
+    use rustreexo::accumulator::node_hash::BitcoinNodeHash;
+
+    use crate::p2p_wire::tests::chain_selector::tests_utils::setup_node;
+    use crate::p2p_wire::tests::utils::create_false_acc;
+    use crate::p2p_wire::tests::utils::get_essentials;
+    use crate::p2p_wire::tests::utils::get_test_filters;
+
+    use crate::p2p_wire::tests::chain_selector::tests_utils::NUM_BLOCKS;
+    const STARTING_LIE_BLOCK_HEIGHT: usize = 30;
+
+    #[tokio::test]
+    async fn two_peers_one_lying() {
+        let essentials = get_essentials();
+        let headers = essentials.headers[..120].to_vec();
+
+        let true_filters = get_test_filters().unwrap();
+
+        let mut false_filters = true_filters.clone();
+
+        // this weird looking for loop is due to lint
+        for (i, _) in headers
+            .iter()
+            .enumerate()
+            .take(NUM_BLOCKS)
+            .skip(STARTING_LIE_BLOCK_HEIGHT)
+        {
+            false_filters.remove(&headers[i].block_hash());
+            false_filters.insert(headers[i].block_hash(), create_false_acc(i));
+        }
+
+        let peers = vec![
+            (headers.clone(), essentials.blocks.clone(), true_filters),
+            (headers.clone(), essentials.blocks.clone(), false_filters),
+        ];
+
+        let chain = setup_node(peers, true, Network::Signet).await;
+        let best_block = chain.get_best_block().unwrap();
+        assert_eq!(best_block.1, headers[119].block_hash());
+
+        let root_hashes = chain.get_root_hashes();
+        assert_eq!(
+            root_hashes[3],
+            BitcoinNodeHash::from_str(
+                "bfe030a7a994b921fb2329ff085bd0f2351cb5fa251985d6646aaf57954b782b"
+            )
+            .unwrap()
+        );
+        assert_eq!(root_hashes.len(), 6);
+    }
+}

--- a/crates/floresta-wire/src/p2p_wire/tests/mod.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/mod.rs
@@ -1,2 +1,3 @@
+mod chain_selector;
 mod sync_node;
 mod utils;

--- a/crates/floresta-wire/src/p2p_wire/tests/utils.rs
+++ b/crates/floresta-wire/src/p2p_wire/tests/utils.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io;
 use std::io::Read;
-use std::str::FromStr;
 use std::time::Instant;
 
 use bitcoin::block::Header;
@@ -13,9 +12,11 @@ use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
 use bitcoin::Network;
 use floresta_chain::UtreexoBlock;
-use floresta_common::bhash;
 use floresta_common::service_flags;
 use floresta_common::service_flags::UTREEXO;
+use hex;
+use rand::rngs::OsRng;
+use rand::RngCore;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -23,11 +24,11 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::task;
 use zstd;
 
+use crate::node::ConnectionKind;
 use crate::node::LocalPeerView;
 use crate::node::NodeNotification;
 use crate::node::NodeRequest;
 use crate::node::PeerStatus;
-use crate::p2p_wire::node::ConnectionKind;
 use crate::p2p_wire::peer::PeerMessages;
 use crate::p2p_wire::peer::Version;
 use crate::p2p_wire::transport::TransportProtocol;
@@ -117,6 +118,30 @@ impl TestPeer {
             let req = self.node_rx.recv().await.unwrap();
 
             match req {
+                NodeRequest::GetHeaders(hashes) => {
+                    let pos = hashes.first().unwrap();
+                    let pos = self._headers.iter().position(|h| h.block_hash() == *pos);
+                    let headers = match pos {
+                        None => vec![],
+                        Some(pos) => self._headers[(pos + 1)..].to_vec(),
+                    };
+
+                    self.node_tx
+                        .send(NodeNotification::FromPeer(
+                            self.peer_id,
+                            PeerMessages::Headers(headers),
+                        ))
+                        .unwrap();
+                }
+                NodeRequest::GetUtreexoState((hash, _)) => {
+                    let filters = self._filters.get(&hash).unwrap().clone();
+                    self.node_tx
+                        .send(NodeNotification::FromPeer(
+                            self.peer_id,
+                            PeerMessages::UtreexoState(filters),
+                        ))
+                        .unwrap();
+                }
                 NodeRequest::GetBlock((hashes, _)) => {
                     for hash in hashes {
                         let block = self.blocks.get(&hash).unwrap().clone();
@@ -210,6 +235,19 @@ pub fn serialize(root: UtreexoRoots) -> Vec<u8> {
     buffer
 }
 
+pub fn create_false_acc(tip: usize) -> Vec<u8> {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    let node_hash = hex::encode(bytes);
+
+    let utreexo_root = UtreexoRoots {
+        roots: Some(vec![node_hash]),
+        numleaves: tip,
+    };
+
+    serialize(utreexo_root)
+}
+
 pub fn get_test_headers() -> Vec<Header> {
     let mut headers: Vec<Header> = Vec::new();
 
@@ -272,11 +310,7 @@ pub fn generate_invalid_block() -> UtreexoBlock {
 pub fn get_essentials() -> Essentials {
     let headers = get_test_headers();
     let blocks = get_test_blocks().unwrap();
-    let _filters = get_test_filters().unwrap();
     let invalid_block = generate_invalid_block();
-
-    // BlockHash of chain_tip: 0000035f0e5513b26bba7cead874fdf06241a934e4bc4cf7a0381c60e4cdd2bb (119)
-    let _tip_hash = bhash!("0000035f0e5513b26bba7cead874fdf06241a934e4bc4cf7a0381c60e4cdd2bb");
 
     Essentials {
         headers,


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [X] Test
- [X] Other: <!-- Please describe it --> This PR aims to add a test to `find_who_is_lying` and `find_accumulator_for_block` while also improving the logic behind it.

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [X] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description
While working on #545 I faced the issue of lack of expressibility on `find_who_is_lying`. We currently handle cases of unresponsive peers as if they were lying and we also could face marking a valid accumulator as invalid. 

This PR aims to add an enum to better express the different cases the method `find_who_is_lying` could face, which are:
- One peer is lying
- Both peers are lying
- One peer is unresponsive
- Both peers are unresponsive
- Both peers have the correct accumulator and we mistakenly entered into this algorithm

I have also added a test to check if given two peers, one honest and the other providing fake accumulators starting at a given block height, to check if our logic is working as intended and the node ends up in the correct best block and in the correct accumulator.

<!-- Describe the purpose of this PR, what's being added and/or fixed. If there's an open issue for it, link it here -->

### Notes to the reviewers
The test is not passing yet. I am still working on figuring out why. I have taken the `setup_node` from the test suite at `sync_node` with a few tweaks and tried creating fake accumulators starting at height 30 up till the height 120.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts of the PR were done in a specific way -->

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [X] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [ ] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [ ] I've linked any related issue(s) in the sections above
