### PR TITLE
Don't always rebuild core and utreexod

### DIFF
--- a/justfile
+++ b/justfile
@@ -55,7 +55,7 @@ test-functional-uv-fmt:
 
 # Run the functional tests
 test-functional:
-    @just test-functional-prepare --build
+    @just test-functional-prepare
     @just test-functional-run
 
 # Run the benchmarks

--- a/tests/prepare.sh
+++ b/tests/prepare.sh
@@ -133,12 +133,7 @@ check_installed go
 check_installed cargo
 check_installed uv
 
-# Check if florestad is already built or if --build is passed
-if [ ! -f $FLORESTA_TEMP_DIR/binaries/florestad ] || [ "$1" == "--build" ]; then
-    build_floresta
-else
-    echo "Florestad already built, skipping..."
-fi
+build_floresta
 
 # Check if utreexod is already built or if --build is passed
 if [ ! -f $FLORESTA_TEMP_DIR/binaries/utreexod ] || [ "$1" == "--build" ]; then


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [X] Other: `justfile` and `prepare.sh`

### Description

Right now, if we call `prepare.sh` we need to rebuild `utreexod` and `bitcoind` every time we want to update floresta. This doesn't make sense, since those two aren't supposed to change during our development, just floresta itself (the thing we are working on). So, I'm changing this to always build floresta, but utreexod and bitcoind are only built iff (1) they haven't been built yet (2) `--build` is provided.

I then changed the just recipe for `test-functional`, removing the call for `--build`.