### PR TITLE
[FIX] [RPC] floresta-cli command `gettransaction` mismatch with florestad rpc server

### DIFF
--- a/florestad/src/json_rpc/server.rs
+++ b/florestad/src/json_rpc/server.rs
@@ -311,7 +311,7 @@ async fn handle_json_rpc_request(
             .expect("GetTxOutProof implements serde"))
         }
 
-        "getrawtransaction" => {
+        "gettransaction" => {
             let txid = Txid::from_str(params[0].as_str().ok_or(JsonRpcError::InvalidHash)?)
                 .map_err(|_| JsonRpcError::InvalidHash)?;
             let verbosity = params.get(1).map(|v| v.as_bool().unwrap());


### PR DESCRIPTION
### What is the purpose of this pull request?

- [x] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: 

### Which crates are being modified?

- [ ] floresta-chain
- [ ] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [x] florestad
- [ ] Other:

### Description and Notes

https://github.com/vinteumorg/Floresta/issues/453
The command `gettransaction` is already implemented but is mismatch with command used inside `florestad` rpc server.

`florestad` expects `getrawtransaction` while `floresta-cli` sends `gettransaction` command.

I changed the command `getrawtransaction` to `gettransaction` that's a correct functionality inside `florestad` rpc server.

### How to verify the changes you have done?

- Verify `gettransaction` command work correctly using `floresta-cli`.

### Contributor Checklist

- [x] I've followed the [contribution guidelines](https://github.com/vinteumorg/Floresta/blob/master/CONTRIBUTING.md)
- [x] I've verified one of the following:
  - Ran `just pcc` (recommended but slower)
  - Ran `just lint-features '-- -D warnings' && cargo test --release`
  - Confirmed CI passed on my fork
- [x] I've linked any related issue(s) in the sections above

Finally, you are encouraged to sign all your commits (it proves authorship and guards against tampering—see [How (and why) to sign Git commits](https://withblue.ink/2020/05/17/how-and-why-to-sign-git-commits.html) and [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)).
