### PR TITLE
refactor: remove `expect`, add error handling and lints for `florestad`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,6 @@ dependencies = [
 name = "florestad"
 version = "0.8.0"
 dependencies = [
- "anyhow",
  "axum",
  "bitcoin 0.32.6",
  "chrono",

--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -27,7 +27,6 @@ floresta-wire = { path = "../crates/floresta-wire" }
 floresta-compact-filters = { path = "../crates/floresta-compact-filters", optional = true }
 metrics = { path = "../metrics", optional = true }
 axum = { version = "0.7", optional = true }
-anyhow = "1.0.40"
 zmq = { version = "0.10.0", optional = true }
 dns-lookup = "=2.0.4"
 tower-http = { version = "0.6.2", optional = true, features = ["cors"] }

--- a/florestad/src/config_file.rs
+++ b/florestad/src/config_file.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use crate::error::FlorestadError;
+
 #[derive(Default, Debug, Deserialize)]
 pub struct Wallet {
     pub xpubs: Option<Vec<String>>,
@@ -13,7 +15,7 @@ pub struct ConfigFile {
 }
 
 impl ConfigFile {
-    pub fn from_file(filename: &str) -> Result<Self, crate::error::Error> {
+    pub fn from_file(filename: &str) -> Result<Self, FlorestadError> {
         let file = std::fs::read_to_string(filename)?;
         Ok(toml::from_str(&file)?)
     }

--- a/florestad/src/error.rs
+++ b/florestad/src/error.rs
@@ -1,79 +1,273 @@
+use std::net::AddrParseError;
+
 use bitcoin::consensus::encode;
 use floresta_chain::BlockValidationErrors;
 use floresta_chain::BlockchainError;
+#[cfg(feature = "flat-chainstore")]
+use floresta_chain::FlatChainstoreError;
+#[cfg(feature = "compact-filters")]
+use floresta_compact_filters::IterableFilterStoreError;
+use floresta_watch_only::kv_database::KvDatabaseError;
+use floresta_watch_only::WatchOnlyError;
 use tokio_rustls::rustls::pki_types;
 
 use crate::slip132;
 #[derive(Debug)]
-pub enum Error {
+pub enum FlorestadError {
+    /// Encoding/decoding error.
     Encode(encode::Error),
+
+    /// Key-value database error
     Db(kv::Error),
+
+    /// Integer parsing error.
     ParseNum(std::num::ParseIntError),
+
+    /// Proof validation failure.
     Rustreexo(String),
+
+    /// Generic IO operation error.
     Io(std::io::Error),
+
+    // Block validation error, such as a missing transaction or an invalid proof.
     BlockValidation(BlockValidationErrors),
+
+    /// Script validation error, such as an invalid script or a failed evaluation.
     ScriptValidation(bitcoin::blockdata::script::Error),
+
+    /// Blockchain backend error, such as a missing block.
     Blockchain(BlockchainError),
+
+    /// Deserializing JSON error.
     SerdeJson(serde_json::Error),
+
+    /// TOML parsing error.
     TomlParsing(toml::de::Error),
+
+    /// Parsing registered HD version bytes from slip132.
     WalletInput(slip132::Error),
+
+    /// Parsing a bitcoin address.
     AddressParsing(bitcoin::address::ParseError),
+
+    /// Parsing miniscript error.
     Miniscript(miniscript::Error),
+
+    /// Parsing a private key in PEM format.
     InvalidPrivKey(pki_types::pem::Error),
+
+    /// Parsing a certificate from PEM format.
     InvalidCert(pki_types::pem::Error),
+
+    /// Configuring TLS settings.
     CouldNotConfigureTLS(tokio_rustls::rustls::Error),
+
+    /// Generating a PKCS#8 keypair.
     CouldNotGenerateKeypair(rcgen::Error),
+
+    /// Generating a certificate parameter.
     CouldNotGenerateCertParam(rcgen::Error),
+
+    /// Generating a self-signed certificate.
     CouldNotGenerateSelfSignedCert(rcgen::Error),
+
+    /// Writing a file to the filesystem.
     CouldNotWriteFile(String, std::io::Error),
+
+    /// Creating the data directory.
+    CouldNotCreateDataDir(String, std::io::Error),
+
+    /// Initializing the logger error.
+    CouldNotInitializeLogger(fern::InitError),
+
+    /// Obtaining a lock on the data directory.
+    CouldNotOpenKvDatabase(KvDatabaseError),
+
+    /// Initializing the watch-only wallet.
+    CouldNotInitializeWallet(WatchOnlyError<KvDatabaseError>),
+
+    /// Setting up the watch-only wallet.
+    CouldNotSetupWallet(String),
+
+    /// Invalid assumed valid value.
+    InvalidAssumeValid(bitcoin::hex::HexToArrayError),
+
+    #[cfg(feature = "compact-filters")]
+    /// Loading the compact filters store.
+    CouldNotLoadCompactFiltersStore(IterableFilterStoreError),
+
+    /// Failed to create a chain provider.
+    CouldNotCreateChainProvider(String),
+
+    /// Failed to create an Electrum server.
+    CouldNotCreateElectrumServer(Box<dyn std::error::Error>),
+
+    /// Failed to bind the Electrum server to a socket.
+    FailedToBindElectrumServer(std::io::Error),
+
+    /// Failed to create the TLS data directory.
+    CouldNotCreateTLSDataDir(String, std::io::Error),
+
+    /// Failed to provide a valid xpub.
+    InvalidProvidedXpub(String, crate::slip132::Error),
+
+    /// Failed to obtain the wallet cache.
+    CouldNotObtainWalletCache(WatchOnlyError<KvDatabaseError>),
+
+    /// Failed to push a descriptor to the wallet.
+    CouldNotPushDescriptor(String),
+
+    /// The network is unsupported.
+    UnsupportedNetwork(bitcoin::Network),
+
+    /// Invalid Ip address error.
+    InvalidIpAddress(AddrParseError),
+
+    /// Ip address not found error.
+    NoIPAddressesFound(String),
+
+    /// Resolve a hostname error.
+    CouldNotResolveHostname(std::io::Error),
+
+    #[cfg(feature = "flat-chainstore")]
+    /// Create a flat chain store error.
+    CouldNotCreateFlatChainStore(FlatChainstoreError),
+
+    #[cfg(feature = "flat-chainstore")]
+    /// Load a flat chain store error.
+    CouldNotLoadFlatChainStore(BlockchainError),
+
+    #[cfg(feature = "kv-chainstore")]
+    /// Load a key-value chain store error.
+    CouldNotLoadKvChainStore(BlockchainError),
 }
 
-impl std::fmt::Display for Error {
+impl std::fmt::Display for FlorestadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Encode(err) => write!(f, "Encode error: {err}"),
-            Error::Db(err) => write!(f, "Database error {err}"),
-            Error::ParseNum(err) => write!(f, "int parse error: {err}"),
-            Error::Rustreexo(err) => write!(f, "Rustreexo error: {err}"),
-            Error::Io(err) => write!(f, "Io error {err}"),
-            Error::ScriptValidation(err) => write!(f, "Error during script evaluation: {err}"),
-            Error::Blockchain(err) => write!(f, "Error with our blockchain backend: {err:?}"),
-            Error::SerdeJson(err) => write!(f, "Error serializing object {err}"),
-            Error::WalletInput(err) => write!(f, "Error while parsing user input {err:?}"),
-            Error::TomlParsing(err) => write!(f, "Error deserializing toml file {err}"),
-            Error::AddressParsing(err) => write!(f, "Invalid address {err}"),
-            Error::Miniscript(err) => write!(f, "Miniscript error: {err}"),
-            Error::BlockValidation(err) => write!(f, "Error while validating block: {err:?}"),
-            Error::CouldNotConfigureTLS(err) => write!(f, "Error while configuring TLS: {err:?}"),
-            Error::InvalidPrivKey(err) => {
+            FlorestadError::Encode(err) => write!(f, "Encode error: {err}"),
+            FlorestadError::Db(err) => write!(f, "Database error {err}"),
+            FlorestadError::ParseNum(err) => write!(f, "int parse error: {err}"),
+            FlorestadError::Rustreexo(err) => write!(f, "Rustreexo error: {err}"),
+            FlorestadError::Io(err) => write!(f, "Io error {err}"),
+            FlorestadError::ScriptValidation(err) => {
+                write!(f, "Error during script evaluation: {err}")
+            }
+            FlorestadError::Blockchain(err) => {
+                write!(f, "Error with our blockchain backend: {err:?}")
+            }
+            FlorestadError::SerdeJson(err) => write!(f, "Error serializing object {err}"),
+            FlorestadError::WalletInput(err) => write!(f, "Error while parsing user input {err:?}"),
+            FlorestadError::TomlParsing(err) => write!(f, "Error deserializing toml file {err}"),
+            FlorestadError::AddressParsing(err) => write!(f, "Invalid address {err}"),
+            FlorestadError::Miniscript(err) => write!(f, "Miniscript error: {err}"),
+            FlorestadError::BlockValidation(err) => {
+                write!(f, "Error while validating block: {err:?}")
+            }
+            FlorestadError::CouldNotConfigureTLS(err) => {
+                write!(f, "Error while configuring TLS: {err:?}")
+            }
+            FlorestadError::InvalidPrivKey(err) => {
                 write!(f, "Error while reading PKCS#8 private key {err:?}")
             }
-            Error::InvalidCert(err) => {
+            FlorestadError::InvalidCert(err) => {
                 write!(f, "Error while reading PKCS#8 certificate {err:?}")
             }
-            Error::CouldNotGenerateKeypair(err) => {
+            FlorestadError::CouldNotGenerateKeypair(err) => {
                 write!(f, "Error while generating PKCS#8 keypair: {err}")
             }
-            Error::CouldNotGenerateCertParam(err) => {
+            FlorestadError::CouldNotGenerateCertParam(err) => {
                 write!(f, "Error while generating certificate param: {err}")
             }
-            Error::CouldNotGenerateSelfSignedCert(err) => {
+            FlorestadError::CouldNotGenerateSelfSignedCert(err) => {
                 write!(f, "Error while generating self-signed certificate: {err}")
             }
-            Error::CouldNotWriteFile(path, err) => {
+            FlorestadError::CouldNotWriteFile(path, err) => {
                 write!(f, "Error while creating file {path}: {err}")
+            }
+            FlorestadError::CouldNotCreateDataDir(path, err) => {
+                write!(f, "Error while creating data directory {path}: {err}")
+            }
+            FlorestadError::CouldNotInitializeLogger(err) => {
+                write!(f, "Error while initializing logger: {err}")
+            }
+            FlorestadError::CouldNotOpenKvDatabase(err) => {
+                write!(f, "Cannot open a key-value database: {err}")
+            }
+            FlorestadError::CouldNotInitializeWallet(err) => {
+                write!(f, "Could not initialize wallet: {err}")
+            }
+            FlorestadError::CouldNotSetupWallet(err) => {
+                write!(f, "Could not setup wallet: {err}")
+            }
+            FlorestadError::InvalidAssumeValid(error) => {
+                write!(f, "Invalid assumed valid value: {error}")
+            }
+
+            #[cfg(feature = "compact-filters")]
+            FlorestadError::CouldNotLoadCompactFiltersStore(err) => {
+                write!(f, "Could not load compact filters store: {err}")
+            }
+
+            FlorestadError::CouldNotCreateChainProvider(err) => {
+                write!(f, "Could not create chain provider: {err}")
+            }
+            FlorestadError::CouldNotCreateElectrumServer(err) => {
+                write!(f, "Could not create Electrum server: {err}")
+            }
+            FlorestadError::FailedToBindElectrumServer(err) => {
+                write!(f, "Failed to bind Electrum server: {err}")
+            }
+            FlorestadError::CouldNotCreateTLSDataDir(path, err) => {
+                write!(f, "Could not create TLS data directory {path}: {err}")
+            }
+            FlorestadError::InvalidProvidedXpub(xpub, err) => {
+                write!(f, "Invalid provided xpub {xpub}: {err:?}")
+            }
+            FlorestadError::CouldNotObtainWalletCache(err) => {
+                write!(f, "Could not obtain wallet cache: {err}")
+            }
+            FlorestadError::CouldNotPushDescriptor(err) => {
+                write!(f, "Could not push descriptor to wallet: {err}")
+            }
+            FlorestadError::UnsupportedNetwork(err) => {
+                write!(f, "Unsupported network: {err}")
+            }
+            FlorestadError::InvalidIpAddress(err) => {
+                write!(f, "Invalid IP address: {err}")
+            }
+            FlorestadError::NoIPAddressesFound(hostname) => {
+                write!(f, "No IP Addresses found for {hostname}")
+            }
+            FlorestadError::CouldNotResolveHostname(host) => {
+                write!(f, "Could not resolve hostname: {host}")
+            }
+
+            #[cfg(feature = "flat-chainstore")]
+            FlorestadError::CouldNotCreateFlatChainStore(err) => {
+                write!(f, "Failure while creating chainstore: {err:?}")
+            }
+
+            #[cfg(feature = "flat-chainstore")]
+            FlorestadError::CouldNotLoadFlatChainStore(err) => {
+                write!(f, "Failure while loading flat chainstore: {err:?}")
+            }
+
+            #[cfg(feature = "kv-chainstore")]
+            FlorestadError::CouldNotLoadKvChainStore(err) => {
+                write!(f, "Failure while loading key-value chainstore: {err:?}")
             }
         }
     }
 }
 
 /// Implements `From<T>` where `T` is a possible error outcome in this crate, this macro only
-/// takes `T` and builds [`Error`] with the right variant.
+/// takes `T` and builds [`FlorestadError`] with the right variant.
 macro_rules! impl_from_error {
     ($field:ident, $error:ty) => {
-        impl From<$error> for Error {
+        impl From<$error> for FlorestadError {
             fn from(err: $error) -> Self {
-                Error::$field(err)
+                FlorestadError::$field(err)
             }
         }
     };
@@ -92,5 +286,5 @@ impl_from_error!(TomlParsing, toml::de::Error);
 impl_from_error!(BlockValidation, BlockValidationErrors);
 impl_from_error!(AddressParsing, bitcoin::address::ParseError);
 impl_from_error!(Miniscript, miniscript::Error);
-
-impl std::error::Error for Error {}
+impl_from_error!(CouldNotObtainWalletCache, WatchOnlyError<KvDatabaseError>);
+impl std::error::Error for FlorestadError {}

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -17,6 +17,7 @@
 #![deny(non_upper_case_globals)]
 
 mod cli;
+use std::process::exit;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -106,7 +107,10 @@ fn main() {
 
     let florestad = Florestad::from(config);
     _rt.block_on(async {
-        florestad.start().await;
+        florestad.start().await.unwrap_or_else(|e| {
+            eprintln!("Failed to start florestad: {e}");
+            exit(1);
+        });
 
         // wait for shutdown
         loop {


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: refactor;

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Follow-up of #463;

### Notes to the reviewers

- Replace `expect` methods in favor of match clause;
- replace `std::proccess::exit` in favor of imported `exit`;
- replace `panic!` calls with `error!` calls followed by `exit(1)`;
- add spaces between `Config` struct propeties to better readability;
- add docstring for `connect` property in the `Config` struct;
- renamed `florestad/src/error.rs::Error` to
`florestad/src/error.rs::FlorestadError`;
- added more types on `florestad/src/error.rs::FlorestadError`.

### Author Checklist

<!-- Feel free to remove this section once you've confirmed all items -->

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
