### PR TITLE
CI: Check cargo doc lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Run cargo fmt
         run: cargo +nightly fmt --all --check
 
+      - name: Run cargo doc
+        run: |
+          RUSTDOCFLAGS="--cfg docsrs -D warnings" \
+          cargo +nightly doc --workspace --no-deps --all-features --document-private-items
+
       - name: Run cargo clippy
         run: ./contrib/feature_matrix.sh clippy '-- -D warnings'
         shell: bash   # Ensure the script runs using bash on all platforms
@@ -105,4 +110,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker buildx build --cache-to=type=local,dest=/tmp/.buildx-cache --cache-from=type=local,src=/tmp/.buildx-cache -t dlsz/floresta:latest .
+          docker buildx build \
+          --cache-to=type=local,dest=/tmp/.buildx-cache \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          -t dlsz/floresta:latest .

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -95,8 +95,8 @@ pub struct ChainStateInner<PersistedState: ChainStore> {
     /// be notified of new blocks, a module should implement the [BlockConsumer] trait, and
     /// subscribe by passing an [Arc] of itself to chainstate.
     /// When a new block is accepted (as valid) we call `consume_block` from [BlockConsumer].
-    /// If a module just wants pass in a channel, [Sender] implements [BlockConsumer], and can
-    /// be used during subscription (just keep the [Receiver] side.
+    /// If a module just wants pass in a channel, `Sender` implements [BlockConsumer], and can
+    /// be used during subscription (just keep the `Receiver` side.
     subscribers: Vec<Arc<dyn BlockConsumer>>,
     /// Fee estimation for 1, 10 and 20 blocks
     fee_estimation: (f64, f64, f64),

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -22,7 +22,7 @@
 //!
 //! We want to keep the load factor for the hash map as low as possible, while also avoiding
 //! re-hashing. So we pick a fairly big initial space to it, say 10 million buckets. Each bucket is
-//! 4 bytes long, so we have 40 MiB of map. Each [HashedDiskHeader] is 124 bytes long (80 bytes for
+//! 4 bytes long, so we have 40 MiB of map. Each `HashedDiskHeader` is 124 bytes long (80 bytes for
 //! header + 4 for height + 32 for hash + 8 for the accumulator size and pos), so the maximum size
 //! for it, assuming 2.5 million headers (good for the next ~30 years), is 310 MiB.
 //! The smallest device I know that can run floresta has ~250 MiB of RAM, so we could
@@ -53,7 +53,8 @@
 //!
 //! Buckets are the slots of a hashmap.
 //!
-//! For more detailed information please refer to [Hash Table] (https://en.wikipedia.org/wiki/Hash_table) from wikipedia.
+//! For more detailed information please refer to [Hash Table](https://en.wikipedia.org/wiki/Hash_table)
+//! from wikipedia.
 //!
 //! # Safety
 //!

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -176,7 +176,7 @@ pub trait UpdatableChainstate {
 /// This trait is defining how we interact with our chain database. This definitions
 /// will be used by the [ChainState](chain_state::ChainState) to save and retrieve data about the blockchain, likely
 /// on disk.
-/// Right now, you can use the [KvChainStore](chainstore::KvChainStore) in your code, it implements this trait and
+/// Right now, you can use the [KvChainStore](crate::KvChainStore) in your code, it implements this trait and
 /// uses a key-value store to save data.
 /// The [DatabaseError] is a simple trait that can be implemented by any error type that
 /// implements `std::error::Error` and `std::fmt::Display`. This is useful to abstract

--- a/crates/floresta-watch-only/src/memory_database.rs
+++ b/crates/floresta-watch-only/src/memory_database.rs
@@ -2,7 +2,7 @@
 //! volatile, and all data is lost after the database is dropped or the process is terminated.
 //! It's not meant to use in production, but for the integrated testing framework
 //!
-//! For actual databases that can be used for production code, see [KvDatabase].
+//! For actual databases that can be used for production code, see [KvDatabase](crate::kv_database::KvDatabase).
 use bitcoin::hashes::sha256;
 use bitcoin::Txid;
 use floresta_common::prelude::sync::RwLock;

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -447,7 +447,7 @@ where
 
     /// Handles remove node requests, removing a peer from the node.
     ///
-    /// Removes a node from the [`added_peers`] list but does not
+    /// Removes a node from the `added_peers` list but does not
     /// disconnect the node if it was already connected.  It only ensures
     /// that the node is no longer treated as a manually added node
     /// (i.e., it won't be reconnected if disconnected).
@@ -1645,7 +1645,7 @@ where
 
     /// Creates a new outgoing connection with `address`.
     ///
-    /// [`kind`] may or may not be a [`ConnectionKind::Feeler`], a special connection type
+    /// `kind` may or may not be a [`ConnectionKind::Feeler`], a special connection type
     /// that is used to learn about good peers, but are not kept after handshake
     /// (others are [`ConnectionKind::Regular`] and [`ConnectionKind::Extra`]).
     ///
@@ -1653,7 +1653,7 @@ where
     /// we may retry the connection with the old V1 protocol if the V2 connection fails.
     /// We don't open the connection here, we create a [`Peer`] actor that will try to open
     /// a connection with the given address and kind. If it succeeds, it will send a
-    /// [`NodeNotification::Ready`] to the node after handshaking.
+    /// [`PeerMessages::Ready`] to the node after handshaking.
     pub(crate) async fn open_connection(
         &mut self,
         kind: ConnectionKind,

--- a/doc/rpc/addnode.md
+++ b/doc/rpc/addnode.md
@@ -14,7 +14,7 @@ Attempts to add or remove a node from the addnode list.
 
 - json null
 
-### Error Enum [`CommandError`]
+### Error Enum `CommandError`
 
 Any of the error types on `rpc_types::Error`
 

--- a/doc/rpc/template.md
+++ b/doc/rpc/template.md
@@ -31,7 +31,7 @@ Please, always skip a line to render properly on man-pages.
 - `field1`- (type) Description of return field
 - `field2` - (type) Description of another return field
 
-### Error Enum [`CommandError`]
+### Error Enum `CommandError`
 
 (Command error is a well documented enum returned client side)
 

--- a/florestad/src/error.rs
+++ b/florestad/src/error.rs
@@ -66,8 +66,9 @@ impl std::fmt::Display for Error {
         }
     }
 }
+
 /// Implements `From<T>` where `T` is a possible error outcome in this crate, this macro only
-/// takes [T] and builds [Error] with the right variant.
+/// takes `T` and builds [`Error`] with the right variant.
 macro_rules! impl_from_error {
     ($field:ident, $error:ty) => {
         impl From<$error> for Error {

--- a/florestad/src/json_rpc/blockchain.rs
+++ b/florestad/src/json_rpc/blockchain.rs
@@ -215,9 +215,9 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
     /// Specifying the blockhash will make this function go after the block and search
     /// for the transactions inside it, building a merkle proof from the block with its
     /// indexes. Not specifying will redirect it to search for the merkle proof on our
-    /// Watch-only wallet which may not have the transaction cached, returning [`JsonRpcError::UncertainTxNotFound`].
+    /// watch-only wallet which may not have the transaction cached.
     ///
-    /// Not founding one of the specified transactions will raise [`JsonRpcError::TxNotFound`].
+    /// Not finding one of the specified transactions will raise [`JsonRpcError::TxNotFound`].
     pub(super) async fn get_txout_proof(
         &self,
         tx_ids: &[Txid],


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [x] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

I have fixed all doc warnings generated by `cargo +nightly doc ... --document-private-items`, and added a CI and justfile check for it.

`just doc` and `just open-doc` will still only document the public API, but I think it's worth it to also check docstrings on our private items. `just lint` and `just lint-features` will check it now.