### PR TITLE
feat(chain): Enable subscriptions to blocks with input UTXOs

### DIFF
--- a/crates/floresta-chain/src/lib.rs
+++ b/crates/floresta-chain/src/lib.rs
@@ -27,6 +27,8 @@ pub use pruned_utreexo::flat_chain_store::*;
 #[cfg(feature = "kv-chainstore")]
 pub use pruned_utreexo::kv_chainstore::*;
 pub use pruned_utreexo::udata::*;
+pub use pruned_utreexo::utxo_data::*;
+pub use pruned_utreexo::BlockchainInterface;
 pub use pruned_utreexo::ChainBackend;
 pub use pruned_utreexo::Notification;
 pub use pruned_utreexo::ThreadSafeChain;

--- a/crates/floresta-chain/src/pruned_utreexo/mod.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/mod.rs
@@ -63,7 +63,7 @@ pub trait BlockchainInterface {
     /// Register for receiving notifications for some event. Right now it only works for
     /// new blocks, but may work with transactions in the future too.
     /// if a module performs some heavy-lifting on the block's data, it should pass in a
-    /// vector or a channel where data can be  transferred to the atual worker, otherwise
+    /// vector or a channel where data can be transferred to the actual worker, otherwise
     /// chainstate will be stuck for as long as you have work to do.
     fn subscribe(&self, tx: Arc<dyn BlockConsumer>);
     /// Tells whether or not we are on IBD

--- a/crates/floresta-watch-only/src/lib.rs
+++ b/crates/floresta-watch-only/src/lib.rs
@@ -9,6 +9,7 @@ use core::fmt::Debug;
 use bitcoin::hashes::sha256;
 use bitcoin::ScriptBuf;
 use floresta_chain::BlockConsumer;
+use floresta_chain::UtxoData;
 use floresta_common::get_spk_hash;
 use floresta_common::parse_descriptors;
 
@@ -554,7 +555,16 @@ pub struct AddressCache<D: AddressCacheDatabase> {
 }
 
 impl<D: AddressCacheDatabase + Sync + Send + 'static> BlockConsumer for AddressCache<D> {
-    fn consume_block(&self, block: &Block, height: u32) {
+    fn wants_spent_utxos(&self) -> bool {
+        false
+    }
+
+    fn on_block(
+        &self,
+        block: &Block,
+        height: u32,
+        _spent_utxos: Option<&HashMap<OutPoint, UtxoData>>,
+    ) {
         self.block_process(block, height);
     }
 }

--- a/crates/floresta/examples/indexer.rs
+++ b/crates/floresta/examples/indexer.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+//! In node.rs we created a node that connects to the Bitcoin network and downloads the blockchain.
+//! We use the default chainstate, which starts at genesis and validates all blocks, but you can
+//! customized the chainstate to subscribe to all new blocks, including the input UTXO set. This
+//! is useful for indexing metaprotocols, tracking recent fee rates, and detecting new spends from
+//! wallets with unknown balances.
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bitcoin::Block;
+use bitcoin::Network;
+use bitcoin::OutPoint;
+use floresta_chain::AssumeValidArg;
+use floresta_chain::BlockConsumer;
+use floresta_chain::BlockchainInterface;
+use floresta_chain::ChainState;
+use floresta_chain::FlatChainStore;
+use floresta_chain::FlatChainStoreConfig;
+use floresta_chain::UtxoData;
+
+const DATA_DIR: &str = "./tmp-db";
+
+/// A sample indexer that tracks the min fee rate of the last block
+struct FeeRateIndexer {
+    /// The median fee rate of the last block (sats / kvb)
+    min_sats_per_kvb: AtomicU64,
+}
+
+impl FeeRateIndexer {
+    pub fn new() -> Self {
+        FeeRateIndexer {
+            min_sats_per_kvb: AtomicU64::new(0),
+        }
+    }
+}
+
+// Implement BlockConsumer so we can subscribe on `ChainState`
+impl BlockConsumer for FeeRateIndexer {
+    fn wants_spent_utxos(&self) -> bool {
+        true
+    }
+
+    fn on_block(
+        &self,
+        block: &Block,
+        _height: u32,
+        spent_utxos: Option<&HashMap<OutPoint, UtxoData>>,
+    ) {
+        // Calculate minimum fee rate, ignoring coinbase transaction
+        let spent_utxos = spent_utxos.expect("Safe to unwrap because wants_spent_utxos()");
+        let min_fee_rate = block
+            .txdata
+            .iter()
+            .skip(1)
+            .map(|tx| {
+                let total_in: u64 = tx
+                    .input
+                    .iter()
+                    .filter_map(|txin| {
+                        spent_utxos
+                            .get(&txin.previous_output)
+                            .map(|utxo| utxo.txout.value.to_sat())
+                    })
+                    .sum();
+
+                let total_out: u64 = tx.output.iter().map(|txout| txout.value.to_sat()).sum();
+
+                let fee = total_in - total_out;
+                let weight = tx.weight().to_wu();
+                fee * 4000 / weight
+            })
+            .min()
+            .unwrap_or(0);
+
+        self.min_sats_per_kvb.store(min_fee_rate, Ordering::Relaxed);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Create a new chain state, which will store the accumulator and the headers chain.
+    // It will be stored in the DATA_DIR directory. With this chain state, we don't keep
+    // the block data after we have validated it. This saves a lot of space, but it means that
+    // we can't serve blocks to other nodes or rescan the blockchain without downloading
+    // it again.
+    let chain_store_config = FlatChainStoreConfig::new(DATA_DIR.into());
+    let chain_store =
+        FlatChainStore::new(chain_store_config).expect("failed to open the blockchain database");
+
+    // The actual chainstate. It will keep track of the current state of the accumulator
+    // and the headers chain. It will also validate new blocks and headers as we receive them.
+    // The last parameter is the assume valid block. We assume that all blocks before this
+    // one have valid signatures. This is a performance optimization, as we don't need to validate all
+    // signatures in the blockchain, just the ones after the assume valid block. We are giving a Disabled
+    // value, so we will validate all signatures regardless.
+    // We place the chain state in an Arc, so we can share it with other components.
+    let chain = Arc::new(ChainState::new(
+        chain_store,
+        Network::Bitcoin,
+        AssumeValidArg::Disabled,
+    ));
+
+    // Create the indexer and subscribe to new blocks with the spent UTXOs
+    let indexer = FeeRateIndexer::new();
+    chain.subscribe(Arc::new(indexer));
+
+    // ... If you want to drive the chainstate, you can use the BlockchainInterface trait.
+    // See node.rs for an example on how to do it ...
+}

--- a/crates/floresta/examples/node.rs
+++ b/crates/floresta/examples/node.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use bitcoin::BlockHash;
 use bitcoin::Network;
-use floresta::chain::pruned_utreexo::BlockchainInterface;
+use floresta::chain::BlockchainInterface;
 use floresta::chain::ChainState;
 use floresta::wire::mempool::Mempool;
 use floresta::wire::node::UtreexoNode;

--- a/florestad/src/zmq.rs
+++ b/florestad/src/zmq.rs
@@ -1,26 +1,31 @@
+//! A small Zero Message Queue (ZMQ) implementation for floresta, that pushes new blocks
+//! as they are found.
+//!
+//! # Examples
+//! Creating a server
+//! ```ignore
+//! use florestad::zmq::ZMQServer;
+//! let _ = ZMQServer::new("tcp://127.0.0.1:5150");
+//! ```
+//!
+//! Listening for new blocks
+//!
+//! ```ignore
+//! use zmq::{Context, Socket};
+//! let ctx =  Context::new();
+//! // The opposite of PUSH is PULL
+//! let socket = ctx.socket(zmq::SocketType::PULL).unwrap();
+//!
+//! socket.connect(addr).unwrap();
+//! let block = socket.recv().unwrap();
+//! ```
+
+use std::collections::HashMap;
+
 use bitcoin::consensus::serialize;
-/// A small Zero Message Queue (ZMQ) implementation for floresta, that pushes new blocks
-/// as they are found.
-///
-/// # Examples
-/// Creating a server
-/// ```ignore
-/// use florestad::zmq::ZMQServer;
-/// let _ = ZMQServer::new("tcp://127.0.0.1:5150");
-/// ```
-///
-/// Listening for new blocks
-///
-/// ```ignore
-/// use zmq::{Context, Socket};
-/// let ctx =  Context::new();
-/// // The opposite of PUSH is PULL
-/// let socket = ctx.socket(zmq::SocketType::PULL).unwrap();
-///
-/// socket.connect(addr).unwrap();
-/// let block = socket.recv().unwrap();
-/// ```
+use bitcoin::OutPoint;
 use floresta_chain::BlockConsumer;
+use floresta_chain::UtxoData;
 use zmq::Context;
 use zmq::Socket;
 
@@ -51,7 +56,16 @@ impl ZMQServer {
 
 // Implement BlockConsumer so we can subscribe on `ChainState`
 impl BlockConsumer for ZMQServer {
-    fn consume_block(&self, block: &bitcoin::Block, _height: u32) {
+    fn wants_spent_utxos(&self) -> bool {
+        false
+    }
+
+    fn on_block(
+        &self,
+        block: &bitcoin::Block,
+        _height: u32,
+        _spent_utxos: Option<&HashMap<OutPoint, UtxoData>>,
+    ) {
         let block = serialize(&block);
         if let Err(e) = self.socket.send(block, zmq::DONTWAIT) {
             log::error!("while sending block over zmq: {e}");


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [x] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Introduces a new subscription mechanism that provides both block data _and_ input UTXO data to subscribers. This enables applications that require knowledge of the spent UTXOs.

### Changes

- **New trait**: `BlockWithInputsConsumer` for subscribers that need input data alongside blocks
- **New method**: Use `subscribe_with_inputs()` to subscribe to block data with input UTXOs
- **Backward compatible**: Existing `BlockConsumer` subscribers continue to work unchanged

### Use Cases

The primary motivation for this PR is to support metaprotocol indexers, which require access to the spent UTXOs of each transaction, but not the full UTXO set. Developers can then integrate Floresta directly into their indexer, so that users do not need to run a separate full node in order to index the chain.

In addition, this PR enables basic blockchain analytics on light clients. Light clients can track recent fee rates and other transaction patterns that may be useful to the user.

Finally, this PR enables light clients that track spends from addresses with unknown balances, without needing to download filters or reindex the entire chain. For example, as an intrusion detection mechanism, a user could setup a watchtower that notifies them of spends from their wallet, providing only their wallet's descriptor.

### Example Usage

```rust
struct FeeAnalyzer;

impl BlockWithInputsConsumer for FeeAnalyzer {
    fn consume_block_with_inputs(&self, block: &Block, height: u32, inputs: &HashMap<OutPoint, UtxoData>) {
        // Calculate fee rates using block data and the UTXO data for all inputs in this block
        let fee_rates = calculate_fee_rates(block, inputs);
        // Process...
    }
}

// Subscribe
chainstate.subscribe_with_inputs(Arc::new(FeeAnalyzer));
```

### Notes to the reviewers

Passing input data to subscribers requires the data to be cloned once, because `validate_block_no_acc` needs to own and modify the input set during validation. To prevent unnecessary cloning, the input data is only cloned if there exists an input subscriber. This keeps the memory footprint unchanged for existing Floresta users.