### PR TITLE
fix(florestad): disable cfilters by default

### DIFF
--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -39,7 +39,7 @@ pub struct Cli {
     /// Defaults to `~/.floresta`. The passed value should be an absolute path.
     pub data_dir: Option<String>,
 
-    #[arg(long, default_value_t = true)]
+    #[arg(long)]
     /// Whether to build Compact Block Filters
     ///
     /// Those filters let you query for chain data after IBD, like wallet rescan,


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Disables `cfilters` by default, requiring usage of the argument `--cfilters` in order to download compact block filters, as specified by the [docs](https://github.com/vinteumorg/Floresta/blob/master/doc/run.md#compact-filters).

Fixed #597