### PR TITLE
[Fix] Lock lib dns-lookup version to 2.0.4

### DIFF
--- a/florestad/Cargo.toml
+++ b/florestad/Cargo.toml
@@ -29,7 +29,7 @@ metrics = { path = "../metrics", optional = true }
 axum = { version = "0.7", optional = true }
 anyhow = "1.0.40"
 zmq = { version = "0.10.0", optional = true }
-dns-lookup = "2.0.4"
+dns-lookup = "=2.0.4"
 tower-http = { version = "0.6.2", optional = true, features = ["cors"] }
 rcgen = "0.13.2"
 console-subscriber = { version = "0.4.1", optional = true }


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other: <!-- Please describe it -->

### Description and Notes

This will fix problem with `dns-lookup` versioning:
https://github.com/vinteumorg/Floresta/issues/611

- I just set to lock the version of `dns-lookup` library to `2.0.4`.

### How to verify the changes you have done?

See the `/florestad/Cargo.toml` file and check if bug  https://github.com/vinteumorg/Floresta/issues/611 will be happening.

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
