### PR TITLE
refactor: get rid of `expect` method of Electrum server

### DIFF
--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -497,15 +497,20 @@ impl Florestad {
         // Electrum Server configuration.
 
         // Instantiate the Electrum Server.
-
-        let electrum_server = ElectrumServer::new(
+        let electrum_server = match ElectrumServer::new(
             wallet,
             blockchain_state,
             cfilters,
             chain_provider.get_handle(),
         )
         .await
-        .expect("Could not create an Electrum Server");
+        {
+            Ok(server) => server,
+            Err(e) => {
+                error!("Could not create an Electrum Server: {e}");
+                std::process::exit(1);
+            }
+        };
 
         // Default Electrum Server port.
         let default_electrum_port: u16 =


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: refactor;

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Follow-up of #463;

### Notes to the reviewers

While review #569, saw that the instantiation of `ElectrumServer` use `expect` method. This commit match a `Result` instead call `expect` so if any error occurs it will be logged with `error!` and `std::process::exit` will be called.

### Author Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
