### PR TITLE
florestad: disable cfilters with --no-cfilters

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -72,7 +72,7 @@ show_usage() {
     echo "                                   (default: '')"
     echo "  -v  --assume-valid <BLOCK_HASH>  Pass --assume-valid=<BLOCK_HASH> onto built service"
     echo "                                   (default: '')"
-    echo "  -f, --filters <HEIGHT>           Pass --cfilters and --filters-start-height=<HEIGHT> onto"
+    echo "  -f, --filters <HEIGHT>           Pass --filters-start-height=<HEIGHT> onto"
     echo "                                   built service. If the value is negative, it's relative"
     echo "                                   to the current tip; e.g., if the current tip is 1000 and"
     echo "                                   we set this value to -100, we will start downloading"
@@ -428,7 +428,7 @@ After=network-online.target time-set.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/florestad --daemon --network $network --data-dir $florestaDir --config-file $florestaLib/config.toml --pid-file $florestaRun/florestad.pid --log-to-file$([ -n "$proxy" ] && echo " --proxy $proxy ")$([ -n "$connect" ] && echo " --connect $connect ")$([ -n "$zeromq" ] && echo " --zmq-address $zeromq ")$([ -n "$assume_valid" ] && echo " --assume-valid $assume_valid ")$([ "$assume_utreexo" = true ] && echo " --assume-utreexo ")$([ "$enable_cfilters" = true ] && echo " --cfilters ")$([ -n "$filters_start_height" ] && echo " --filters-start-height \"$filters_start_height\" ")$([ "$enable_tls" == true ] && echo " --generate-cert --enable-electrum-tls")
+ExecStart=/usr/local/bin/florestad --daemon --network $network --data-dir $florestaDir --config-file $florestaLib/config.toml --pid-file $florestaRun/florestad.pid --log-to-file$([ -n "$proxy" ] && echo " --proxy $proxy ")$([ -n "$connect" ] && echo " --connect $connect ")$([ -n "$zeromq" ] && echo " --zmq-address $zeromq ")$([ -n "$assume_valid" ] && echo " --assume-valid $assume_valid ")$([ "$assume_utreexo" = true ] && echo " --assume-utreexo ")$([ "$enable_cfilters" = false ] && echo " --no-cfilters ")$([ -n "$filters_start_height" ] && echo " --filters-start-height \"$filters_start_height\" ")$([ "$enable_tls" == true ] && echo " --generate-cert --enable-electrum-tls")
 
 # Ensure that the service is ready after the MainPID exists
 Type=forking
@@ -1017,7 +1017,7 @@ interactive_zeromq() {
 
 # func: interactive_filters
 #
-# Ask if user want to use --cfilters or not
+# Ask if user want to use --no-cfilters or not
 interactive_filters() {
     local filters_start_height_regex="^-?[0-9]+$"
 

--- a/doc/run.md
+++ b/doc/run.md
@@ -65,10 +65,16 @@ florestad --no-backfill
 
 ## Compact Filters
 
-Floresta supports compact block filters, which can be used to scan for transactions in a block without downloading the entire block. You can start the node with the `--cfilters` flag to download the filters for the blocks that you're interested in. You can also use the `--filters-start-height` flag to specify the block height that you want to start downloading the filters from. This is useful if you want to download only the filters for a specific range of blocks.
+Floresta supports compact block filters, which can be used to scan for transactions in a block without downloading the entire block. By default, the node will download filters for all blocks. You can also use the `--filters-start-height` flag to specify the block height that you want to start downloading the filters from. This is useful if you want to download only the filters for a specific range of blocks.
 
 ```bash
-florestad --cfilters --filters-start-height 800000
+florestad --filters-start-height 800000
+```
+
+To disable compact block filters, start the node with the `--no-cfilters` flag. This will prevent the node from downloading filters.
+
+```bash
+florestad --no-cfilters
 ```
 
 ## Getting Help
@@ -101,7 +107,7 @@ The rescan assumes that you have compact block filters for the blocks that you'r
 using the `--filters-start-height` option. Let's you know that none of your wallets are older than block 800,000. Just start the node with.
 
 ```bash
-./target/release/florestad --cfilters --filters-start-height 800000
+./target/release/florestad --filters-start-height 800000
 ```
 
 if you add a wallet and want to rescan the blocks from 800,000 to the current height, you can use the `rescan` rpc.

--- a/florestad/src/cli.rs
+++ b/florestad/src/cli.rs
@@ -39,13 +39,13 @@ pub struct Cli {
     /// Defaults to `~/.floresta`. The passed value should be an absolute path.
     pub data_dir: Option<String>,
 
-    #[arg(long, default_value_t = true)]
-    /// Whether to build Compact Block Filters
+    #[arg(long)]
+    /// Whether Compact Block Filters should be disabled
     ///
     /// Those filters let you query for chain data after IBD, like wallet rescan,
     /// finding a utxo, finding specific tx_ids.
-    /// Will cause more disk usage
-    pub cfilters: bool,
+    /// Will cause less disk usage if disabled.
+    pub no_cfilters: bool,
 
     #[arg(long, short, default_value = None, value_name = "address[:<port>]")]
     /// The url of a proxy we should open p2p connections through (e.g. 127.0.0.1:9050)

--- a/florestad/src/json_rpc/res.rs
+++ b/florestad/src/json_rpc/res.rs
@@ -295,7 +295,7 @@ impl Display for JsonRpcError {
             JsonRpcError::InvalidPort => write!(f, "Invalid port"),
             JsonRpcError::InvalidAddress => write!(f, "Invalid address"),
             JsonRpcError::Node(e) => write!(f, "Node error: {e}"),
-            JsonRpcError::NoBlockFilters => write!(f, "You don't have block filters enabled, please start florestad with --cfilters to run this RPC"),
+            JsonRpcError::NoBlockFilters => write!(f, "You don't have block filters enabled, please start florestad without --no-cfilters to run this RPC"),
             JsonRpcError::InvalidNetwork => write!(f, "Invalid network"),
             JsonRpcError::InInitialBlockDownload => write!(f, "Node is in initial block download, wait until it's finished"),
             JsonRpcError::Encode => write!(f, "Error encoding response"),

--- a/florestad/src/main.rs
+++ b/florestad/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
         network: params.network,
         debug: params.debug,
         data_dir: params.data_dir.clone(),
-        cfilters: params.cfilters,
+        cfilters: !params.no_cfilters,
         proxy: params.proxy,
         assume_utreexo: !params.no_assume_utreexo,
         connect: params.connect,

--- a/tests/test_framework/daemon/floresta.py
+++ b/tests/test_framework/daemon/floresta.py
@@ -32,7 +32,7 @@ class FlorestaDaemon(BaseDaemon):
             "--debug",
             "--log-to-file",
             "--data-dir",
-            "--cfilters",
+            "--no-cfilters",
             "-p",
             "--proxy",
             "--wallet-xpub",


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description

Adds `--no-cfilters` flag to disable compact block filters and removes the `--cfilters` flag, which is redundant as filters are enabled by default. This PR also updates documentation to reflect the new CLI flag.

Fixed #597  
