### PR TITLE
Fix reindex during chain selection

### DIFF
--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -677,6 +677,12 @@ where
                         break;
                     }
                 }
+
+                // Shutdown if needed while in the notifications loop
+                if *self.kill_signal.read().await {
+                    self.shutdown().await;
+                    return Ok(());
+                }
             }
 
             // Checks if we need to open a new connection
@@ -729,6 +735,7 @@ where
             try_and_log!(self.check_for_timeout().await);
 
             if *self.kill_signal.read().await {
+                self.shutdown().await;
                 break;
             }
         }

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -838,6 +838,7 @@ impl Florestad {
             Ok(chainstate) => chainstate,
             Err(err) => match err {
                 BlockchainError::ChainNotInitialized => {
+                    info!("Initializing ChainState for the first time");
                     let db = Self::load_chain_store(data_dir);
 
                     ChainState::<ChainStore>::new(db, network, assume_valid)


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [x] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

In `reindex_chain` we don't update the best block field if there's no accumulator associated, but this must be allowed in the chain selection phase (or else we can't "reindex" in that phase).

Another problem is that when we try to shutdown the node during chain selection we don't flush the chain, so we don't save the `BestChain`, which means the next re-start will not identify the chain as initialized and will reindex. But this reindex loops forever because we never update the `BestChain` as explained above.

Also added warns before each `reindex_chain` such that we know the reason in each case.

### Notes to the reviewers

I am calling the `shutdown` method which in turn calls `flush`. But I am not sure why we see a channel error at the end, perhaps because the peer is already closed:

```bash
[2025-08-04 02:48:46 INFO floresta_wire::p2p_wire::node] Shutting down node
[2025-08-04 02:48:46 WARN floresta_wire::p2p_wire::node] Failed to save Utreexo peers: no peers to save to anchors.json
[2025-08-04 02:48:47 INFO floresta_wire::p2p_wire::node] Shutting down node
[2025-08-04 02:48:47 WARN floresta_wire::p2p_wire::node] Failed to save Utreexo peers: no peers to save to anchors.json
[2025-08-04 02:48:47 ERROR floresta_wire::p2p_wire::node] 1332: crates/floresta-wire/src/p2p_wire/node.rs - ChannelSend(SendError { .. })
```
