### PR TITLE
Refactor `get_validation_flags`

### DIFF
--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -22,8 +22,6 @@ use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::UnsafeCell;
-#[cfg(feature = "bitcoinconsensus")]
-use core::ffi::c_uint;
 
 use bitcoin::block::Header as BlockHeader;
 use bitcoin::blockdata::constants::genesis_block;
@@ -161,41 +159,6 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         }
 
         Ok(())
-    }
-
-    #[cfg(feature = "bitcoinconsensus")]
-    /// Returns the validation flags, given the current block height
-    fn get_validation_flags(&self, height: u32, hash: BlockHash) -> c_uint {
-        let chain_params = &read_lock!(self).consensus.parameters;
-
-        if let Some(flag) = chain_params.exceptions.get(&hash) {
-            return *flag;
-        }
-
-        // From Bitcoin Core:
-        // BIP16 didn't become active until Apr 1 2012 (on mainnet, and
-        // retroactively applied to testnet)
-        // However, only one historical block violated the P2SH rules (on both
-        // mainnet and testnet).
-        // Similarly, only one historical block violated the TAPROOT rules on
-        // mainnet.
-        // For simplicity, always leave P2SH+WITNESS+TAPROOT on except for the two
-        // violating blocks.
-        let mut flags = bitcoinconsensus::VERIFY_P2SH | bitcoinconsensus::VERIFY_WITNESS;
-
-        if height >= chain_params.params.bip65_height {
-            flags |= bitcoinconsensus::VERIFY_CHECKLOCKTIMEVERIFY;
-        }
-        if height >= chain_params.params.bip66_height {
-            flags |= bitcoinconsensus::VERIFY_DERSIG;
-        }
-        if height >= chain_params.csv_activation_height {
-            flags |= bitcoinconsensus::VERIFY_CHECKSEQUENCEVERIFY;
-        }
-        if height >= chain_params.segwit_activation_height {
-            flags |= bitcoinconsensus::VERIFY_NULLDUMMY;
-        }
-        flags
     }
 
     fn update_header(&self, header: &DiskBlockHeader) -> Result<(), BlockchainError> {
@@ -976,10 +939,15 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
         // Validate block transactions
         let subsidy = read_lock!(self).consensus.get_subsidy(height);
         let verify_script = self.verify_script(height)?;
+
         #[cfg(feature = "bitcoinconsensus")]
-        let flags = self.get_validation_flags(height, block.block_hash());
+        let flags = read_lock!(self)
+            .consensus
+            .parameters
+            .get_validation_flags(height, block.block_hash());
         #[cfg(not(feature = "bitcoinconsensus"))]
         let flags = 0;
+
         Consensus::verify_block_transactions(
             height,
             inputs,


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: Refactor

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

This function is more concerned with our chain parameters, so the natural place is `chainparams.rs`, as a method for the type.

This also removes the duplication that we see in both chain backends.