### PR TITLE
fix(rpc): add default `Testnet4` RPC port to server and client

### DIFF
--- a/bin/floresta-cli/src/main.rs
+++ b/bin/floresta-cli/src/main.rs
@@ -39,12 +39,15 @@ fn get_host(cmd: &Cli) -> String {
     }
 
     // Otherwise, use the default host based on the network type
+    //
+    // TODO(@luisschwab): use `NetworkExt` to append the correct port
+    // once https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
     match cmd.network {
         Network::Bitcoin => "http://127.0.0.1:8332".into(),
-        Network::Testnet => "http://127.0.0.1:18332".into(),
         Network::Signet => "http://127.0.0.1:38332".into(),
+        Network::Testnet => "http://127.0.0.1:18332".into(),
+        Network::Testnet4 => "http://127.0.0.1:48332".into(),
         Network::Regtest => "http://127.0.0.1:18442".into(),
-        _ => "http://127.0.0.1:8332".into(),
     }
 }
 

--- a/crates/floresta-node/src/florestad.rs
+++ b/crates/floresta-node/src/florestad.rs
@@ -432,8 +432,8 @@ impl Florestad {
             Network::Bitcoin => false,
             Network::Signet => true,
             Network::Testnet => false,
-            Network::Regtest => false,
             Network::Testnet4 => false,
+            Network::Regtest => false,
         };
 
         // If this network already allows pow fraud proofs, we should use it instead of assumeutreexo

--- a/crates/floresta-node/src/json_rpc/res.rs
+++ b/crates/floresta-node/src/json_rpc/res.rs
@@ -291,9 +291,6 @@ pub enum JsonRpcError {
     /// This error is returned when the node does not have block filters enabled, which is required for some RPC calls
     NoBlockFilters,
 
-    /// The provided network is invalid, e.g., when it is not a valid Bitcoin network (mainnet, testnet3, testnet4, regtest)
-    InvalidNetwork,
-
     /// This error is returned when a hex value is invalid
     InvalidHex,
 
@@ -335,7 +332,6 @@ impl Display for JsonRpcError {
             JsonRpcError::InvalidAddress => write!(f, "Invalid address"),
             JsonRpcError::Node(e) => write!(f, "Node error: {e}"),
             JsonRpcError::NoBlockFilters => write!(f, "You don't have block filters enabled, please start florestad without --no-cfilters to run this RPC"),
-            JsonRpcError::InvalidNetwork => write!(f, "Invalid network"),
             JsonRpcError::InInitialBlockDownload => write!(f, "Node is in initial block download, wait until it's finished"),
             JsonRpcError::InvalidScript => write!(f, "Invalid script"),
             JsonRpcError::InvalidVerbosityLevel => write!(f, "Invalid verbosity level"),

--- a/crates/floresta-node/src/json_rpc/server.rs
+++ b/crates/floresta-node/src/json_rpc/server.rs
@@ -91,12 +91,14 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
                 node[1].parse().map_err(|_| JsonRpcError::InvalidPort)?,
             )
         } else {
+            // TODO(@luisschwab): use `NetworkExt` to append the correct port
+            // once https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
             match self.network {
                 Network::Bitcoin => (node[0], 8333),
-                Network::Testnet => (node[0], 18333),
-                Network::Regtest => (node[0], 18444),
                 Network::Signet => (node[0], 38333),
-                _ => return Err(JsonRpcError::InvalidNetwork),
+                Network::Testnet => (node[0], 18333),
+                Network::Testnet4 => (node[0], 48333),
+                Network::Regtest => (node[0], 18444),
             }
         };
 
@@ -468,7 +470,6 @@ fn get_http_error_code(err: &JsonRpcError) -> u16 {
         | JsonRpcError::InvalidRequest
         | JsonRpcError::InvalidPort
         | JsonRpcError::InvalidDescriptor
-        | JsonRpcError::InvalidNetwork
         | JsonRpcError::InvalidVerbosityLevel
         | JsonRpcError::Decode(_)
         | JsonRpcError::NoBlockFilters
@@ -508,7 +509,6 @@ fn get_json_rpc_error_code(err: &JsonRpcError) -> i32 {
         | JsonRpcError::InvalidRequest
         | JsonRpcError::InvalidPort
         | JsonRpcError::InvalidDescriptor
-        | JsonRpcError::InvalidNetwork
         | JsonRpcError::InvalidVerbosityLevel
         | JsonRpcError::TxNotFound
         | JsonRpcError::BlockNotFound
@@ -724,13 +724,15 @@ impl<Blockchain: RpcChain> RpcImpl<Blockchain> {
         }
     }
 
+    // TODO(@luisschwab): get rid of this once
+    // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
     fn get_port(net: &Network) -> u16 {
         match net {
             Network::Bitcoin => 8332,
-            Network::Testnet => 18332,
             Network::Signet => 38332,
+            Network::Testnet => 18332,
+            Network::Testnet4 => 48332,
             Network::Regtest => 18442,
-            _ => 8332,
         }
     }
 

--- a/crates/floresta-wire/src/p2p_wire/address_man.rs
+++ b/crates/floresta-wire/src/p2p_wire/address_man.rs
@@ -731,10 +731,10 @@ impl AddressMan {
     fn get_net_seeds(network: Network) -> &'static str {
         match network {
             Network::Bitcoin => include_str!("seeds/mainnet_seeds.json"),
-            Network::Testnet => include_str!("seeds/testnet_seeds.json"),
             Network::Signet => include_str!("seeds/signet_seeds.json"),
-            Network::Regtest => include_str!("seeds/regtest_seeds.json"),
+            Network::Testnet => include_str!("seeds/testnet_seeds.json"),
             Network::Testnet4 => include_str!("seeds/testnet4_seeds.json"),
+            Network::Regtest => include_str!("seeds/regtest_seeds.json"),
         }
     }
 

--- a/crates/floresta-wire/src/p2p_wire/node.rs
+++ b/crates/floresta-wire/src/p2p_wire/node.rs
@@ -740,13 +740,15 @@ where
         Ok(())
     }
 
+    // TODO(@luisschwab): get rid of this once
+    // https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 makes it into a release.
     fn get_port(network: Network) -> u16 {
         match network {
             Network::Bitcoin => 8333,
             Network::Signet => 38333,
             Network::Testnet => 18333,
-            Network::Regtest => 18444,
             Network::Testnet4 => 48333,
+            Network::Regtest => 18444,
         }
     }
 


### PR DESCRIPTION
### What is the purpose of this pull request?

- [X] Bug fix
- [ ] Documentation update
- [ ] New feature
- [ ] Test
- [ ] Other: <!-- Please describe it -->

### Which crates are being modified?

- [ ] floresta-chain
- [X] floresta-cli
- [ ] floresta-common
- [ ] floresta-compact-filters
- [ ] floresta-electrum
- [ ] floresta-watch-only
- [ ] floresta-wire
- [ ] floresta
- [ ] florestad
- [ ] Other: <!-- Please describe it -->

## Changelog
- Add default `Testnet4` RPC port to RPC server and client.
- Remove catch-all from `get_port`: `Network` is exhaustive since `bitcoin 0.32.7` (https://github.com/rust-bitcoin/rust-bitcoin/pull/4640).
- Remove the `JsonRpcError::InvalidNetwork` variant.

I also left some TODO comments that are to be addressed when https://github.com/rust-bitcoin/rust-bitcoin/pull/4639 gets into a `rust-bitcoin` release. At that point we can remove the `get_port` functions.