### PR TITLE
RPC: don't use the [] syntax, as it will panic

### DIFF
--- a/florestad/src/json_rpc/mod.rs
+++ b/florestad/src/json_rpc/mod.rs
@@ -1,3 +1,4 @@
+pub mod request;
 pub mod res;
 pub mod server;
 

--- a/florestad/src/json_rpc/request.rs
+++ b/florestad/src/json_rpc/request.rs
@@ -1,0 +1,152 @@
+//! This module defines the structure for JSON-RPC requests and provides utility functions to
+//! extract parameters from the request.
+
+use serde_json::Value;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+/// Represents a JSON-RPC 2.0 request.
+pub struct RpcRequest {
+    /// The JSON-RPC version, typically "2.0".
+    pub jsonrpc: String,
+
+    /// The method to be invoked, e.g., "getblock", "sendtransaction".
+    pub method: String,
+
+    /// The parameters for the method, as an array of json values.
+    pub params: Vec<Value>,
+
+    /// An optional identifier for the request, which can be used to match responses.
+    pub id: Value,
+}
+
+/// Some utility functions to extract parameters from the request. These
+/// methods already handle the case where the parameter is missing or has an
+/// unexpected type, returning an error if so.
+pub mod arg_parser {
+    use std::str::FromStr;
+
+    use serde_json::Value;
+
+    use crate::json_rpc::res::JsonRpcError;
+
+    /// Extracts a u64 parameter from the request parameters at the specified index.
+    ///
+    /// This function checks if the parameter exists, is of type u64 and can be converted to `T`.
+    /// Returns an error otherwise.
+    pub fn get_numeric<T: TryFrom<u64>>(
+        params: &[Value],
+        index: usize,
+        opt_name: &str,
+    ) -> Result<T, JsonRpcError> {
+        let v = params
+            .get(index)
+            .ok_or_else(|| JsonRpcError::MissingParameter(opt_name.to_string()))?;
+
+        let n = v.as_u64().ok_or_else(|| {
+            JsonRpcError::InvalidParameterType(format!("{opt_name} must be a number"))
+        })?;
+
+        T::try_from(n)
+            .map_err(|_| JsonRpcError::InvalidParameterType(format!("{opt_name} is out-of-range")))
+    }
+
+    /// Extracts a string parameter from the request parameters at the specified index.
+    ///
+    /// This function checks if the parameter exists and is of type string. Returns an error
+    /// otherwise.
+    pub fn get_string(
+        params: &[Value],
+        index: usize,
+        opt_name: &str,
+    ) -> Result<String, JsonRpcError> {
+        let v = params
+            .get(index)
+            .ok_or_else(|| JsonRpcError::MissingParameter(opt_name.to_string()))?;
+
+        let str = v.as_str().ok_or_else(|| {
+            JsonRpcError::InvalidParameterType(format!("{opt_name} must be a string"))
+        })?;
+
+        Ok(str.to_string())
+    }
+
+    /// Extracts a boolean parameter from the request parameters at the specified index.
+    ///
+    /// This function checks if the parameter exists and is of type boolean. Returns an error
+    /// otherwise.
+    pub fn get_bool(params: &[Value], index: usize, opt_name: &str) -> Result<bool, JsonRpcError> {
+        let v = params
+            .get(index)
+            .ok_or_else(|| JsonRpcError::MissingParameter(opt_name.to_string()))?;
+
+        v.as_bool().ok_or_else(|| {
+            JsonRpcError::InvalidParameterType(format!("{opt_name} must be a boolean"))
+        })
+    }
+
+    /// Extracts a hash parameter from the request parameters at the specified index.
+    ///
+    /// This function can extract any type that implements `FromStr`, such as `BlockHash` or
+    /// `Txid`. It checks if the parameter exists and is a valid string representation of the type.
+    /// Returns an error otherwise.
+    pub fn get_hash<T: FromStr>(
+        params: &[Value],
+        index: usize,
+        opt_name: &str,
+    ) -> Result<T, JsonRpcError> {
+        let v = params
+            .get(index)
+            .ok_or_else(|| JsonRpcError::MissingParameter(opt_name.to_string()))?;
+
+        v.as_str().and_then(|s| s.parse().ok()).ok_or_else(|| {
+            JsonRpcError::InvalidParameterType(format!("{opt_name} must be a valid hash"))
+        })
+    }
+
+    /// Extracts an array of hashes from the request parameters at the specified index.
+    ///
+    /// This function can extract an array of any type that implements `FromStr`, such as
+    /// `BlockHash` or `Txid`. It checks if the parameter exists and is an array of valid string
+    /// representations of the type. Returns an error otherwise.
+    pub fn get_hashes_array<T: FromStr>(
+        params: &[Value],
+        index: usize,
+        opt_name: &str,
+    ) -> Result<Vec<T>, JsonRpcError> {
+        let v = params
+            .get(index)
+            .ok_or_else(|| JsonRpcError::MissingParameter(opt_name.to_string()))?;
+
+        let array = v.as_array().ok_or_else(|| {
+            JsonRpcError::InvalidParameterType(format!("{opt_name} must be an array of hashes"))
+        })?;
+
+        array
+            .iter()
+            .map(|v| {
+                v.as_str().and_then(|s| s.parse().ok()).ok_or_else(|| {
+                    JsonRpcError::InvalidParameterType(format!("{opt_name} must be a valid hash"))
+                })
+            })
+            .collect()
+    }
+
+    /// Extracts an optional field from the request parameters at the specified index.
+    ///
+    /// This function checks if the parameter exists and is of the expected type. If the parameter
+    /// doesn't exist, it returns `None`. If it exists but is of an unexpected type, it returns an
+    /// error.
+    pub fn get_optional_field<T>(
+        params: &[Value],
+        index: usize,
+        opt_name: &str,
+        extractor_fn: impl Fn(&[Value], usize, &str) -> Result<T, JsonRpcError>,
+    ) -> Result<Option<T>, JsonRpcError> {
+        if params.len() <= index {
+            return Ok(None);
+        }
+
+        let value = extractor_fn(params, index, opt_name)?;
+        Ok(Some(value))
+    }
+}

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -245,11 +245,12 @@ pub enum JsonRpcError {
     /// There was a rescan request with invalid values
     InvalidRescanVal,
 
-    /// The request is missing some params field, which is required for most RPC calls
-    MissingParams,
+    /// Missing parameter, e.g., if a required parameter is not provided in the request
+    MissingParameter(String),
 
-    /// The request is missing a request field, which is required for most RPC calls
-    MissingReq,
+    /// The provided parameter is of the wrong type, e.g., if a string is expected but a number is
+    /// provided
+    InvalidParameterType(String),
 
     /// Verbosity level is not 0 or 1
     InvalidVerbosityLevel,
@@ -268,18 +269,6 @@ pub enum JsonRpcError {
 
     /// There is an error with the chain, e.g., if the chain is not synced or when the chain is not valid
     Chain,
-
-    /// The provided vout is invalid, e.g., if it is not a valid output
-    InvalidVout,
-
-    /// The provided height is invalid, e.g., if it is negative or too high
-    InvalidHeight,
-
-    /// The provided hash is invalid, e.g., if it is not a valid SHA256 hash
-    InvalidHash,
-
-    /// The provided block hash is invalid, e.g., if it is not a valid SHA256 hash
-    InvalidBlockHash,
 
     /// The request is invalid, e.g., some parameters use an incorrect type
     InvalidRequest,
@@ -329,15 +318,13 @@ pub enum JsonRpcError {
 impl Display for JsonRpcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            JsonRpcError::InvalidBlockHash => write!(f, "Provided a invalid BlockHash"),
             JsonRpcError::InvalidTimestamp => write!(f, "Invalid timestamp, ensure that it is between the genesis and the tip."),
             JsonRpcError::InvalidRescanVal => write!(f, "You rescan request contains invalid values"),
-            JsonRpcError::InvalidRequest => write!(f, "Invalid request"),
             JsonRpcError::NoAddressesToRescan => write!(f, "You do not have any address to proceed with the rescan"),
-            JsonRpcError::InvalidHeight => write!(f, "Invalid height"),
-            JsonRpcError::InvalidHash =>  write!(f, "Invalid hash"),
+            JsonRpcError::MissingParameter(opt) => write!(f, "Missing parameter: {opt}"),
+            JsonRpcError::InvalidParameterType(opt) => write!(f, "Invalid parameter type for: {opt}"),
+            JsonRpcError::InvalidRequest => write!(f, "Invalid request"),
             JsonRpcError::InvalidHex =>  write!(f, "Invalid hex"),
-            JsonRpcError::InvalidVout =>  write!(f, "Invalid vout"),
             JsonRpcError::MethodNotFound =>  write!(f, "Method not found"),
             JsonRpcError::Decode(e) =>  write!(f, "error decoding request: {e}"),
             JsonRpcError::TxNotFound =>  write!(f, "Transaction not found"),
@@ -351,8 +338,6 @@ impl Display for JsonRpcError {
             JsonRpcError::InvalidNetwork => write!(f, "Invalid network"),
             JsonRpcError::InInitialBlockDownload => write!(f, "Node is in initial block download, wait until it's finished"),
             JsonRpcError::InvalidScript => write!(f, "Invalid script"),
-            JsonRpcError::MissingParams => write!(f, "Missing params field"),
-            JsonRpcError::MissingReq => write!(f, "Missing request field"),
             JsonRpcError::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),
             JsonRpcError::InvalidMemInfoMode => write!(f, "Invalid meminfo mode, should be stats or mallocinfo"),
             JsonRpcError::Wallet(e) => write!(f, "Wallet error: {e}"),


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [X] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Using brackets for getting an item from an array is a bad practice, because if the element isn't there, we will panic. This commit introduces a new way to handle parameters, with actual error handling for missing parameters.

I've also introduced a few helper functions to avoid code duplication.

Finally, I've added a RpcRequest struct to avoid using the black box "Value" type around, which require error handling all the time we access it.