### PR TITLE
chore(ci): add spell-check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Spell check
+        uses: crate-ci/typos@v1
+
       - name: Run cargo fmt
         run: cargo +nightly fmt --all --check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ pub struct Foo {
   bar: u32,
 
   /// Another awesome comment
-  foor: u32
+  foo: u32
 }
 
 impl Foo {
@@ -146,7 +146,7 @@ All new features require testing. Tests should be unique and self-describing. If
 
 If you have `just`, we have a script that performs all the checks we do on CI (test, linting, docker...) use `just pcc` (pre commit check) before pushing your changes.
 
-When it comes error handling, we prefer exact and meaningful error handling to deliver consumers(developers and users) an accurate error that describes exatcly what happened wrong.
+When it comes error handling, we prefer exact and meaningful error handling to deliver consumers(developers and users) an accurate error that describes exactly what happened wrong.
 
 Instead of:
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -706,7 +706,7 @@ interactive_greeting() {
 # interactive_setup, interactive_greeting
 # interactive_wallet, interactive_advanced_setup
 # and all interactive_ask_* functions
-# and imediately after a dialog command.
+# and immediately after a dialog command.
 check_dialog_escape() {
     code=$?
     if [ "$code" -eq 255 ]; then
@@ -1155,7 +1155,7 @@ interactive_ask_for_add_xpubs() {
 # func: interactive_add_xpub
 #
 # Ask to user add a valid xpub. If a valid one is provided, add to wallet_xpubs array, show the
-# xpub to user confirm it and back to interactive_ask_for_add_xpubs function (thourgh returning true).
+# xpub to user confirm it and back to interactive_ask_for_add_xpubs function (through returning true).
 # If user provided an invalid one, clean the wallet_xpubs list and back to interactive_ask_for_add_xpubs
 # to do all again.
 interactive_add_xpub() {

--- a/contrib/nix/build_floresta.nix
+++ b/contrib/nix/build_floresta.nix
@@ -41,7 +41,7 @@ let
 
         # We need to get a different toml for different packages
         #
-        # Since we only use this instrospection of Cargo.toml for getting package
+        # Since we only use this introspection of Cargo.toml for getting package
         # version, this ones gets the version from florestad which is the one we
         # track major progress of the project.
         cargoToml = builtins.fromTOML (builtins.readFile "${src}/florestad/Cargo.toml");

--- a/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/chain_state.rs
@@ -345,9 +345,9 @@ impl<PersistedState: ChainStore> ChainState<PersistedState> {
     }
 
     /// Changes the acc we are using to validate blocks.
-    fn reorg_acc(&self, fork_pont: &BlockHeader) -> Result<(), BlockchainError> {
+    fn reorg_acc(&self, fork_point: &BlockHeader) -> Result<(), BlockchainError> {
         let height = self
-            .get_block_height(&fork_pont.block_hash())?
+            .get_block_height(&fork_point.block_hash())?
             .ok_or(BlockchainError::BlockNotPresent)?;
 
         let acc = self.get_roots_for_block(height)?.unwrap_or_default();

--- a/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/flat_chain_store.rs
@@ -135,7 +135,7 @@ pub struct FlatChainStoreConfig {
     /// The size of the headers file map, in headers
     ///
     /// This is the size of the flat file that holds all of our block headers. We keep all headers
-    /// in a simple flat file, one after the other. That file then gets mmaped into RAM, so we can
+    /// in a simple flat file, one after the other. That file then gets mapped into RAM, so we can
     /// use pointer arithmetic to find specific block, since pos(h) = h * size_of(DiskBlockHeader)
     /// The default value is having space for 10 million blocks.
     ///
@@ -764,7 +764,7 @@ impl FlatChainStore {
     /// This function will check the integrity of our database by comparing the checksum of the
     /// headers file, index map, and fork headers file with the checksum stored in the metadata.
     ///
-    /// As checksum, the [xxHash] of the memory-maped region is used. This is a fast hash function that
+    /// As checksum, the [xxHash] of the memory-mapped region is used. This is a fast hash function that
     /// is very good at detecting errors in memory. It is not cryptographically secure, but it is
     /// enough for random errors in a file.
     ///

--- a/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
+++ b/crates/floresta-chain/src/pruned_utreexo/partial_chain.rs
@@ -224,7 +224,7 @@ impl PartialChainState {
     /// [PartialChainState] is through our APIs, and we make sure this [UnsafeCell] is
     /// always valid.
     /// The reference returned here **should not** leak through the API, as there's no
-    /// synchronization mechanims for it.
+    /// synchronization mechanisms for it.
     #[inline(always)]
     #[must_use]
     #[doc(hidden)]
@@ -239,7 +239,7 @@ impl PartialChainState {
     /// [PartialChainState] is through our APIs, and we make sure this [UnsafeCell] is
     /// always valid.
     /// The reference returned here **should not** leak through the API, as there's no
-    /// synchronization mechanims for it.
+    /// synchronization mechanisms for it.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
     #[must_use]

--- a/crates/floresta-cli/src/parsers.rs
+++ b/crates/floresta-cli/src/parsers.rs
@@ -22,7 +22,7 @@ impl Display for ParseError {
                 "Couldnt parse the inserted as an Array, please refer to the docs"
             ),
             ParseError::InvalidTarget(target) => {
-                write!(f, "Could parse itens to {target}")
+                write!(f, "Could parse items to {target}")
             }
         }
     }

--- a/crates/floresta-cli/src/rpc_types.rs
+++ b/crates/floresta-cli/src/rpc_types.rs
@@ -60,7 +60,7 @@ pub struct RawTx {
     pub in_active_chain: bool,
     /// The hex-encoded tx
     pub hex: String,
-    /// Tha sha256d of the serialized transaction without witness
+    /// The sha256d of the serialized transaction without witness
     pub txid: String,
     /// The sha256d of the serialized transaction including witness
     pub hash: String,

--- a/crates/floresta-common/src/spsc.rs
+++ b/crates/floresta-common/src/spsc.rs
@@ -63,7 +63,7 @@ impl<T> Channel<T> {
     }
     /// Reads from a channel
     ///
-    /// This method returns an iterator over all alements inside a [Channel]
+    /// This method returns an iterator over all elements inside a [Channel]
     pub fn recv(&self) -> RecvIter<T> {
         let inner = take(&mut *self.content.lock());
         RecvIter { inner }

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -529,7 +529,7 @@ impl AddressMan {
         }
     }
 
-    /// Attept to find one random peer that advertises the required service
+    /// Attempt to find one random peer that advertises the required service
     ///
     /// If we cannot find a peer that advertises the required service, we return any peer
     /// that we have in our list of known peers. Luckily, either we'll connect to a peer that has

--- a/crates/floresta-wire/src/p2p_wire/chain_selector.rs
+++ b/crates/floresta-wire/src/p2p_wire/chain_selector.rs
@@ -24,7 +24,7 @@
 //! block, everyone comparing the same chain, be on earth, on mars; in 2020 or 2100, they will
 //! choose the exact same chain, always.
 //!
-//! The most critial part of syncing-up a Bitcoin node is making sure you know about the most-work
+//! The most critical part of syncing-up a Bitcoin node is making sure you know about the most-work
 //! chain. If someone can eclypse you, they can make you start following a chain that only you and
 //! the attacker care about. If you get paid in this chain, you can't pay someone else outside this
 //! chain, because they will be following other chains. Luckily, we only need one honest peer, to
@@ -81,7 +81,7 @@ use crate::node_interface::NodeResponse;
 #[derive(Debug, Default, Clone)]
 /// A p2p driver that attempts to connect with multiple peers, ask which chain are them following
 /// and download and verify the headers, **not** the actual blocks. This is the first part of a
-/// loger IBD pipeline.
+/// logger IBD pipeline.
 /// The actual blocks should be downloaded by a SyncPeer.
 pub struct ChainSelector {
     /// The state we are in
@@ -463,7 +463,7 @@ where
         Self::parse_acc(candidate_accs.pop().unwrap().1)
     }
 
-    /// If we get an empty `haders` message, our next action depends on which state are
+    /// If we get an empty `headers` message, our next action depends on which state are
     /// we in:
     ///   - If we are downloading headers for the first time, this means we've just
     ///     finished and should go to the next phase

--- a/crates/floresta-wire/src/p2p_wire/mempool.rs
+++ b/crates/floresta-wire/src/p2p_wire/mempool.rs
@@ -39,8 +39,8 @@ type ShortTxid = u64;
 /// A transaction in the mempool.
 ///
 /// This struct holds the transaction itself, the time when we added it to the mempool, the
-/// transactions that depend on it, and the transactions that it depends on. We need those extra
-/// informations to make decisions when to include or not a transaction in mempool or in a block.
+/// transactions that depend on it, and the transactions that it depends on. We need that extra
+/// information to make decisions when to include or not a transaction in mempool or in a block.
 struct MempoolTransaction {
     transaction: Transaction,
     time: Instant,
@@ -203,7 +203,7 @@ impl Mempool {
                 .get(&input.previous_output)
                 .ok_or(AcceptToMempoolError::PrevoutNotFound)?;
 
-            // The block hash of the block that commited the prevout.
+            // The block hash of the block that committed the prevout.
             let block_hash = block_hash.get_block_hash(prevout.header_code >> 1).unwrap();
             let leaf_data: LeafData = proof_util::reconstruct_leaf_data(prevout, input, block_hash)
                 .map_err(|_| AcceptToMempoolError::InvalidPrevout)?;
@@ -397,7 +397,7 @@ impl Mempool {
 
     /// Checks if a outpoint is already spent in the mempool.
     ///
-    /// This can be used to find conficts before adding a transaction to the mempool.
+    /// This can be used to find conflicts before adding a transaction to the mempool.
     fn is_already_spent(&self, outpoint: &OutPoint) -> bool {
         let short_txid = self.hasher.hash_one(outpoint.txid);
         let Some(tx) = self.transactions.get(&short_txid) else {
@@ -839,15 +839,15 @@ mod tests {
 
         let transactions = build_transactions(21, true);
 
-        let mut did_confict = false;
+        let mut did_conflict = false;
         for tx in transactions {
             if mempool.accept_to_mempool_no_acc(tx).is_ok() {
-                did_confict = true;
+                did_conflict = true;
             }
         }
 
         // we expect at least one conflict
-        assert!(did_confict);
+        assert!(did_conflict);
 
         let target = Target::MAX_ATTAINABLE_REGTEST;
         let block = mempool.get_block_template(

--- a/crates/floresta-wire/src/p2p_wire/node_interface.rs
+++ b/crates/floresta-wire/src/p2p_wire/node_interface.rs
@@ -109,7 +109,7 @@ impl NodeInterface {
 
     /// Sends a request to the node.
     ///
-    /// This is an iternal utility function that will be used to send requests to the node. It will
+    /// This is an internal utility function that will be used to send requests to the node. It will
     /// send the request to the node and return a oneshot receiver that will be used to get the
     /// response back.
     async fn send_request(

--- a/crates/floresta-wire/src/p2p_wire/running_node.rs
+++ b/crates/floresta-wire/src/p2p_wire/running_node.rs
@@ -119,7 +119,7 @@ where
     /// - At least one utreexo peer
     /// - At least one compact filters peer
     ///
-    /// If we are missing the speciall peers but have 10 connections, we should disconnect one
+    /// If we are missing the special peers but have 10 connections, we should disconnect one
     /// random peer and try to connect to a utreexo and a compact filters peer.
     async fn check_connections(&mut self) -> Result<(), WireError> {
         // retry the added peers connections

--- a/doc/nix.md
+++ b/doc/nix.md
@@ -121,7 +121,7 @@ You can find more information about our tests in [running tests](./running-tests
 This project also integrates some checks for CI.
 
 ```Bash
-# This command will run all the checks setted by flake.nix
+# This command will run all the checks set by flake.nix
 $ nix flake check
 ```
 Checks enabled:

--- a/doc/run.md
+++ b/doc/run.md
@@ -47,7 +47,7 @@ man-in-the-middle (MITM) attacks because they
 
 ## Assume Utreexo
 
-If you want to start your node and get up and running quickly, you can use the Assume Utreexo feature. This is enabled by defalt, but you can disable it with the `--no-assume-utreexo` flag.
+If you want to start your node and get up and running quickly, you can use the Assume Utreexo feature. This is enabled by default, but you can disable it with the `--no-assume-utreexo` flag.
 
 ```bash
 florestad --no-assume-utreexo

--- a/florestad/src/florestad.rs
+++ b/florestad/src/florestad.rs
@@ -196,7 +196,7 @@ pub struct Config {
     pub generate_cert: bool,
     /// Whether to allow fallback to v1 transport if v2 connection fails.
     pub allow_v1_fallback: bool,
-    /// Whehter we should backfill
+    /// Whether we should backfill
     ///
     /// If we assumeutreexo or use pow fraud proofs, you have the option to download and validate
     /// the blocks that were skipped. This will take a long time, but will run on the background

--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -55,7 +55,7 @@ pub(super) struct InflightRpc {
 
 /// Utility trait to ensure that the chain implements all the necessary traits
 ///
-/// Instead of using this very complext trait bound declaration on every impl block
+/// Instead of using this very complex trait bound declaration on every impl block
 /// and function, this trait makes sure everything we need is implemented.
 pub trait RpcChain: ThreadSafeChain + Clone {}
 

--- a/justfile
+++ b/justfile
@@ -78,6 +78,7 @@ doc-check:
 
 # Format code and run configured linters
 lint:
+    @just spell-check
     @just fmt
     @just doc-check
 
@@ -119,6 +120,7 @@ test-features arg="":
 
 # Format code and run clippy for all feature combinations in each crate (arg: optional, e.g., '-- -D warnings')
 lint-features arg="":
+    @just spell-check
     @just fmt
     @just doc-check
     @just test-functional-uv-fmt
@@ -141,3 +143,7 @@ pcc:
 # Convert all markdown files on /doc/rpc/ to man pages on /doc/rpc_man/
 gen-manpages path="":
     ./contrib/dist/gen_manpages.sh {{path}}
+
+spell-check:
+    cargo +nightly install typos-cli --locked
+    typos

--- a/tests/floresta-cli/getblockcount.py
+++ b/tests/floresta-cli/getblockcount.py
@@ -15,7 +15,7 @@ class GetBlockCountTest(FlorestaTestFramework):
     """
     Test florestad's `getbestblockhash` by running three nodes in
     a "semi-triangle" network structure, where florestad and bitcoind
-    nodes are connected to utreexod, but not coneected between them.
+    nodes are connected to utreexod, but not connected between them.
     Then assert that the same blockcount in three nodes, before mining
     and after mining.
     """

--- a/tests/floresta-cli/getmemoryinfo.py
+++ b/tests/floresta-cli/getmemoryinfo.py
@@ -43,7 +43,7 @@ class GetMemoryInfoTest(FlorestaTestFramework):
             self.assertTrue(result["locked"]["used"] >= 0)
         else:
             self.log(
-                f"Skiping test: 'getmemoryinfo stats' not implemented for '{sys.platform}'"
+                f"Skipping test: 'getmemoryinfo stats' not implemented for '{sys.platform}'"
             )
 
     def test_mode_mallocinfo_ibd(self, node):
@@ -70,7 +70,7 @@ class GetMemoryInfoTest(FlorestaTestFramework):
             self.assertMatch(result, pattern)
         else:
             self.log(
-                f"Skiping test: 'getmemoryinfo malloc' not implemented for '{sys.platform}'"
+                f"Skipping test: 'getmemoryinfo malloc' not implemented for '{sys.platform}'"
             )
 
     def run_test(self):

--- a/tests/test_framework/__init__.py
+++ b/tests/test_framework/__init__.py
@@ -4,7 +4,7 @@ tests/test_framework/__init__.py
 Adapted from
 https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/test_framework.py
 
-Bitcoin Core's functional tests define a metaclass that checks wheter the required
+Bitcoin Core's functional tests define a metaclass that checks whether the required
 methods are defined or not. Floresta's functional tests will follow this battle tested structure.
 The difference is that `florestad` will run under a `cargo run` subprocess, which is defined at
 `add_node_settings`.
@@ -245,7 +245,7 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
             for node in self._nodes:
 
                 # If the node has an RPC server, stop it gracefully
-                # otherwise (maybe the error occured before the RPC server
+                # otherwise (maybe the error occurred before the RPC server
                 # is started), try to kill the process with SIGTERM. If that
                 # fails, try to force kill it with SIGKILL.
                 processes.append(str(node.daemon.process.pid))
@@ -263,7 +263,7 @@ class FlorestaTestFramework(metaclass=FlorestaTestMetaClass):
                 f"Process with pids {', '.join(processes)} failed to start: {err}"
             ) from err
 
-    # Should be overrided by individual tests
+    # Should be overridden by individual tests
     def set_test_params(self):
         """
         Tests must override this method to change default values for number of nodes, topology, etc

--- a/tests/test_framework/bitcoin.py
+++ b/tests/test_framework/bitcoin.py
@@ -152,7 +152,7 @@ class TxOutput:
 
     @staticmethod
     def from_dict(data: dict):
-        """Convert a dictionary to a TxOuput object"""
+        """Convert a dictionary to a TxOutput object"""
         return TxOutput(data["value"], data["script_pub_key"])
 
 

--- a/tests/test_framework/daemon/base.py
+++ b/tests/test_framework/daemon/base.py
@@ -64,7 +64,7 @@ class BaseDaemon(metaclass=BaseDaemonMetaClass):
     is a parent process of the test process, that is a parent of daemon
     processes. If a test fail and the daemon process isnt properly
     stopped, the `tests/run_test.py` and the test itself will be killed,
-    but the daemon process will be reparented before the ports beign closed,
+    but the daemon process will be reparented before the ports being closed,
     therefore, the ports will remain opened.
 
     For example:
@@ -232,7 +232,7 @@ class BaseDaemon(metaclass=BaseDaemonMetaClass):
         Add node settings to the list of settings.
 
         settings are the CLI arguments to be passed to the node and
-        are based on the `valid_deamon_args` method.
+        are based on the `valid_daemon_args` method.
 
         Not all possible arguments are valid for tests
         (for example, "--version" or "--help" are not valid).

--- a/tests/test_framework/rpc/base.py
+++ b/tests/test_framework/rpc/base.py
@@ -128,7 +128,7 @@ class BaseRPC(metaclass=BaseRpcMetaClass):
     stuff = myrpc.get_stuff("stuff")
 
     # this will send a stop JSON-RPC request to the daemon
-    # and stop the daemon process throught the RPC connection.
+    # and stop the daemon process through the RPC connection.
     stop_msg = myrpc.stop()
     """
 

--- a/tests/test_framework/rpc/floresta.py
+++ b/tests/test_framework/rpc/floresta.py
@@ -66,7 +66,7 @@ class FlorestaRPC(BaseRPC):
         The returns for this rpc are identical to bitcoin core's getblock rpc
         as of version 27.0.
 
-        the `str` param should be a valid 32 bytes hex formated string
+        the `str` param should be a valid 32 bytes hex formatted string
         the `int` param should be a integer verbosity level
         """
         if len(blockhash) != 64:

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["florestad/docs/tutorial(PT-BR).md"]


### PR DESCRIPTION
### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [x] Other: ci.

### Which crates are being modified?

- [x] floresta-chain
- [x] floresta-cli
- [x] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [x] floresta-wire
- [ ] floresta
- [x] florestad
- [x] Other: docs and tests
### Description

Fix #591.

### Notes to the reviewers

Adding a [`typos` crate](https://github.com/crate-ci/typos), will be possible to check if any typo occurs. While it not fix all possible spell errors, at least mitigate some spelling errors.